### PR TITLE
feat(续航): 增加有界触发器观测

### DIFF
--- a/src/dyro/cli.py
+++ b/src/dyro/cli.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import argparse
 from concurrent.futures import ThreadPoolExecutor, as_completed
+from datetime import datetime, timezone
 import json
 import os
 from pathlib import Path
@@ -44,6 +45,7 @@ from .continuation.store import (
     resume_objective,
     stop_objective,
 )
+from .continuation.triggers import TriggerConfig, TriggerKind, TriggerProbeInput, probe_builtin
 from .evidence import build_execution_bundle, unpack_execution_bundle
 from .errors import DyroError, ValidationError
 from .home import (
@@ -1776,6 +1778,107 @@ def cmd_objective_graph(args: argparse.Namespace) -> None:
     print(render_projection_mermaid(projection))
 
 
+def _trigger_cli_time(value: str | None, label: str) -> datetime | None:
+    if value is None:
+        return None
+    try:
+        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError as exc:
+        raise DyroError(f"{label} 必须是带时区的 ISO-8601 时间") from exc
+    if parsed.tzinfo is None:
+        raise DyroError(f"{label} 必须是带时区的 ISO-8601 时间")
+    return parsed.astimezone(timezone.utc)
+
+
+def _trigger_cli_facts(values: list[str] | None, label: str) -> tuple[tuple[str, str], ...]:
+    facts: list[tuple[str, str]] = []
+    seen: set[str] = set()
+    for value in values or []:
+        name, separator, state = value.partition("=")
+        name, state = name.strip(), state.strip()
+        if not separator or not name or not state:
+            raise DyroError(f"{label} 必须使用 KEY=VALUE；可重复指定")
+        if name in seen:
+            raise DyroError(f"{label} 不能重复指定同一个 KEY：{name}")
+        seen.add(name)
+        facts.append((name, state))
+    return tuple(facts)
+
+
+def _trigger_payload(observation, *, delivery: str | None = None) -> dict[str, object]:
+    payload: dict[str, object] = {
+        "trigger_id": observation.trigger_id,
+        "state": observation.state.value,
+        "summary": observation.summary,
+        "evidence_ref": observation.evidence_ref,
+        "observed_at": observation.observed_at.isoformat() if observation.observed_at else None,
+        "next_probe_at": observation.next_probe_at.isoformat() if observation.next_probe_at else None,
+    }
+    if delivery is not None:
+        payload["delivery"] = delivery
+    return payload
+
+
+def _print_trigger_observation(args: argparse.Namespace, observation, *, delivery: str | None = None) -> None:
+    payload = _trigger_payload(observation, delivery=delivery)
+    if args.format == "json":
+        print(json.dumps(payload, ensure_ascii=False, sort_keys=True))
+        return
+    print(
+        f"{payload['trigger_id']}: {payload['state']} ({payload['summary']}) "
+        f"@ {payload['observed_at']}"
+    )
+    if delivery:
+        print("只读观测已输出；尚未写入任务、证据或执行台账。")
+
+
+def cmd_trigger_list(args: argparse.Namespace) -> None:
+    rows = [
+        {
+            "kind": kind.value,
+            "execution": "bounded_adapter_required" if kind is TriggerKind.PROVIDER else "builtin_read_only",
+        }
+        for kind in TriggerKind
+    ]
+    if args.format == "json":
+        print(json.dumps(rows, ensure_ascii=False, sort_keys=True))
+        return
+    for row in rows:
+        print(f"{row['kind']:16} {row['execution']}")
+
+
+def cmd_trigger_probe(args: argparse.Namespace) -> None:
+    kind = TriggerKind(args.kind)
+    if kind is TriggerKind.PROVIDER:
+        raise DyroError("provider Trigger 只能由已登记的有界 adapter 调用；CLI 不接受命令、URL 或脚本")
+    now = _trigger_cli_time(args.at, "--at") or datetime.now(timezone.utc)
+    not_before = _trigger_cli_time(args.not_before, "--not-before")
+    if args.signal and kind is not TriggerKind.MANUAL_SIGNAL:
+        raise DyroError("--signal 只能与 manual_signal Trigger 一起使用")
+    observation = probe_builtin(
+        TriggerProbeInput(
+            config=TriggerConfig(args.id, kind, not_before=not_before),
+            now=now,
+            current_facts=_trigger_cli_facts(args.current, "--current"),
+            previous_facts=_trigger_cli_facts(args.previous, "--previous"),
+            manual_signal=args.signal or "",
+        )
+    )
+    _print_trigger_observation(args, observation, delivery="ephemeral")
+
+
+def cmd_trigger_signal(args: argparse.Namespace) -> None:
+    now = _trigger_cli_time(args.at, "--at") or datetime.now(timezone.utc)
+    observation = probe_builtin(
+        TriggerProbeInput(
+            config=TriggerConfig(args.id, TriggerKind.MANUAL_SIGNAL),
+            now=now,
+            manual_signal=args.signal,
+        )
+    )
+    _print_trigger_observation(args, observation, delivery="ephemeral")
+
+
 def _cmd_objective_transition(args: argparse.Namespace, action: str) -> None:
     config = _config(args)
     _require_objective_yes(args, f"Objective {action}")
@@ -2262,6 +2365,28 @@ def build_parser() -> argparse.ArgumentParser:
         parser_item.add_argument("task")
         parser_item.add_argument("--yes", action="store_true")
         parser_item.set_defaults(func=function)
+
+    trigger = sub.add_parser("trigger", help="只读 Trigger 观测与有界 provider 协议入口")
+    trigger_sub = trigger.add_subparsers(dest="trigger_command", required=True)
+    trigger_list = trigger_sub.add_parser("list", help="列出内置 Trigger 类型与 provider 边界")
+    trigger_list.add_argument("--format", choices=("text", "json"), default="text")
+    trigger_list.set_defaults(func=cmd_trigger_list)
+    trigger_probe = trigger_sub.add_parser("probe", help="用显式事实执行一次只读内置 Trigger 观测")
+    trigger_probe.add_argument("kind", choices=tuple(item.value for item in TriggerKind))
+    trigger_probe.add_argument("--id", default="manual-probe")
+    trigger_probe.add_argument("--at", help="观测时间（带时区 ISO-8601）；默认当前 UTC 时间")
+    trigger_probe.add_argument("--not-before", help="time_due 的最早触发时间（带时区 ISO-8601）")
+    trigger_probe.add_argument("--current", action="append", metavar="KEY=VALUE", help="当前事实；可重复指定")
+    trigger_probe.add_argument("--previous", action="append", metavar="KEY=VALUE", help="上次事实；可重复指定")
+    trigger_probe.add_argument("--signal", help="manual_signal 的非空人工信号")
+    trigger_probe.add_argument("--format", choices=("text", "json"), default="text")
+    trigger_probe.set_defaults(func=cmd_trigger_probe)
+    trigger_signal = trigger_sub.add_parser("signal", help="输出一次临时人工信号观测，不写入任务或控制面")
+    trigger_signal.add_argument("signal")
+    trigger_signal.add_argument("--id", default="manual-signal")
+    trigger_signal.add_argument("--at", help="观测时间（带时区 ISO-8601）；默认当前 UTC 时间")
+    trigger_signal.add_argument("--format", choices=("text", "json"), default="text")
+    trigger_signal.set_defaults(func=cmd_trigger_signal)
 
     task = sub.add_parser("task", help="任务编排")
     task_sub = task.add_subparsers(dest="task_command", required=True)

--- a/src/dyro/continuation/triggers.py
+++ b/src/dyro/continuation/triggers.py
@@ -1,0 +1,287 @@
+"""Bounded Trigger observations and deterministic retry scheduling.
+
+Triggers only state when a planner should reconsider immutable facts.  This
+module contains no Task mutation, evidence import, review, merge, push, or
+network client. An extension process must be described by an allowlisted
+``ProviderDescriptor`` and feed its bounded JSON bytes through
+:func:`parse_provider_observation`; it cannot receive control-plane authority.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from enum import Enum
+import hashlib
+import json
+import re
+from typing import Any
+
+from ..config import validate_id
+from .models import TriggerObservation, TriggerState
+
+
+MAX_PROVIDER_BYTES = 65_536
+MAX_SUMMARY_LENGTH = 512
+_SECRET_MARKER = re.compile(r"(?:sk-[A-Za-z0-9_-]{16,}|gh[pousr]_[A-Za-z0-9]{20,})")
+
+
+class TriggerKind(str, Enum):
+    TIME_DUE = "time_due"
+    TASK_STATE = "task_state"
+    DECISION_STATE = "decision_state"
+    MANUAL_SIGNAL = "manual_signal"
+    LOCAL_REF = "local_ref"
+    PROVIDER = "provider"
+
+
+class TriggerErrorKind(str, Enum):
+    TRANSIENT = "transient"
+    PERMANENT = "permanent"
+    AUTH_MISSING = "auth_missing"
+    INVALID_OUTPUT = "invalid_output"
+    TIMEOUT = "timeout"
+
+
+@dataclass(frozen=True)
+class ProviderDescriptor:
+    """A declarative boundary for an externally run observation provider.
+
+    The core process never imports provider code and this type intentionally
+    has no command or URL field. A later adapter may map a trusted,
+    allowlisted descriptor ID to a bounded subprocess invocation, then pass
+    its stdout to this module. This keeps arbitrary shell and HTTP triggers
+    out of the continuation core.
+    """
+
+    id: str
+    trigger_ids: tuple[str, ...]
+    timeout_seconds: int = 30
+    maximum_bytes: int = MAX_PROVIDER_BYTES
+
+    def __post_init__(self) -> None:
+        validate_id(self.id, "provider ID")
+        try:
+            trigger_ids = tuple(self.trigger_ids)
+        except TypeError as exc:
+            raise TypeError("ProviderDescriptor.trigger_ids 必须是 Trigger ID 集合") from exc
+        if not trigger_ids:
+            raise ValueError("ProviderDescriptor.trigger_ids 不能为空")
+        for trigger_id in trigger_ids:
+            if not isinstance(trigger_id, str):
+                raise TypeError("ProviderDescriptor.trigger_ids 必须只包含字符串")
+            validate_id(trigger_id, "Trigger ID")
+        if len(set(trigger_ids)) != len(trigger_ids):
+            raise ValueError("ProviderDescriptor.trigger_ids 不能重复")
+        object.__setattr__(self, "trigger_ids", trigger_ids)
+        if type(self.timeout_seconds) is not int or not 1 <= self.timeout_seconds <= 300:
+            raise ValueError("ProviderDescriptor.timeout_seconds 必须在 1 到 300 秒之间")
+        if type(self.maximum_bytes) is not int or not 1 <= self.maximum_bytes <= MAX_PROVIDER_BYTES:
+            raise ValueError("ProviderDescriptor.maximum_bytes 超出允许范围")
+
+
+def _utc(value: datetime, label: str) -> datetime:
+    if not isinstance(value, datetime) or value.tzinfo is None:
+        raise TypeError(f"{label} 必须是带时区的 datetime")
+    return value.astimezone(timezone.utc)
+
+
+def _facts(value: Any, label: str) -> tuple[tuple[str, str], ...]:
+    if isinstance(value, (str, bytes)):
+        raise TypeError(f"{label} 必须是键值对集合")
+    try:
+        raw = tuple(value)
+    except TypeError as exc:
+        raise TypeError(f"{label} 必须是键值对集合") from exc
+    facts: list[tuple[str, str]] = []
+    for item in raw:
+        try:
+            pair = tuple(item)
+        except TypeError as exc:
+            raise TypeError(f"{label} 包含无效键值对") from exc
+        if len(pair) != 2 or not all(isinstance(part, str) and part for part in pair):
+            raise TypeError(f"{label} 必须包含非空字符串键值对")
+        facts.append((pair[0], pair[1]))
+    return tuple(sorted(facts))
+
+
+@dataclass(frozen=True)
+class TriggerConfig:
+    id: str
+    kind: TriggerKind
+    not_before: datetime | None = None
+    min_interval_seconds: int = 30
+    max_interval_seconds: int = 900
+
+    def __post_init__(self) -> None:
+        validate_id(self.id, "Trigger ID")
+        if not isinstance(self.kind, TriggerKind):
+            raise TypeError("TriggerConfig.kind 必须是 TriggerKind")
+        for field in ("min_interval_seconds", "max_interval_seconds"):
+            value = getattr(self, field)
+            if type(value) is not int or value < 1:
+                raise TypeError(f"TriggerConfig.{field} 必须是正整数")
+        if self.min_interval_seconds > self.max_interval_seconds:
+            raise TypeError("TriggerConfig.min_interval_seconds 不能大于 max_interval_seconds")
+        if self.not_before is not None:
+            object.__setattr__(self, "not_before", _utc(self.not_before, "TriggerConfig.not_before"))
+
+
+@dataclass(frozen=True)
+class TriggerProbeInput:
+    config: TriggerConfig
+    now: datetime
+    current_facts: tuple[tuple[str, str], ...] = ()
+    previous_facts: tuple[tuple[str, str], ...] = ()
+    manual_signal: str = ""
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.config, TriggerConfig):
+            raise TypeError("TriggerProbeInput.config 必须是 TriggerConfig")
+        object.__setattr__(self, "now", _utc(self.now, "TriggerProbeInput.now"))
+        object.__setattr__(self, "current_facts", _facts(self.current_facts, "TriggerProbeInput.current_facts"))
+        object.__setattr__(self, "previous_facts", _facts(self.previous_facts, "TriggerProbeInput.previous_facts"))
+        if not isinstance(self.manual_signal, str) or len(self.manual_signal) > MAX_SUMMARY_LENGTH:
+            raise TypeError("TriggerProbeInput.manual_signal 无效")
+
+
+@dataclass(frozen=True)
+class TriggerProbeSchedule:
+    next_probe_at: datetime | None
+    unchanged_cycles: int
+    disabled: bool = False
+
+
+def _observation(config: TriggerConfig, state: TriggerState, summary: str, now: datetime) -> TriggerObservation:
+    return TriggerObservation(
+        trigger_id=config.id,
+        state=state,
+        summary=summary,
+        observed_at=now,
+    )
+
+
+def probe_builtin(input: TriggerProbeInput) -> TriggerObservation:
+    """Observe one built-in Trigger using only caller-supplied facts."""
+    config = input.config
+    if config.kind is TriggerKind.TIME_DUE:
+        due = config.not_before is not None and input.now >= config.not_before
+        return _observation(config, TriggerState.SATISFIED if due else TriggerState.PENDING, "time_due" if due else "time_waiting", input.now)
+    if config.kind in {TriggerKind.TASK_STATE, TriggerKind.LOCAL_REF}:
+        changed = input.current_facts != input.previous_facts and bool(input.current_facts or input.previous_facts)
+        return _observation(config, TriggerState.SATISFIED if changed else TriggerState.PENDING, "state_changed" if changed else "state_unchanged", input.now)
+    if config.kind is TriggerKind.DECISION_STATE:
+        resolved = any(value == "resolved" for _, value in input.current_facts)
+        return _observation(config, TriggerState.SATISFIED if resolved else TriggerState.PENDING, "decision_resolved" if resolved else "decision_open", input.now)
+    if config.kind is TriggerKind.MANUAL_SIGNAL:
+        signalled = bool(input.manual_signal)
+        return _observation(config, TriggerState.SATISFIED if signalled else TriggerState.PENDING, "manual_signal" if signalled else "signal_absent", input.now)
+    return _observation(config, TriggerState.DISABLED, "provider_requires_bounded_adapter", input.now)
+
+
+def _jitter_seconds(config: TriggerConfig, cycles: int, interval: int) -> int:
+    window = max(1, interval // 10)
+    digest = hashlib.sha256(f"{config.id}:{cycles}:{interval}".encode("utf-8")).digest()
+    return int.from_bytes(digest[:4], "big") % (window + 1)
+
+
+def next_probe_schedule(
+    config: TriggerConfig,
+    observation: TriggerObservation,
+    *,
+    unchanged_cycles: int,
+    now: datetime,
+    changed: bool = False,
+    error_kind: TriggerErrorKind | None = None,
+) -> TriggerProbeSchedule:
+    """Compute bounded exponential backoff without sampling a new clock."""
+    if not isinstance(config, TriggerConfig) or observation.trigger_id != config.id:
+        raise ValueError("Trigger 配置与观测不匹配")
+    if type(unchanged_cycles) is not int or unchanged_cycles < 0:
+        raise TypeError("unchanged_cycles 必须是非负整数")
+    if error_kind is not None and not isinstance(error_kind, TriggerErrorKind):
+        raise TypeError("error_kind 必须是 TriggerErrorKind 或 None")
+    now_utc = _utc(now, "now")
+    if error_kind in {TriggerErrorKind.PERMANENT, TriggerErrorKind.AUTH_MISSING, TriggerErrorKind.INVALID_OUTPUT}:
+        return TriggerProbeSchedule(next_probe_at=None, unchanged_cycles=unchanged_cycles, disabled=True)
+    if observation.state is TriggerState.DISABLED:
+        return TriggerProbeSchedule(next_probe_at=None, unchanged_cycles=unchanged_cycles, disabled=True)
+    # A planner must explicitly establish an edge before waking immediately.
+    # Treating a level-triggered condition (for example, time_due after its
+    # deadline) as a change would otherwise spin with a zero delay forever.
+    if changed:
+        return TriggerProbeSchedule(next_probe_at=now_utc, unchanged_cycles=0)
+    cycles = unchanged_cycles + 1
+    interval = min(config.max_interval_seconds, config.min_interval_seconds * (2 ** min(cycles - 1, 30)))
+    interval = min(config.max_interval_seconds, interval + _jitter_seconds(config, cycles, interval))
+    return TriggerProbeSchedule(next_probe_at=now_utc + timedelta(seconds=interval), unchanged_cycles=cycles)
+
+
+def _parse_time(value: object, label: str) -> datetime | None:
+    if value is None:
+        return None
+    if not isinstance(value, str) or not value:
+        raise ValueError(f"{label} 必须是带时区的 ISO-8601 时间")
+    try:
+        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError as exc:
+        raise ValueError(f"{label} 必须是带时区的 ISO-8601 时间") from exc
+    return _utc(parsed, label)
+
+
+def parse_provider_observation(
+    payload: bytes,
+    *,
+    trigger_id: str,
+    observed_at: datetime,
+    maximum_bytes: int = MAX_PROVIDER_BYTES,
+) -> TriggerObservation:
+    """Validate an extension's bounded JSON output without trusting its content.
+
+    This parser accepts no delivery-state fields.  A validated observation can
+    request a replan only; it never represents Task, review, evidence, merge,
+    or push authority.
+    """
+    validate_id(trigger_id, "Trigger ID")
+    if type(maximum_bytes) is not int or maximum_bytes < 1 or maximum_bytes > MAX_PROVIDER_BYTES:
+        raise ValueError("maximum_bytes 超出允许范围")
+    if not isinstance(payload, bytes) or len(payload) > maximum_bytes:
+        raise ValueError("provider 输出超过允许大小")
+    try:
+        raw = json.loads(payload.decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError, RecursionError) as exc:
+        raise ValueError("provider 输出不是有效 JSON") from exc
+    if not isinstance(raw, dict):
+        raise ValueError("provider 输出必须是对象")
+    allowed = {"schema_version", "state", "summary", "evidence_ref", "next_probe_at"}
+    unknown = sorted(set(raw) - allowed)
+    if unknown:
+        raise ValueError(f"provider 输出包含未知字段：{', '.join(unknown)}")
+    if type(raw.get("schema_version")) is not int or raw["schema_version"] != 1:
+        raise ValueError("provider 输出必须使用 schema_version = 1")
+    try:
+        state = TriggerState(raw.get("state"))
+    except (TypeError, ValueError) as exc:
+        raise ValueError("provider 输出 state 无效") from exc
+    summary = raw.get("summary")
+    if not isinstance(summary, str) or not summary or len(summary) > MAX_SUMMARY_LENGTH:
+        raise ValueError("provider 输出 summary 无效")
+    if _SECRET_MARKER.search(summary) or any(ord(character) < 32 for character in summary):
+        raise ValueError("provider 输出 summary 疑似包含机密")
+    evidence_ref = raw.get("evidence_ref", "")
+    if not isinstance(evidence_ref, str) or len(evidence_ref) > MAX_SUMMARY_LENGTH or ".." in evidence_ref or evidence_ref.startswith("/"):
+        raise ValueError("provider 输出 evidence_ref 无效")
+    if _SECRET_MARKER.search(evidence_ref) or any(ord(character) < 32 for character in evidence_ref):
+        raise ValueError("provider 输出 evidence_ref 疑似包含机密")
+    observed_at_utc = _utc(observed_at, "observed_at")
+    next_probe_at = _parse_time(raw.get("next_probe_at"), "next_probe_at")
+    if next_probe_at is not None and next_probe_at < observed_at_utc:
+        raise ValueError("provider 输出 next_probe_at 不能早于 observed_at")
+    return TriggerObservation(
+        trigger_id=trigger_id,
+        state=state,
+        summary=summary,
+        evidence_ref=evidence_ref,
+        observed_at=observed_at_utc,
+        next_probe_at=next_probe_at,
+    )

--- a/tests/test_continuation_triggers.py
+++ b/tests/test_continuation_triggers.py
@@ -1,0 +1,210 @@
+from __future__ import annotations
+
+from contextlib import redirect_stdout
+from datetime import datetime, timezone
+from io import StringIO
+import json
+import unittest
+
+from dyro.cli import build_parser
+from dyro.errors import DyroError
+from dyro.continuation.models import TriggerState
+from dyro.continuation.triggers import (
+    ProviderDescriptor,
+    TriggerConfig,
+    TriggerErrorKind,
+    TriggerKind,
+    TriggerProbeInput,
+    next_probe_schedule,
+    parse_provider_observation,
+    probe_builtin,
+)
+
+
+class ContinuationTriggerTests(unittest.TestCase):
+    def test_builtin_time_task_decision_and_manual_signals_only_observe(self) -> None:
+        now = datetime(2026, 8, 4, 10, 0, tzinfo=timezone.utc)
+        time_due = probe_builtin(
+            TriggerProbeInput(
+                config=TriggerConfig("wake", TriggerKind.TIME_DUE, not_before=now),
+                now=now,
+            )
+        )
+        task_change = probe_builtin(
+            TriggerProbeInput(
+                config=TriggerConfig("task", TriggerKind.TASK_STATE),
+                now=now,
+                current_facts=(("TASK-A", "review"),),
+                previous_facts=(("TASK-A", "backlog"),),
+            )
+        )
+        unresolved = probe_builtin(
+            TriggerProbeInput(
+                config=TriggerConfig("decision", TriggerKind.DECISION_STATE),
+                now=now,
+                current_facts=(("D-1", "open"),),
+                previous_facts=(("D-1", "open"),),
+            )
+        )
+        signal = probe_builtin(
+            TriggerProbeInput(
+                config=TriggerConfig("signal", TriggerKind.MANUAL_SIGNAL),
+                now=now,
+                manual_signal="operator-ready",
+            )
+        )
+
+        self.assertEqual(time_due.state, TriggerState.SATISFIED)
+        self.assertEqual(task_change.state, TriggerState.SATISFIED)
+        self.assertEqual(unresolved.state, TriggerState.PENDING)
+        self.assertEqual(signal.state, TriggerState.SATISFIED)
+        self.assertFalse(any(hasattr(item, "mutation") for item in (time_due, task_change, unresolved, signal)))
+
+    def test_backoff_is_deterministic_and_changes_wake_immediately(self) -> None:
+        now = datetime(2026, 8, 4, 10, 0, tzinfo=timezone.utc)
+        config = TriggerConfig("poll", TriggerKind.TIME_DUE, min_interval_seconds=10, max_interval_seconds=80)
+        pending = probe_builtin(TriggerProbeInput(config=config, now=now))
+        first = next_probe_schedule(config, pending, unchanged_cycles=1, now=now)
+        repeat = next_probe_schedule(config, pending, unchanged_cycles=1, now=now)
+        changed = next_probe_schedule(
+            config,
+            probe_builtin(TriggerProbeInput(config=config, now=now, manual_signal="n/a")),
+            unchanged_cycles=4,
+            now=now,
+            changed=True,
+        )
+
+        self.assertEqual(first, repeat)
+        self.assertGreater(first.next_probe_at, now)
+        self.assertLessEqual((first.next_probe_at - now).total_seconds(), 80)
+        self.assertEqual(changed.next_probe_at, now)
+
+    def test_level_trigger_does_not_spin_and_deleted_fact_is_a_change(self) -> None:
+        now = datetime(2026, 8, 4, 10, 0, tzinfo=timezone.utc)
+        time_config = TriggerConfig("due", TriggerKind.TIME_DUE, not_before=now, min_interval_seconds=10)
+        due = probe_builtin(TriggerProbeInput(config=time_config, now=now))
+        schedule = next_probe_schedule(time_config, due, unchanged_cycles=7, now=now)
+        self.assertGreater(schedule.next_probe_at, now)
+        self.assertEqual(schedule.unchanged_cycles, 8)
+
+        deleted = probe_builtin(
+            TriggerProbeInput(
+                config=TriggerConfig("ref", TriggerKind.LOCAL_REF),
+                now=now,
+                current_facts=(),
+                previous_facts=(("refs/main", "abc123"),),
+            )
+        )
+        self.assertEqual(deleted.state, TriggerState.SATISFIED)
+
+    def test_provider_protocol_is_bounded_and_fail_closed(self) -> None:
+        now = datetime(2026, 8, 4, 10, 0, tzinfo=timezone.utc)
+        payload = json.dumps(
+            {
+                "schema_version": 1,
+                "state": "satisfied",
+                "summary": "green",
+                "evidence_ref": "ci:123",
+            }
+        ).encode()
+        observation = parse_provider_observation(
+            payload,
+            trigger_id="provider-ci",
+            observed_at=now,
+            maximum_bytes=256,
+        )
+
+        self.assertEqual(observation.state, TriggerState.SATISFIED)
+        self.assertEqual(observation.trigger_id, "provider-ci")
+        with self.assertRaisesRegex(ValueError, "超过"):
+            parse_provider_observation(b"x" * 257, trigger_id="provider-ci", observed_at=now, maximum_bytes=256)
+        with self.assertRaisesRegex(ValueError, "未知字段"):
+            parse_provider_observation(
+                b'{"schema_version":1,"state":"satisfied","summary":"ok","mutation":"task merge"}',
+                trigger_id="provider-ci",
+                observed_at=now,
+                maximum_bytes=256,
+            )
+        with self.assertRaisesRegex(ValueError, "schema_version"):
+            parse_provider_observation(
+                b'{"schema_version":true,"state":"pending","summary":"wait"}',
+                trigger_id="provider-ci",
+                observed_at=now,
+            )
+        with self.assertRaisesRegex(ValueError, "有效 JSON"):
+            parse_provider_observation(
+                (b"[" * 10_000) + (b"]" * 10_000),
+                trigger_id="provider-ci",
+                observed_at=now,
+            )
+        self.assertEqual(TriggerErrorKind.AUTH_MISSING.value, "auth_missing")
+
+    def test_provider_descriptor_and_output_protocol_fail_closed(self) -> None:
+        now = datetime(2026, 8, 4, 10, 0, tzinfo=timezone.utc)
+        descriptor = ProviderDescriptor("ci-provider", ("provider-ci",), timeout_seconds=20, maximum_bytes=1024)
+
+        self.assertEqual(descriptor.trigger_ids, ("provider-ci",))
+        self.assertFalse(hasattr(descriptor, "command"))
+        with self.assertRaisesRegex(ValueError, "next_probe_at"):
+            parse_provider_observation(
+                b'{"schema_version":1,"state":"pending","summary":"wait","next_probe_at":"2026-08-04T09:59:59Z"}',
+                trigger_id="provider-ci",
+                observed_at=now,
+            )
+        with self.assertRaisesRegex(ValueError, "summary"):
+            parse_provider_observation(
+                b'{"schema_version":1,"state":"pending","summary":"line\\nbreak"}',
+                trigger_id="provider-ci",
+                observed_at=now,
+            )
+
+    def test_cli_probe_and_signal_are_ephemeral_and_provider_cannot_execute(self) -> None:
+        parser = build_parser()
+        probe = parser.parse_args(
+            [
+                "trigger",
+                "probe",
+                "task_state",
+                "--id",
+                "task-change",
+                "--current",
+                "T-1=review",
+                "--previous",
+                "T-1=backlog",
+                "--at",
+                "2026-08-04T10:00:00Z",
+                "--format",
+                "json",
+            ]
+        )
+        output = StringIO()
+        with redirect_stdout(output):
+            probe.func(probe)
+        rendered = json.loads(output.getvalue())
+        self.assertEqual(rendered["state"], "satisfied")
+        self.assertEqual(rendered["delivery"], "ephemeral")
+
+        signal = parser.parse_args(
+            ["trigger", "signal", "operator-ready", "--at", "2026-08-04T10:00:00Z", "--format", "json"]
+        )
+        output = StringIO()
+        with redirect_stdout(output):
+            signal.func(signal)
+        self.assertEqual(json.loads(output.getvalue())["summary"], "manual_signal")
+
+        listing = parser.parse_args(["trigger", "list", "--format", "json"])
+        output = StringIO()
+        with redirect_stdout(output):
+            listing.func(listing)
+        self.assertIn(
+            {"kind": "provider", "execution": "bounded_adapter_required"},
+            json.loads(output.getvalue()),
+        )
+
+        provider = parser.parse_args(["trigger", "probe", "provider"])
+        with self.assertRaisesRegex(DyroError, "不接受命令、URL 或脚本"):
+            provider.func(provider)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_continuation_triggers.py
+++ b/tests/test_continuation_triggers.py
@@ -131,7 +131,10 @@ class ContinuationTriggerTests(unittest.TestCase):
                 trigger_id="provider-ci",
                 observed_at=now,
             )
-        with self.assertRaisesRegex(ValueError, "有效 JSON"):
+        # Some Python versions reject this pathological nesting in the JSON
+        # decoder; others parse it then reject its non-object top level. Both
+        # outcomes must fail closed without leaking RecursionError.
+        with self.assertRaises(ValueError):
             parse_provider_observation(
                 (b"[" * 10_000) + (b"]" * 10_000),
                 trigger_id="provider-ci",


### PR DESCRIPTION
## 变更\n- 新增纯函数内置 Trigger 观测、确定性退避和有界 provider JSON 协议。\n- 新增只读 CLI：trigger list/probe/signal；拒绝从 CLI 执行 provider 命令、URL 或脚本。\n- 修复并覆盖 level-trigger 自旋、深层 JSON、布尔 schema 与删除型事实变化。\n\n## 验证\n- python -m unittest -q（372 项）\n- ruff check src tests\n- build wheel/sdist，并在新虚拟环境从 wheel 实际运行 trigger probe\n\n## 安全边界\n- Trigger 仅产生 observation；不取得任务、证据、复核、合并或推送权限。