### PR TITLE
feat(续航): 增加动作日志与围栏租约

### DIFF
--- a/docs/designs/native-continuation-engine.md
+++ b/docs/designs/native-continuation-engine.md
@@ -414,6 +414,12 @@ accepted revision、scope manifest、policy digest、activation generation 或�
 start 的旧 generation 动作可提交与其 start binding 匹配的终态 receipt，但不能创建下一动作。
 例如 review 执行期间 lease 到期，只能接收 review receipt，不能顺带启动 merge。
 
+涉及 Objective event 的取消计划与 event 同写入 pending transaction：只有 event 已持久化后才
+materialize cancellation receipt；崩溃恢复会完成该计划，未提交 event 则丢弃计划且不改变 Action。
+lease 接管使用独立 pending record 绑定新 lease 的完整内容；先持久化 lease，随后完成取消，恢复时
+仅在新 lease 精确匹配时完成取消，若仍是接管前 lease 则丢弃计划，其余组合 fail-closed，避免在
+新 owner 未成立时取消旧 intent。
+
 ### 7.2 恢复分类
 
 | 发现状态 | 恢复动作 |

--- a/src/dyro/continuation/action_journal.py
+++ b/src/dyro/continuation/action_journal.py
@@ -1,0 +1,455 @@
+"""Secure persistent Action Journal storage and cancellation plans."""
+
+from __future__ import annotations
+
+from contextlib import contextmanager
+from datetime import datetime
+import json
+import os
+import stat
+from typing import Iterator
+
+from ..canonical import canonical_json_bytes
+from ..config import validate_id
+from ..errors import DyroError, ValidationError
+from ..state import open_safe_child_directory
+from .action_models import (
+    ACTION_SCHEMA_VERSION, ActionIntent, ActionReceipt, ActionRecord, ActionStart, ActionStatus,
+    parse_timestamp, reservation_from_payload, reservation_payload, safe_summary, timestamp, utc,
+)
+from .models import ActionKind
+from .objective_storage import ObjectiveDirectory
+
+
+MAX_ACTION_FILE_BYTES = 65_536
+MAX_CANCELLATION_RECEIPTS = 128
+_ACTION_DIRECTORIES = {"intent": "actions", "start": "action-starts", "receipt": "action-receipts"}
+
+
+def _filename(action_id: str) -> str:
+    return f"{validate_id(action_id, 'Action ID')}.json"
+
+
+@contextmanager
+def _child_directory(directory: ObjectiveDirectory, kind: str, *, create: bool) -> Iterator[int]:
+    descriptor = open_safe_child_directory(directory.fd, _ACTION_DIRECTORIES[kind], create=create)
+    try:
+        yield descriptor
+    finally:
+        os.close(descriptor)
+
+
+def _child_exists(directory: ObjectiveDirectory, kind: str) -> bool:
+    try:
+        info = os.stat(_ACTION_DIRECTORIES[kind], dir_fd=directory.fd, follow_symlinks=False)
+    except FileNotFoundError:
+        return False
+    except OSError as exc:
+        raise DyroError(f"无法读取 Action {kind} 目录") from exc
+    if stat.S_ISLNK(info.st_mode) or not stat.S_ISDIR(info.st_mode):
+        raise ValidationError(f"Action {kind} 目录必须是安全的普通目录")
+    return True
+
+
+def _read_exact(descriptor: int, size: int) -> bytes:
+    chunks: list[bytes] = []
+    while size:
+        chunk = os.read(descriptor, size)
+        if not chunk:
+            raise ValidationError("Action 状态文件读取中断")
+        chunks.append(chunk)
+        size -= len(chunk)
+    return b"".join(chunks)
+
+
+def _read_json(parent_fd: int, name: str, label: str) -> object:
+    flags = os.O_RDONLY | (os.O_NOFOLLOW if hasattr(os, "O_NOFOLLOW") else 0)
+    try:
+        descriptor = os.open(name, flags, dir_fd=parent_fd)
+    except FileNotFoundError:
+        raise
+    except OSError as exc:
+        raise ValidationError(f"无法安全读取 {label}") from exc
+    try:
+        info = os.fstat(descriptor)
+        if not stat.S_ISREG(info.st_mode) or info.st_size > MAX_ACTION_FILE_BYTES:
+            raise ValidationError(f"{label} 必须是受限普通文件")
+        raw = _read_exact(descriptor, info.st_size)
+    finally:
+        os.close(descriptor)
+    try:
+        return json.loads(raw.decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError, RecursionError) as exc:
+        raise ValidationError(f"{label} 不是有效 JSON") from exc
+
+
+def _write_all(descriptor: int, content: bytes) -> None:
+    view = memoryview(content)
+    while view:
+        written = os.write(descriptor, view)
+        if written <= 0:
+            raise DyroError("Action 状态文件写入中断")
+        view = view[written:]
+
+
+def _canonical_bytes(value: object) -> bytes:
+    content = canonical_json_bytes(value)
+    if len(content) > MAX_ACTION_FILE_BYTES:
+        raise ValidationError("Action 状态文件超过允许大小")
+    return content
+
+
+def _create_only_json(parent_fd: int, name: str, value: object, label: str) -> None:
+    flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL | (os.O_NOFOLLOW if hasattr(os, "O_NOFOLLOW") else 0)
+    try:
+        descriptor = os.open(name, flags, 0o600, dir_fd=parent_fd)
+    except FileExistsError:
+        raise
+    except OSError as exc:
+        raise DyroError(f"无法安全创建 {label}") from exc
+    try:
+        _write_all(descriptor, _canonical_bytes(value))
+        os.fsync(descriptor)
+    finally:
+        os.close(descriptor)
+    os.fsync(parent_fd)
+
+
+def _replace_json(parent_fd: int, name: str, value: object, label: str) -> None:
+    temporary = f".{name}.{os.getpid()}.{os.urandom(8).hex()}"
+    flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL | (os.O_NOFOLLOW if hasattr(os, "O_NOFOLLOW") else 0)
+    try:
+        descriptor = os.open(temporary, flags, 0o600, dir_fd=parent_fd)
+        try:
+            _write_all(descriptor, _canonical_bytes(value))
+            os.fsync(descriptor)
+        finally:
+            os.close(descriptor)
+        os.replace(temporary, name, src_dir_fd=parent_fd, dst_dir_fd=parent_fd)
+        os.fsync(parent_fd)
+    except OSError as exc:
+        raise DyroError(f"无法安全更新 {label}") from exc
+    finally:
+        try:
+            os.unlink(temporary, dir_fd=parent_fd)
+        except FileNotFoundError:
+            pass
+        except OSError as exc:
+            raise DyroError(f"无法清理 {label} 临时文件") from exc
+
+
+def _remove_json(parent_fd: int, name: str, label: str) -> None:
+    try:
+        info = os.stat(name, dir_fd=parent_fd, follow_symlinks=False)
+    except FileNotFoundError:
+        return
+    except OSError as exc:
+        raise DyroError(f"无法读取 {label}") from exc
+    if stat.S_ISLNK(info.st_mode) or not stat.S_ISREG(info.st_mode):
+        raise ValidationError(f"{label} 必须是安全的普通文件")
+    try:
+        os.unlink(name, dir_fd=parent_fd)
+        os.fsync(parent_fd)
+    except OSError as exc:
+        raise DyroError(f"无法清理 {label}") from exc
+
+
+def _intent_payload(intent: ActionIntent) -> dict[str, object]:
+    return {
+        "schema_version": ACTION_SCHEMA_VERSION, "action_id": intent.action_id,
+        "idempotency_key": intent.idempotency_key, "objective_id": intent.objective_id,
+        "objective_revision": intent.objective_revision, "objective_event_seq": intent.objective_event_seq,
+        "objective_event_sha256": intent.objective_event_sha256, "scope_sha256": intent.scope_sha256,
+        "snapshot_sha256": intent.snapshot_sha256, "plan_sha256": intent.plan_sha256,
+        "operation": intent.operation.value, "subject_id": intent.subject_id, "owner_generation": intent.owner_generation,
+        "expected_operation_generation": intent.expected_operation_generation, "authority_sha256": intent.authority_sha256,
+        "budget_reservation": reservation_payload(intent.budget_reservation), "created_at": timestamp(intent.created_at),
+    }
+
+
+def _intent_from_payload(value: object) -> ActionIntent:
+    fields = {
+        "schema_version", "action_id", "idempotency_key", "objective_id", "objective_revision", "objective_event_seq",
+        "objective_event_sha256", "scope_sha256", "snapshot_sha256", "plan_sha256", "operation", "subject_id",
+        "owner_generation", "expected_operation_generation", "authority_sha256", "budget_reservation", "created_at",
+    }
+    if not isinstance(value, dict) or set(value) != fields:
+        raise ValidationError("Action intent 结构无效")
+    if type(value.get("schema_version")) is not int or value["schema_version"] != ACTION_SCHEMA_VERSION:
+        raise ValidationError("Action intent schema_version 无效")
+    try:
+        return ActionIntent(
+            action_id=value["action_id"], idempotency_key=value["idempotency_key"], objective_id=value["objective_id"],
+            objective_revision=value["objective_revision"], objective_event_seq=value["objective_event_seq"],
+            objective_event_sha256=value["objective_event_sha256"], scope_sha256=value["scope_sha256"],
+            snapshot_sha256=value["snapshot_sha256"], plan_sha256=value["plan_sha256"], operation=ActionKind(value["operation"]),
+            subject_id=value["subject_id"], owner_generation=value["owner_generation"],
+            expected_operation_generation=value["expected_operation_generation"], authority_sha256=value["authority_sha256"],
+            budget_reservation=reservation_from_payload(value["budget_reservation"]),
+            created_at=parse_timestamp(value["created_at"], "Action intent created_at"),
+        )
+    except (KeyError, TypeError, ValueError, ValidationError) as exc:
+        raise ValidationError("Action intent 内容无效") from exc
+
+
+def _start_payload(start: ActionStart) -> dict[str, object]:
+    return {
+        "schema_version": ACTION_SCHEMA_VERSION, "action_id": start.action_id, "idempotency_key": start.idempotency_key,
+        "owner_generation": start.owner_generation, "owner_token_sha256": start.owner_token_sha256,
+        "started_at": timestamp(start.started_at),
+    }
+
+
+def _start_from_payload(value: object) -> ActionStart:
+    fields = {"schema_version", "action_id", "idempotency_key", "owner_generation", "owner_token_sha256", "started_at"}
+    if not isinstance(value, dict) or set(value) != fields:
+        raise ValidationError("Action start 结构无效")
+    if type(value.get("schema_version")) is not int or value["schema_version"] != ACTION_SCHEMA_VERSION:
+        raise ValidationError("Action start schema_version 无效")
+    try:
+        return ActionStart(
+            action_id=value["action_id"], idempotency_key=value["idempotency_key"], owner_generation=value["owner_generation"],
+            owner_token_sha256=value["owner_token_sha256"], started_at=parse_timestamp(value["started_at"], "Action start started_at"),
+        )
+    except (KeyError, TypeError, ValidationError) as exc:
+        raise ValidationError("Action start 内容无效") from exc
+
+
+def _receipt_payload(receipt: ActionReceipt) -> dict[str, object]:
+    return {
+        "schema_version": ACTION_SCHEMA_VERSION, "action_id": receipt.action_id,
+        "idempotency_key": receipt.idempotency_key, "owner_generation": receipt.owner_generation,
+        "status": receipt.status.value, "summary": receipt.summary, "recorded_at": timestamp(receipt.recorded_at),
+    }
+
+
+def _receipt_from_payload(value: object) -> ActionReceipt:
+    fields = {"schema_version", "action_id", "idempotency_key", "owner_generation", "status", "summary", "recorded_at"}
+    if not isinstance(value, dict) or set(value) != fields:
+        raise ValidationError("Action receipt 结构无效")
+    if type(value.get("schema_version")) is not int or value["schema_version"] != ACTION_SCHEMA_VERSION:
+        raise ValidationError("Action receipt schema_version 无效")
+    try:
+        return ActionReceipt(
+            action_id=value["action_id"], idempotency_key=value["idempotency_key"], owner_generation=value["owner_generation"],
+            status=ActionStatus(value["status"]), summary=value["summary"],
+            recorded_at=parse_timestamp(value["recorded_at"], "Action receipt recorded_at"),
+        )
+    except (KeyError, TypeError, ValueError, ValidationError) as exc:
+        raise ValidationError("Action receipt 内容无效") from exc
+
+
+def _read_intent(directory: ObjectiveDirectory, action_id: str) -> ActionIntent:
+    with _child_directory(directory, "intent", create=False) as parent_fd:
+        return _intent_from_payload(_read_json(parent_fd, _filename(action_id), "Action intent"))
+
+
+def _read_optional_component(directory: ObjectiveDirectory, kind: str, action_id: str) -> ActionStart | ActionReceipt | None:
+    if not _child_exists(directory, kind):
+        return None
+    try:
+        with _child_directory(directory, kind, create=False) as parent_fd:
+            payload = _read_json(parent_fd, _filename(action_id), f"Action {kind}")
+    except FileNotFoundError:
+        return None
+    return _start_from_payload(payload) if kind == "start" else _receipt_from_payload(payload)
+
+
+def read_action(directory: ObjectiveDirectory, action_id: str) -> ActionRecord:
+    intent = _read_intent(directory, action_id)
+    start = _read_optional_component(directory, "start", action_id)
+    receipt = _read_optional_component(directory, "receipt", action_id)
+    if start is not None and (not isinstance(start, ActionStart) or start.action_id != intent.action_id or start.idempotency_key != intent.idempotency_key or start.owner_generation != intent.owner_generation):
+        raise ValidationError("Action start 与 intent binding 不匹配")
+    if receipt is not None:
+        if not isinstance(receipt, ActionReceipt) or receipt.action_id != intent.action_id or receipt.idempotency_key != intent.idempotency_key or receipt.owner_generation != intent.owner_generation:
+            raise ValidationError("Action receipt 与 intent binding 不匹配")
+        if start is None and receipt.status is not ActionStatus.CANCELLED:
+            raise ValidationError("未 start 的 Action 只能写 cancelled receipt")
+    return ActionRecord(intent=intent, start=start, receipt=receipt)
+
+
+def _list_component_ids(directory: ObjectiveDirectory, kind: str) -> tuple[str, ...]:
+    if not _child_exists(directory, kind):
+        return ()
+    with _child_directory(directory, kind, create=False) as parent_fd:
+        ids: list[str] = []
+        for name in os.listdir(parent_fd):
+            if not name.endswith(".json") or name.startswith("."):
+                raise ValidationError(f"Action {kind} 目录包含未知条目")
+            action_id = validate_id(name.removesuffix(".json"), "Action ID")
+            info = os.stat(name, dir_fd=parent_fd, follow_symlinks=False)
+            if not stat.S_ISREG(info.st_mode) or stat.S_ISLNK(info.st_mode):
+                raise ValidationError(f"Action {kind} 目录包含不安全条目")
+            ids.append(action_id)
+    return tuple(sorted(ids))
+
+
+def list_actions(directory: ObjectiveDirectory) -> tuple[ActionRecord, ...]:
+    intent_ids = _list_component_ids(directory, "intent")
+    for kind in ("start", "receipt"):
+        orphaned = sorted(set(_list_component_ids(directory, kind)) - set(intent_ids))
+        if orphaned:
+            raise ValidationError(f"Action {kind} 包含没有 intent 的记录：{', '.join(orphaned)}")
+    return tuple(read_action(directory, action_id) for action_id in intent_ids)
+
+
+def _same_intent_binding(existing: ActionIntent, candidate: ActionIntent) -> bool:
+    return (
+        existing.idempotency_key == candidate.idempotency_key and existing.objective_id == candidate.objective_id
+        and existing.objective_revision == candidate.objective_revision and existing.objective_event_seq == candidate.objective_event_seq
+        and existing.objective_event_sha256 == candidate.objective_event_sha256 and existing.scope_sha256 == candidate.scope_sha256
+        and existing.snapshot_sha256 == candidate.snapshot_sha256 and existing.plan_sha256 == candidate.plan_sha256
+        and existing.operation is candidate.operation and existing.subject_id == candidate.subject_id
+        and existing.owner_generation == candidate.owner_generation and existing.expected_operation_generation == candidate.expected_operation_generation
+        and existing.authority_sha256 == candidate.authority_sha256 and existing.budget_reservation == candidate.budget_reservation
+    )
+
+
+def reserve_action(directory: ObjectiveDirectory, intent: ActionIntent) -> ActionRecord:
+    from .owner_lease import recover_owner_takeover
+
+    recover_owner_takeover(directory)
+    for existing in list_actions(directory):
+        if existing.intent.idempotency_key == intent.idempotency_key:
+            if not _same_intent_binding(existing.intent, intent):
+                raise DyroError("Action idempotency_key 已绑定不同的 intent")
+            return existing
+    with _child_directory(directory, "intent", create=True) as parent_fd:
+        try:
+            _create_only_json(parent_fd, _filename(intent.action_id), _intent_payload(intent), "Action intent")
+        except FileExistsError:
+            existing = read_action(directory, intent.action_id)
+            if not _same_intent_binding(existing.intent, intent):
+                raise DyroError("Action ID 已绑定不同的 intent")
+            return existing
+    return ActionRecord(intent=intent, start=None, receipt=None)
+
+
+def start_action(directory: ObjectiveDirectory, *, action_id: str, grant: object, now: datetime) -> ActionRecord:
+    from .owner_lease import OwnerLeaseGrant, assert_owner, read_optional_lease, recover_owner_takeover
+
+    if not isinstance(grant, OwnerLeaseGrant):
+        raise TypeError("grant 必须是 OwnerLeaseGrant")
+    recover_owner_takeover(directory)
+    record = read_action(directory, action_id)
+    if record.receipt is not None:
+        raise DyroError("Action 已有终态 receipt；不能再次 start")
+    lease = read_optional_lease(directory)
+    if lease is None:
+        raise DyroError("Scheduler owner lease 不存在")
+    now_utc = assert_owner(lease, grant, now)
+    if lease.objective_id != record.intent.objective_id or lease.generation != record.intent.owner_generation:
+        raise DyroError("Action intent 已被新的 Scheduler generation 围栏")
+    expected = ActionStart(record.intent.action_id, record.intent.idempotency_key, record.intent.owner_generation, lease.owner_token_sha256, now_utc)
+    if record.start is not None:
+        if record.start != expected and (
+            record.start.action_id != expected.action_id or record.start.idempotency_key != expected.idempotency_key
+            or record.start.owner_generation != expected.owner_generation or record.start.owner_token_sha256 != expected.owner_token_sha256
+        ):
+            raise DyroError("Action start 已存在且与当前 owner binding 不匹配")
+        return record
+    with _child_directory(directory, "start", create=True) as parent_fd:
+        try:
+            _create_only_json(parent_fd, _filename(action_id), _start_payload(expected), "Action start")
+        except FileExistsError:
+            current = read_action(directory, action_id)
+            if current.start is None or current.start.action_id != expected.action_id or current.start.idempotency_key != expected.idempotency_key or current.start.owner_generation != expected.owner_generation or current.start.owner_token_sha256 != expected.owner_token_sha256:
+                raise DyroError("Action start 已存在且与当前 owner binding 不匹配")
+            return current
+    return ActionRecord(intent=record.intent, start=expected, receipt=None)
+
+
+def _same_receipt(existing: ActionReceipt, candidate: ActionReceipt) -> bool:
+    return existing == candidate
+
+
+def _publish_receipt(directory: ObjectiveDirectory, receipt: ActionReceipt) -> ActionRecord:
+    record = read_action(directory, receipt.action_id)
+    if receipt.idempotency_key != record.intent.idempotency_key or receipt.owner_generation != record.intent.owner_generation:
+        raise ValidationError("Action receipt 与 intent binding 不匹配")
+    if record.receipt is not None:
+        if not _same_receipt(record.receipt, receipt):
+            raise DyroError("Action receipt 已存在且不匹配")
+        return record
+    with _child_directory(directory, "receipt", create=True) as parent_fd:
+        try:
+            _create_only_json(parent_fd, _filename(receipt.action_id), _receipt_payload(receipt), "Action receipt")
+        except FileExistsError:
+            current = read_action(directory, receipt.action_id)
+            if current.receipt is None or not _same_receipt(current.receipt, receipt):
+                raise DyroError("Action receipt 已存在且不匹配")
+            return current
+    return ActionRecord(intent=record.intent, start=record.start, receipt=receipt)
+
+
+def _cancellation_plan_payload(receipts: tuple[ActionReceipt, ...]) -> dict[str, object]:
+    return {"schema_version": ACTION_SCHEMA_VERSION, "receipts": [_receipt_payload(receipt) for receipt in receipts]}
+
+
+def cancellation_plan_from_payload(value: object) -> tuple[ActionReceipt, ...]:
+    if not isinstance(value, dict) or set(value) != {"schema_version", "receipts"}:
+        raise ValidationError("Action cancellation plan 结构无效")
+    if value.get("schema_version") != ACTION_SCHEMA_VERSION:
+        raise ValidationError("Action cancellation plan 版本无效")
+    raw = value.get("receipts")
+    if not isinstance(raw, list) or not raw or len(raw) > MAX_CANCELLATION_RECEIPTS:
+        raise ValidationError("Action cancellation plan receipts 无效")
+    try:
+        receipts = tuple(_receipt_from_payload(item) for item in raw)
+    except (TypeError, ValidationError) as exc:
+        raise ValidationError("Action cancellation plan receipts 无效") from exc
+    ids = tuple(receipt.action_id for receipt in receipts)
+    if ids != tuple(sorted(ids)) or len(set(ids)) != len(ids) or any(receipt.status is not ActionStatus.CANCELLED for receipt in receipts):
+        raise ValidationError("Action cancellation plan 无效")
+    return receipts
+
+
+def prepare_action_cancellation(directory: ObjectiveDirectory, *, summary: str, now: datetime) -> dict[str, object] | None:
+    recorded_at = utc(now, "now")
+    reserved = tuple(record for record in list_actions(directory) if record.start is None and record.receipt is None)
+    if not reserved:
+        return None
+    if len(reserved) > MAX_CANCELLATION_RECEIPTS:
+        raise DyroError("待取消 Action 数量超过单次安全上限")
+    safe = safe_summary(summary)
+    return _cancellation_plan_payload(tuple(
+        ActionReceipt(record.intent.action_id, record.intent.idempotency_key, record.intent.owner_generation, ActionStatus.CANCELLED, safe, recorded_at)
+        for record in reserved
+    ))
+
+
+def apply_action_cancellation(directory: ObjectiveDirectory, plan: object) -> tuple[ActionRecord, ...]:
+    receipts = cancellation_plan_from_payload(plan)
+    for receipt in receipts:
+        record = read_action(directory, receipt.action_id)
+        if record.receipt is not None and not _same_receipt(record.receipt, receipt):
+            raise DyroError("Action cancellation plan 与既有 receipt 不匹配")
+        if record.receipt is None and record.start is not None:
+            raise DyroError("Action 已 start；拒绝应用 cancellation plan")
+    return tuple(_publish_receipt(directory, receipt) for receipt in receipts)
+
+
+def cancel_unstarted_actions(directory: ObjectiveDirectory, *, summary: str, now: datetime) -> tuple[ActionRecord, ...]:
+    plan = prepare_action_cancellation(directory, summary=summary, now=now)
+    return () if plan is None else apply_action_cancellation(directory, plan)
+
+
+def record_action_receipt(directory: ObjectiveDirectory, receipt: ActionReceipt, *, grant: object = None, now: datetime | None = None) -> ActionRecord:
+    from .owner_lease import OwnerLeaseGrant, recover_owner_takeover, verify_owner_lease
+
+    recover_owner_takeover(directory)
+    record = read_action(directory, receipt.action_id)
+    if receipt.idempotency_key != record.intent.idempotency_key or receipt.owner_generation != record.intent.owner_generation:
+        raise ValidationError("Action receipt 与 intent binding 不匹配")
+    if record.receipt is not None:
+        return _publish_receipt(directory, receipt)
+    if record.start is None:
+        if receipt.status is not ActionStatus.CANCELLED:
+            raise DyroError("未 start 的 Action 只能写 cancelled receipt")
+        if not isinstance(grant, OwnerLeaseGrant) or now is None:
+            raise DyroError("取消未 start 的 Action 必须提供当前 Scheduler owner grant")
+        lease = verify_owner_lease(directory, grant=grant, now=now)
+        if lease.objective_id != record.intent.objective_id:
+            raise DyroError("Scheduler owner lease 与 Action Objective 不匹配")
+    return _publish_receipt(directory, receipt)

--- a/src/dyro/continuation/action_models.py
+++ b/src/dyro/continuation/action_models.py
@@ -1,0 +1,242 @@
+"""Immutable Action Journal records and their canonical validation rules."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from enum import Enum
+import hashlib
+
+from ..canonical import canonical_json_bytes
+from ..config import validate_id
+from ..errors import ValidationError
+from .budgets import BudgetReservation
+from .models import ActionKind
+
+
+ACTION_SCHEMA_VERSION = 1
+MAX_RECEIPT_SUMMARY_LENGTH = 512
+_DIGEST_LENGTH = 64
+_MUTATING_OPERATIONS = frozenset({ActionKind.EXECUTE_TASK, ActionKind.REVIEW_TASK, ActionKind.MERGE_TASK})
+
+
+class ActionStatus(str, Enum):
+    RESERVED = "reserved"
+    STARTED = "started"
+    SUCCEEDED = "succeeded"
+    FAILED = "failed"
+    UNCERTAIN = "uncertain"
+    CANCELLED = "cancelled"
+
+
+_TERMINAL_STATUSES = frozenset(
+    {ActionStatus.SUCCEEDED, ActionStatus.FAILED, ActionStatus.UNCERTAIN, ActionStatus.CANCELLED}
+)
+
+
+def utc(value: datetime, label: str) -> datetime:
+    if not isinstance(value, datetime) or value.tzinfo is None:
+        raise TypeError(f"{label} 必须是带时区的 datetime")
+    return value.astimezone(timezone.utc)
+
+
+def timestamp(value: datetime) -> str:
+    return utc(value, "timestamp").isoformat().replace("+00:00", "Z")
+
+
+def parse_timestamp(value: object, label: str) -> datetime:
+    if not isinstance(value, str) or not value:
+        raise ValidationError(f"{label} 必须是带时区的 ISO-8601 时间")
+    try:
+        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError as exc:
+        raise ValidationError(f"{label} 必须是带时区的 ISO-8601 时间") from exc
+    try:
+        return utc(parsed, label)
+    except TypeError as exc:
+        raise ValidationError(f"{label} 必须是带时区的 ISO-8601 时间") from exc
+
+
+def require_digest(value: object, label: str) -> str:
+    if not isinstance(value, str) or len(value) != _DIGEST_LENGTH or any(char not in "0123456789abcdef" for char in value):
+        raise ValidationError(f"{label} 必须是 SHA-256 十六进制摘要")
+    return value
+
+
+def safe_summary(value: object) -> str:
+    if not isinstance(value, str) or not value or len(value) > MAX_RECEIPT_SUMMARY_LENGTH:
+        raise ValidationError("Action receipt summary 无效")
+    if any(ord(character) < 32 for character in value):
+        raise ValidationError("Action receipt summary 不能包含控制字符")
+    return value
+
+
+def reservation_payload(reservation: BudgetReservation) -> dict[str, object]:
+    return {
+        "objective_id": reservation.objective_id,
+        "task_id": reservation.task_id,
+        "actions": reservation.actions,
+        "attempts": reservation.attempts,
+        "failures": reservation.failures,
+        "parallel": reservation.parallel,
+        "provider_usage": reservation.provider_usage,
+    }
+
+
+def reservation_from_payload(value: object) -> BudgetReservation:
+    if not isinstance(value, dict) or set(value) != {
+        "objective_id", "task_id", "actions", "attempts", "failures", "parallel", "provider_usage"
+    }:
+        raise ValidationError("Action budget_reservation 无效")
+    try:
+        return BudgetReservation(
+            objective_id=value["objective_id"], task_id=value["task_id"], actions=value["actions"],
+            attempts=value["attempts"], failures=value["failures"], parallel=value["parallel"],
+            provider_usage=value["provider_usage"],
+        )
+    except (KeyError, TypeError) as exc:
+        raise ValidationError("Action budget_reservation 无效") from exc
+
+
+def action_idempotency_key(
+    *, objective_id: str, objective_revision: int, objective_event_seq: int, objective_event_sha256: str,
+    scope_sha256: str, snapshot_sha256: str, plan_sha256: str, operation: ActionKind, subject_id: str,
+    owner_generation: int, expected_operation_generation: int, authority_sha256: str,
+    budget_reservation: BudgetReservation,
+) -> str:
+    validate_id(objective_id, "Objective ID")
+    validate_id(subject_id, "Action subject ID")
+    if type(objective_revision) is not int or objective_revision < 1:
+        raise TypeError("objective_revision 必须是正整数")
+    if type(objective_event_seq) is not int or objective_event_seq < 1:
+        raise TypeError("objective_event_seq 必须是正整数")
+    if type(owner_generation) is not int or owner_generation < 1:
+        raise TypeError("owner_generation 必须是正整数")
+    if type(expected_operation_generation) is not int or expected_operation_generation < 0:
+        raise TypeError("expected_operation_generation 必须是非负整数")
+    if not isinstance(operation, ActionKind) or operation not in _MUTATING_OPERATIONS:
+        raise TypeError("operation 必须是可变更的 ActionKind")
+    for value, label in ((scope_sha256, "scope_sha256"), (objective_event_sha256, "objective_event_sha256"),
+                         (snapshot_sha256, "snapshot_sha256"), (plan_sha256, "plan_sha256"),
+                         (authority_sha256, "authority_sha256")):
+        require_digest(value, label)
+    if not isinstance(budget_reservation, BudgetReservation):
+        raise TypeError("budget_reservation 必须是 BudgetReservation")
+    if budget_reservation.objective_id != objective_id or budget_reservation.task_id != subject_id:
+        raise ValidationError("budget_reservation 必须绑定同一 Objective 和 Task")
+    payload = {
+        "schema_version": ACTION_SCHEMA_VERSION, "objective_id": objective_id, "objective_revision": objective_revision,
+        "objective_event_seq": objective_event_seq, "objective_event_sha256": objective_event_sha256,
+        "scope_sha256": scope_sha256, "snapshot_sha256": snapshot_sha256, "plan_sha256": plan_sha256,
+        "operation": operation.value, "subject_id": subject_id, "owner_generation": owner_generation,
+        "expected_operation_generation": expected_operation_generation, "authority_sha256": authority_sha256,
+        "budget_reservation": reservation_payload(budget_reservation),
+    }
+    return hashlib.sha256(canonical_json_bytes(payload)).hexdigest()
+
+
+@dataclass(frozen=True)
+class ActionIntent:
+    action_id: str
+    objective_id: str
+    objective_revision: int
+    objective_event_seq: int
+    objective_event_sha256: str
+    scope_sha256: str
+    snapshot_sha256: str
+    plan_sha256: str
+    operation: ActionKind
+    subject_id: str
+    owner_generation: int
+    expected_operation_generation: int
+    authority_sha256: str
+    budget_reservation: BudgetReservation
+    created_at: datetime
+    idempotency_key: str = ""
+
+    def __post_init__(self) -> None:
+        validate_id(self.action_id, "Action ID")
+        validate_id(self.objective_id, "Objective ID")
+        validate_id(self.subject_id, "Action subject ID")
+        if type(self.objective_revision) is not int or self.objective_revision < 1:
+            raise TypeError("ActionIntent.objective_revision 必须是正整数")
+        if type(self.objective_event_seq) is not int or self.objective_event_seq < 1:
+            raise TypeError("ActionIntent.objective_event_seq 必须是正整数")
+        if type(self.owner_generation) is not int or self.owner_generation < 1:
+            raise TypeError("ActionIntent.owner_generation 必须是正整数")
+        if type(self.expected_operation_generation) is not int or self.expected_operation_generation < 0:
+            raise TypeError("ActionIntent.expected_operation_generation 必须是非负整数")
+        if not isinstance(self.operation, ActionKind) or self.operation not in _MUTATING_OPERATIONS:
+            raise TypeError("ActionIntent.operation 必须是可变更的 ActionKind")
+        for value, label in ((self.scope_sha256, "ActionIntent.scope_sha256"),
+                             (self.objective_event_sha256, "ActionIntent.objective_event_sha256"),
+                             (self.snapshot_sha256, "ActionIntent.snapshot_sha256"),
+                             (self.plan_sha256, "ActionIntent.plan_sha256"),
+                             (self.authority_sha256, "ActionIntent.authority_sha256")):
+            require_digest(value, label)
+        if not isinstance(self.budget_reservation, BudgetReservation):
+            raise TypeError("ActionIntent.budget_reservation 必须是 BudgetReservation")
+        if self.budget_reservation.objective_id != self.objective_id or self.budget_reservation.task_id != self.subject_id:
+            raise ValidationError("ActionIntent budget_reservation 必须绑定同一 Objective 和 Task")
+        object.__setattr__(self, "created_at", utc(self.created_at, "ActionIntent.created_at"))
+        expected = action_idempotency_key(
+            objective_id=self.objective_id, objective_revision=self.objective_revision,
+            objective_event_seq=self.objective_event_seq, objective_event_sha256=self.objective_event_sha256,
+            scope_sha256=self.scope_sha256, snapshot_sha256=self.snapshot_sha256, plan_sha256=self.plan_sha256,
+            operation=self.operation, subject_id=self.subject_id, owner_generation=self.owner_generation,
+            expected_operation_generation=self.expected_operation_generation, authority_sha256=self.authority_sha256,
+            budget_reservation=self.budget_reservation,
+        )
+        if self.idempotency_key and self.idempotency_key != expected:
+            raise ValidationError("ActionIntent idempotency_key 与 authority binding 不匹配")
+        object.__setattr__(self, "idempotency_key", expected)
+
+
+@dataclass(frozen=True)
+class ActionStart:
+    action_id: str
+    idempotency_key: str
+    owner_generation: int
+    owner_token_sha256: str
+    started_at: datetime
+
+    def __post_init__(self) -> None:
+        validate_id(self.action_id, "Action ID")
+        require_digest(self.idempotency_key, "ActionStart.idempotency_key")
+        require_digest(self.owner_token_sha256, "ActionStart.owner_token_sha256")
+        if type(self.owner_generation) is not int or self.owner_generation < 1:
+            raise TypeError("ActionStart.owner_generation 必须是正整数")
+        object.__setattr__(self, "started_at", utc(self.started_at, "ActionStart.started_at"))
+
+
+@dataclass(frozen=True)
+class ActionReceipt:
+    action_id: str
+    idempotency_key: str
+    owner_generation: int
+    status: ActionStatus
+    summary: str
+    recorded_at: datetime
+
+    def __post_init__(self) -> None:
+        validate_id(self.action_id, "Action ID")
+        require_digest(self.idempotency_key, "ActionReceipt.idempotency_key")
+        if type(self.owner_generation) is not int or self.owner_generation < 1:
+            raise TypeError("ActionReceipt.owner_generation 必须是正整数")
+        if not isinstance(self.status, ActionStatus) or self.status not in _TERMINAL_STATUSES:
+            raise TypeError("ActionReceipt.status 必须是终态 ActionStatus")
+        object.__setattr__(self, "summary", safe_summary(self.summary))
+        object.__setattr__(self, "recorded_at", utc(self.recorded_at, "ActionReceipt.recorded_at"))
+
+
+@dataclass(frozen=True)
+class ActionRecord:
+    intent: ActionIntent
+    start: ActionStart | None
+    receipt: ActionReceipt | None
+
+    @property
+    def status(self) -> ActionStatus:
+        if self.receipt is not None:
+            return self.receipt.status
+        return ActionStatus.UNCERTAIN if self.start is not None else ActionStatus.RESERVED

--- a/src/dyro/continuation/actions.py
+++ b/src/dyro/continuation/actions.py
@@ -1,0 +1,65 @@
+"""Public compatibility façade for the durable continuation Action Journal.
+
+Action records, secure journal persistence, and scheduler-owner fencing have
+separate implementation modules.  This stable surface keeps downstream code
+from depending on that internal storage layout.
+"""
+
+from .action_journal import (
+    apply_action_cancellation,
+    cancel_unstarted_actions,
+    list_actions,
+    prepare_action_cancellation,
+    read_action,
+    record_action_receipt,
+    reserve_action,
+    start_action,
+)
+from .action_models import (
+    ACTION_SCHEMA_VERSION,
+    ActionIntent,
+    ActionReceipt,
+    ActionRecord,
+    ActionStart,
+    ActionStatus,
+    action_idempotency_key,
+)
+from .owner_lease import (
+    OWNER_LEASE_SCHEMA_VERSION,
+    OWNER_TAKEOVER_SCHEMA_VERSION,
+    OwnerLease,
+    OwnerLeaseGrant,
+    acquire_owner_lease,
+    read_owner_lease,
+    release_owner_lease,
+    renew_owner_lease,
+    verify_owner_lease,
+)
+
+
+__all__ = [
+    "ACTION_SCHEMA_VERSION",
+    "OWNER_LEASE_SCHEMA_VERSION",
+    "OWNER_TAKEOVER_SCHEMA_VERSION",
+    "ActionIntent",
+    "ActionReceipt",
+    "ActionRecord",
+    "ActionStart",
+    "ActionStatus",
+    "OwnerLease",
+    "OwnerLeaseGrant",
+    "acquire_owner_lease",
+    "action_idempotency_key",
+    "apply_action_cancellation",
+    "cancel_unstarted_actions",
+    "list_actions",
+    "prepare_action_cancellation",
+    "read_action",
+    "read_owner_lease",
+    "record_action_receipt",
+    "release_owner_lease",
+    "renew_owner_lease",
+    "reserve_action",
+    "start_action",
+    "verify_owner_lease",
+]

--- a/src/dyro/continuation/objective_storage.py
+++ b/src/dyro/continuation/objective_storage.py
@@ -346,7 +346,11 @@ def _event_for(record: StoredObjective, event_name: str) -> dict[str, object]:
     return event
 
 
-def _pending_payload(event: dict[str, object], contract_content: bytes | None) -> dict[str, object]:
+def _pending_payload(
+    event: dict[str, object],
+    contract_content: bytes | None,
+    action_cancellation: dict[str, object] | None,
+) -> dict[str, object]:
     return {
         "schema_version": OBJECTIVE_STORE_SCHEMA_VERSION,
         "event": event,
@@ -354,6 +358,7 @@ def _pending_payload(event: dict[str, object], contract_content: bytes | None) -
         "contract_sha256": (
             hashlib.sha256(contract_content).hexdigest() if contract_content is not None else ""
         ),
+        "action_cancellation": action_cancellation,
     }
 
 
@@ -365,9 +370,11 @@ def read_pending(directory: ObjectiveDirectory) -> dict[str, object] | None:
         payload = json.loads(_read_file(directory, _PENDING_FILE, "Objective pending transaction").decode("utf-8"))
     except (OSError, UnicodeError, json.JSONDecodeError) as exc:
         raise ValidationError(f"Objective pending transaction JSON 无效：{path}") from exc
-    if not isinstance(payload, dict) or set(payload) != {
-        "schema_version", "event", "contract_revision", "contract_sha256"
-    }:
+    pending_fields = (
+        {"schema_version", "event", "contract_revision", "contract_sha256"},
+        {"schema_version", "event", "contract_revision", "contract_sha256", "action_cancellation"},
+    )
+    if not isinstance(payload, dict) or set(payload) not in pending_fields:
         raise ValidationError(f"Objective pending transaction 结构无效：{path}")
     if payload.get("schema_version") != OBJECTIVE_STORE_SCHEMA_VERSION:
         raise ValidationError(f"Objective pending transaction 版本无效：{path}")
@@ -389,7 +396,19 @@ def read_pending(directory: ObjectiveDirectory) -> dict[str, object] | None:
         and (len(contract_digest) != 64 or any(char not in "0123456789abcdef" for char in contract_digest))
     ):
         raise ValidationError(f"Objective pending transaction contract 哈希无效：{path}")
+    action_cancellation = payload.get("action_cancellation")
+    if action_cancellation is not None and not isinstance(action_cancellation, dict):
+        raise ValidationError(f"Objective pending transaction Action cancellation 无效：{path}")
     return payload
+
+
+def _apply_pending_action_cancellation(directory: ObjectiveDirectory, pending: dict[str, object]) -> None:
+    action_cancellation = pending.get("action_cancellation")
+    if action_cancellation is None:
+        return
+    from .actions import apply_action_cancellation
+
+    apply_action_cancellation(directory, action_cancellation)
 
 
 def _contract_name(revision: int) -> str:
@@ -421,6 +440,7 @@ def recover_pending(directory: ObjectiveDirectory) -> bool:
             event_sha256=expected_sha,
             contract_content=_read_file(directory, _contract_name(revision), "Objective contract"),
         )
+        _apply_pending_action_cancellation(directory, pending)
         write_projection(directory, record)
         _remove_file(directory, _PENDING_FILE, "Objective pending transaction")
         return False
@@ -530,11 +550,12 @@ def commit_event(
     event_name: str,
     *,
     contract_content: bytes | None = None,
+    action_cancellation: dict[str, object] | None = None,
 ) -> StoredObjective:
     """Commit an event with a durable intent record before any new contract."""
     path = _directory_path(directory)
     event = _event_for(record, event_name)
-    pending = _pending_payload(event, contract_content)
+    pending = _pending_payload(event, contract_content, action_cancellation)
     if _file_exists(directory, _PENDING_FILE):
         existing = read_pending(directory)
         if existing is None or _json_bytes(existing) != _json_bytes(pending):
@@ -574,6 +595,7 @@ def commit_event(
         event_seq=int(event["seq"]),
         event_sha256=str(event["sha256"]),
     )
+    _apply_pending_action_cancellation(directory, pending)
     write_projection(directory, persisted)
     _remove_file(directory, _PENDING_FILE, "Objective pending transaction")
     return persisted

--- a/src/dyro/continuation/owner_lease.py
+++ b/src/dyro/continuation/owner_lease.py
@@ -1,0 +1,257 @@
+"""Fenced owner leases and their crash-recoverable takeover protocol."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timedelta
+import hashlib
+import secrets
+
+from ..config import validate_id
+from ..errors import DyroError, ValidationError
+from .action_journal import (
+    _create_only_json, _read_json, _remove_json, _replace_json, apply_action_cancellation,
+    cancellation_plan_from_payload, prepare_action_cancellation,
+)
+from .action_models import parse_timestamp, require_digest, timestamp, utc
+from .objective_storage import ObjectiveDirectory
+
+
+OWNER_LEASE_SCHEMA_VERSION = 1
+OWNER_TAKEOVER_SCHEMA_VERSION = 1
+_OWNER_TAKEOVER_PENDING_FILE = "scheduler-owner-pending.json"
+
+
+@dataclass(frozen=True)
+class OwnerLease:
+    objective_id: str
+    generation: int
+    owner_token_sha256: str
+    pid: int
+    process_start: str
+    issued_at: datetime
+    heartbeat_at: datetime
+    expires_at: datetime
+    released_at: datetime | None = None
+
+    def __post_init__(self) -> None:
+        validate_id(self.objective_id, "Objective ID")
+        require_digest(self.owner_token_sha256, "OwnerLease.owner_token_sha256")
+        if type(self.generation) is not int or self.generation < 1:
+            raise TypeError("OwnerLease.generation 必须是正整数")
+        if type(self.pid) is not int or self.pid < 1:
+            raise TypeError("OwnerLease.pid 必须是正整数")
+        if not isinstance(self.process_start, str) or not self.process_start or len(self.process_start) > 256:
+            raise TypeError("OwnerLease.process_start 无效")
+        for field in ("issued_at", "heartbeat_at", "expires_at"):
+            object.__setattr__(self, field, utc(getattr(self, field), f"OwnerLease.{field}"))
+        if self.heartbeat_at < self.issued_at or self.expires_at <= self.heartbeat_at:
+            raise ValidationError("OwnerLease 时间顺序无效")
+        if self.released_at is not None:
+            released_at = utc(self.released_at, "OwnerLease.released_at")
+            if released_at < self.heartbeat_at or released_at > self.expires_at:
+                raise ValidationError("OwnerLease.released_at 超出有效 lease 时间")
+            object.__setattr__(self, "released_at", released_at)
+
+    @property
+    def active(self) -> bool:
+        return self.released_at is None
+
+
+def _owner_token_digest(owner_token: object) -> str:
+    if not isinstance(owner_token, str) or len(owner_token) != 64 or any(char not in "0123456789abcdef" for char in owner_token):
+        raise ValidationError("owner token 必须是 32 字节十六进制随机值")
+    return hashlib.sha256(owner_token.encode("ascii")).hexdigest()
+
+
+@dataclass(frozen=True)
+class OwnerLeaseGrant:
+    lease: OwnerLease
+    owner_token: str
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.lease, OwnerLease):
+            raise TypeError("OwnerLeaseGrant.lease 必须是 OwnerLease")
+        if _owner_token_digest(self.owner_token) != self.lease.owner_token_sha256:
+            raise ValidationError("OwnerLeaseGrant token 与 lease 不匹配")
+
+
+def _lease_payload(lease: OwnerLease) -> dict[str, object]:
+    return {
+        "schema_version": OWNER_LEASE_SCHEMA_VERSION, "objective_id": lease.objective_id,
+        "generation": lease.generation, "owner_token_sha256": lease.owner_token_sha256, "pid": lease.pid,
+        "process_start": lease.process_start, "issued_at": timestamp(lease.issued_at),
+        "heartbeat_at": timestamp(lease.heartbeat_at), "expires_at": timestamp(lease.expires_at),
+        "released_at": timestamp(lease.released_at) if lease.released_at else None,
+    }
+
+
+def _lease_from_payload(value: object) -> OwnerLease:
+    fields = {
+        "schema_version", "objective_id", "generation", "owner_token_sha256", "pid", "process_start",
+        "issued_at", "heartbeat_at", "expires_at", "released_at",
+    }
+    if not isinstance(value, dict) or set(value) != fields:
+        raise ValidationError("Scheduler owner lease 结构无效")
+    if type(value.get("schema_version")) is not int or value["schema_version"] != OWNER_LEASE_SCHEMA_VERSION:
+        raise ValidationError("Scheduler owner lease schema_version 无效")
+    try:
+        released = value["released_at"]
+        return OwnerLease(
+            objective_id=value["objective_id"], generation=value["generation"], owner_token_sha256=value["owner_token_sha256"],
+            pid=value["pid"], process_start=value["process_start"],
+            issued_at=parse_timestamp(value["issued_at"], "Scheduler owner issued_at"),
+            heartbeat_at=parse_timestamp(value["heartbeat_at"], "Scheduler owner heartbeat_at"),
+            expires_at=parse_timestamp(value["expires_at"], "Scheduler owner expires_at"),
+            released_at=parse_timestamp(released, "Scheduler owner released_at") if released is not None else None,
+        )
+    except (KeyError, TypeError, ValidationError) as exc:
+        raise ValidationError("Scheduler owner lease 内容无效") from exc
+
+
+def read_optional_lease(directory: ObjectiveDirectory) -> OwnerLease | None:
+    try:
+        payload = _read_json(directory.fd, "scheduler-owner.json", "Scheduler owner lease")
+    except FileNotFoundError:
+        return None
+    return _lease_from_payload(payload)
+
+
+def _takeover_pending_payload(lease: OwnerLease, previous: OwnerLease | None, cancellation: dict[str, object]) -> dict[str, object]:
+    return {
+        "schema_version": OWNER_TAKEOVER_SCHEMA_VERSION, "lease": _lease_payload(lease),
+        "previous_lease": _lease_payload(previous) if previous is not None else None,
+        "action_cancellation": cancellation,
+    }
+
+
+def _read_takeover_pending(directory: ObjectiveDirectory) -> tuple[OwnerLease, OwnerLease | None, dict[str, object]] | None:
+    try:
+        payload = _read_json(directory.fd, _OWNER_TAKEOVER_PENDING_FILE, "Scheduler owner takeover pending")
+    except FileNotFoundError:
+        return None
+    fields = {"schema_version", "lease", "previous_lease", "action_cancellation"}
+    if not isinstance(payload, dict) or set(payload) != fields or payload.get("schema_version") != OWNER_TAKEOVER_SCHEMA_VERSION:
+        raise ValidationError("Scheduler owner takeover pending 结构或版本无效")
+    try:
+        expected = _lease_from_payload(payload["lease"])
+    except (KeyError, TypeError, ValidationError) as exc:
+        raise ValidationError("Scheduler owner takeover pending lease 无效") from exc
+    raw_previous = payload["previous_lease"]
+    try:
+        previous = None if raw_previous is None else _lease_from_payload(raw_previous)
+    except (TypeError, ValidationError) as exc:
+        raise ValidationError("Scheduler owner takeover pending previous lease 无效") from exc
+    if previous is None and expected.generation != 1:
+        raise ValidationError("Scheduler owner takeover pending previous lease 无效")
+    if previous is not None and (
+        previous.objective_id != expected.objective_id or previous.generation + 1 != expected.generation
+    ):
+        raise ValidationError("Scheduler owner takeover pending previous lease 无效")
+    cancellation = payload["action_cancellation"]
+    if not isinstance(cancellation, dict):
+        raise ValidationError("Scheduler owner takeover pending cancellation 无效")
+    cancellation_plan_from_payload(cancellation)
+    return expected, previous, cancellation
+
+
+def recover_owner_takeover(directory: ObjectiveDirectory) -> None:
+    pending = _read_takeover_pending(directory)
+    if pending is None:
+        return
+    expected, previous, cancellation = pending
+    current = read_optional_lease(directory)
+    if current == expected:
+        apply_action_cancellation(directory, cancellation)
+        _remove_json(directory.fd, _OWNER_TAKEOVER_PENDING_FILE, "Scheduler owner takeover pending")
+        return
+    if current == previous:
+        _remove_json(directory.fd, _OWNER_TAKEOVER_PENDING_FILE, "Scheduler owner takeover pending")
+        return
+    raise ValidationError("Scheduler owner takeover pending 与当前 lease 不一致")
+
+
+def read_owner_lease(directory: ObjectiveDirectory) -> OwnerLease | None:
+    recover_owner_takeover(directory)
+    return read_optional_lease(directory)
+
+
+def acquire_owner_lease(
+    directory: ObjectiveDirectory, *, objective_id: str, now: datetime, ttl_seconds: int, pid: int,
+    process_start: str, owner_token: str | None = None,
+) -> OwnerLeaseGrant:
+    recover_owner_takeover(directory)
+    validate_id(objective_id, "Objective ID")
+    now_utc = utc(now, "now")
+    if type(ttl_seconds) is not int or not 1 <= ttl_seconds <= 3600:
+        raise TypeError("ttl_seconds 必须在 1 到 3600 秒之间")
+    if type(pid) is not int or pid < 1:
+        raise TypeError("pid 必须是正整数")
+    if not isinstance(process_start, str) or not process_start or len(process_start) > 256:
+        raise TypeError("process_start 无效")
+    previous = read_optional_lease(directory)
+    if previous is not None:
+        if previous.objective_id != objective_id:
+            raise ValidationError("Scheduler owner lease Objective 不匹配")
+        if now_utc < previous.heartbeat_at:
+            raise DyroError("检测到 Scheduler 时钟回拨；拒绝接管 owner lease")
+        if previous.active and now_utc < previous.expires_at:
+            raise DyroError("Scheduler owner lease 仍有效；拒绝并发接管")
+    token = owner_token if owner_token is not None else secrets.token_hex(32)
+    lease = OwnerLease(
+        objective_id=objective_id, generation=1 if previous is None else previous.generation + 1,
+        owner_token_sha256=_owner_token_digest(token), pid=pid, process_start=process_start,
+        issued_at=now_utc, heartbeat_at=now_utc, expires_at=now_utc + timedelta(seconds=ttl_seconds),
+    )
+    cancellation = prepare_action_cancellation(directory, summary="owner lease 已接管；未 start Action 已取消", now=now_utc)
+    if cancellation is not None:
+        _create_only_json(directory.fd, _OWNER_TAKEOVER_PENDING_FILE, _takeover_pending_payload(lease, previous, cancellation), "Scheduler owner takeover pending")
+    _replace_json(directory.fd, "scheduler-owner.json", _lease_payload(lease), "Scheduler owner lease")
+    recover_owner_takeover(directory)
+    return OwnerLeaseGrant(lease, token)
+
+
+def assert_owner(lease: OwnerLease, grant: OwnerLeaseGrant, now: datetime) -> datetime:
+    now_utc = utc(now, "now")
+    if not lease.active or now_utc >= lease.expires_at:
+        raise DyroError("Scheduler owner lease 已失效")
+    if now_utc < lease.heartbeat_at:
+        raise DyroError("检测到 Scheduler 时钟回拨；拒绝继续 owner lease")
+    if grant.lease.generation != lease.generation or grant.lease.owner_token_sha256 != lease.owner_token_sha256:
+        raise DyroError("Scheduler owner generation 已被围栏；拒绝旧 owner")
+    if _owner_token_digest(grant.owner_token) != lease.owner_token_sha256:
+        raise DyroError("Scheduler owner token 不匹配")
+    return now_utc
+
+
+def verify_owner_lease(directory: ObjectiveDirectory, *, grant: OwnerLeaseGrant, now: datetime) -> OwnerLease:
+    recover_owner_takeover(directory)
+    lease = read_optional_lease(directory)
+    if lease is None:
+        raise DyroError("Scheduler owner lease 不存在")
+    assert_owner(lease, grant, now)
+    return lease
+
+
+def renew_owner_lease(directory: ObjectiveDirectory, *, grant: OwnerLeaseGrant, now: datetime, ttl_seconds: int) -> OwnerLeaseGrant:
+    recover_owner_takeover(directory)
+    if type(ttl_seconds) is not int or not 1 <= ttl_seconds <= 3600:
+        raise TypeError("ttl_seconds 必须在 1 到 3600 秒之间")
+    lease = read_optional_lease(directory)
+    if lease is None:
+        raise DyroError("Scheduler owner lease 不存在")
+    now_utc = assert_owner(lease, grant, now)
+    renewed = OwnerLease(lease.objective_id, lease.generation, lease.owner_token_sha256, lease.pid, lease.process_start, lease.issued_at, now_utc, now_utc + timedelta(seconds=ttl_seconds))
+    _replace_json(directory.fd, "scheduler-owner.json", _lease_payload(renewed), "Scheduler owner lease")
+    return OwnerLeaseGrant(renewed, grant.owner_token)
+
+
+def release_owner_lease(directory: ObjectiveDirectory, *, grant: OwnerLeaseGrant, now: datetime) -> OwnerLease:
+    recover_owner_takeover(directory)
+    lease = read_optional_lease(directory)
+    if lease is None:
+        raise DyroError("Scheduler owner lease 不存在")
+    now_utc = assert_owner(lease, grant, now)
+    released = OwnerLease(lease.objective_id, lease.generation, lease.owner_token_sha256, lease.pid, lease.process_start, lease.issued_at, now_utc, lease.expires_at, now_utc)
+    _replace_json(directory.fd, "scheduler-owner.json", _lease_payload(released), "Scheduler owner lease")
+    return released

--- a/src/dyro/continuation/store.py
+++ b/src/dyro/continuation/store.py
@@ -8,6 +8,7 @@ Agent, changes a Task state, or treats a lifecycle flag as completion proof.
 from __future__ import annotations
 
 from contextlib import contextmanager
+from datetime import datetime, timezone
 import hashlib
 import json
 import os
@@ -23,8 +24,26 @@ from ..state import (
     exclusive_lock,
 )
 from ..tasks import Task, list_tasks, status as task_status
+from .actions import (
+    ActionIntent,
+    ActionReceipt,
+    ActionRecord,
+    ActionStatus,
+    OwnerLease,
+    OwnerLeaseGrant,
+    acquire_owner_lease as _acquire_owner_lease,
+    list_actions as _list_actions,
+    prepare_action_cancellation as _prepare_action_cancellation,
+    read_action as _read_action,
+    record_action_receipt as _record_action_receipt,
+    release_owner_lease as _release_owner_lease,
+    renew_owner_lease as _renew_owner_lease,
+    reserve_action as _reserve_action,
+    start_action as _start_action,
+    verify_owner_lease as _verify_owner_lease,
+)
 from .contracts import canonical_contract, contract_sha256, parse_contract, validate_objective_scope
-from .models import Objective
+from .models import ActionKind, Objective, Operation, RequestedMode
 from .objective_storage import (
     OBJECTIVE_STORE_SCHEMA_VERSION,
     OPERATOR_STATES,
@@ -329,11 +348,11 @@ def _assert_ownership_available(
     exclude_id: str = "",
     recover: bool = True,
 ) -> None:
-    if not record.owns_mutation_scope:
+    if not _retains_mutation_scope(config, record):
         return
     requested = set(record.scope)
     for other in list_objectives(config, recover=recover):
-        if other.objective.id == exclude_id or not other.owns_mutation_scope:
+        if other.objective.id == exclude_id or not _retains_mutation_scope(config, other):
             continue
         overlap = sorted(requested & set(other.scope))
         if overlap:
@@ -421,6 +440,175 @@ def get_objective(config: Config, objective_id: str, *, recover: bool = True) ->
         return _read_stored(config, objective_id, recover=False, directory=directory)
 
 
+def _require_actionable_objective(config: Config, objective_id: str, directory: ObjectiveDirectory) -> StoredObjective:
+    record = _read_stored(config, objective_id, directory=directory)
+    if record.operator_state != "active":
+        raise DyroError("Objective 未处于 active 状态；拒绝取得或使用 Scheduler mutation authority")
+    if not record.owns_mutation_scope:
+        raise DyroError("observe Objective 不取得 Scheduler mutation authority")
+    return record
+
+
+def _assert_action_is_authorized(record: StoredObjective, intent: ActionIntent) -> None:
+    """Keep Action Journal records inside the accepted Objective authority."""
+    if (
+        intent.objective_id != record.objective.id
+        or intent.objective_revision != record.revision
+        or intent.objective_event_seq != record.event_seq
+        or intent.objective_event_sha256 != record.event_sha256
+        or intent.scope_sha256 != record.scope_sha256
+    ):
+        raise DyroError("Action intent 未绑定当前已接受的 Objective revision、事件或 scope")
+    if intent.subject_id not in record.scope:
+        raise DyroError("Action subject 不在当前 Objective mutation scope 内")
+    required_operation = {
+        ActionKind.EXECUTE_TASK: Operation.EXECUTE,
+        ActionKind.REVIEW_TASK: Operation.REVIEW,
+        ActionKind.MERGE_TASK: Operation.MERGE,
+    }.get(intent.operation)
+    if required_operation is None or required_operation not in record.objective.operations:
+        raise DyroError("Action operation 未获当前 Objective contract 授权")
+
+
+def _unresolved_actions(directory: ObjectiveDirectory) -> tuple[ActionRecord, ...]:
+    return tuple(record for record in _list_actions(directory) if record.status is ActionStatus.UNCERTAIN)
+
+
+def _assert_no_unresolved_actions(directory: ObjectiveDirectory, *, operation: str) -> None:
+    unresolved = _unresolved_actions(directory)
+    if unresolved:
+        action_ids = ", ".join(record.intent.action_id for record in unresolved)
+        raise DyroError(f"存在 uncertain Action，拒绝 {operation}：{action_ids}")
+
+
+def _prepared_reserved_action_cancellation(directory: ObjectiveDirectory, *, reason: str) -> dict[str, object] | None:
+    return _prepare_action_cancellation(directory, summary=reason, now=datetime.now(timezone.utc))
+
+
+def _retains_mutation_scope(config: Config, record: StoredObjective) -> bool:
+    """Keep a paused/stopped scope reserved while an Action remains uncertain."""
+    if record.owns_mutation_scope:
+        return True
+    if record.objective.requested_mode is RequestedMode.OBSERVE:
+        return False
+    with open_objective_directory(config, record.objective.id) as directory:
+        return bool(_unresolved_actions(directory))
+
+
+def acquire_objective_owner_lease(
+    config: Config,
+    objective_id: str,
+    *,
+    now: datetime,
+    ttl_seconds: int,
+    pid: int,
+    process_start: str,
+    owner_token: str | None = None,
+) -> OwnerLeaseGrant:
+    """Acquire a fenced scheduler owner lease under the workspace Objective lock."""
+    with _objective_lock(config):
+        with open_objective_directory(config, objective_id) as directory:
+            _require_actionable_objective(config, objective_id, directory)
+            grant = _acquire_owner_lease(
+                directory,
+                objective_id=objective_id,
+                now=now,
+                ttl_seconds=ttl_seconds,
+                pid=pid,
+                process_start=process_start,
+                owner_token=owner_token,
+            )
+            return grant
+
+
+def renew_objective_owner_lease(
+    config: Config,
+    objective_id: str,
+    *,
+    grant: OwnerLeaseGrant,
+    now: datetime,
+    ttl_seconds: int,
+) -> OwnerLeaseGrant:
+    with _objective_lock(config):
+        with open_objective_directory(config, objective_id) as directory:
+            _require_actionable_objective(config, objective_id, directory)
+            return _renew_owner_lease(directory, grant=grant, now=now, ttl_seconds=ttl_seconds)
+
+
+def release_objective_owner_lease(
+    config: Config,
+    objective_id: str,
+    *,
+    grant: OwnerLeaseGrant,
+    now: datetime,
+) -> OwnerLease:
+    with _objective_lock(config):
+        with open_objective_directory(config, objective_id) as directory:
+            return _release_owner_lease(directory, grant=grant, now=now)
+
+
+def reserve_objective_action(
+    config: Config,
+    objective_id: str,
+    *,
+    intent: ActionIntent,
+    grant: OwnerLeaseGrant,
+    now: datetime,
+) -> ActionRecord:
+    """Reserve one fenced ActionIntent without invoking a delivery mutation."""
+    with _objective_lock(config):
+        with open_objective_directory(config, objective_id) as directory:
+            record = _require_actionable_objective(config, objective_id, directory)
+            _assert_action_is_authorized(record, intent)
+            _assert_no_unresolved_actions(directory, operation="创建下一 Action")
+            lease = _verify_owner_lease(directory, grant=grant, now=now)
+            if intent.owner_generation != lease.generation:
+                raise DyroError("Action intent owner_generation 与当前 Scheduler lease 不匹配")
+            return _reserve_action(directory, intent)
+
+
+def start_objective_action(
+    config: Config,
+    objective_id: str,
+    *,
+    action_id: str,
+    grant: OwnerLeaseGrant,
+    now: datetime,
+) -> ActionRecord:
+    """Cross only the durable Action start barrier; never start a process here."""
+    with _objective_lock(config):
+        with open_objective_directory(config, objective_id) as directory:
+            record = _require_actionable_objective(config, objective_id, directory)
+            _assert_action_is_authorized(record, _read_action(directory, action_id).intent)
+            return _start_action(directory, action_id=action_id, grant=grant, now=now)
+
+
+def record_objective_action_receipt(
+    config: Config,
+    objective_id: str,
+    *,
+    receipt: ActionReceipt,
+    grant: OwnerLeaseGrant | None = None,
+    now: datetime | None = None,
+) -> ActionRecord:
+    """Accept only a receipt whose immutable binding matches its ActionIntent."""
+    with _objective_lock(config):
+        with open_objective_directory(config, objective_id) as directory:
+            return _record_action_receipt(directory, receipt, grant=grant, now=now)
+
+
+def list_objective_actions(config: Config, objective_id: str) -> tuple[ActionRecord, ...]:
+    with _objective_lock(config, create=False):
+        with open_objective_directory(config, objective_id) as directory:
+            return _list_actions(directory)
+
+
+def get_objective_action(config: Config, objective_id: str, action_id: str) -> ActionRecord:
+    with _objective_lock(config, create=False):
+        with open_objective_directory(config, objective_id) as directory:
+            return _read_action(directory, action_id)
+
+
 def _persist_revision(
     config: Config,
     current: StoredObjective,
@@ -442,11 +630,17 @@ def _persist_revision(
     )
     _assert_ownership_available(config, candidate, exclude_id=current.objective.id)
     _assert_no_inflight_tasks(config, candidate)
+    _assert_no_unresolved_actions(directory, operation=event_name)
+    cancellation = _prepared_reserved_action_cancellation(
+        directory,
+        reason=f"Objective {event_name}；未 start Action 已取消",
+    )
     return _commit_event(
         directory,
         candidate,
         event_name,
         contract_content=_render_contract(objective).encode("utf-8"),
+        action_cancellation=cancellation,
     )
 
 
@@ -579,7 +773,20 @@ def _transition_objective(config: Config, objective_id: str, next_state: str, *,
         if next_state == "active":
             _assert_ownership_available(config, candidate, exclude_id=current.objective.id)
         _assert_no_inflight_tasks(config, candidate)
-        return _commit_event(directory, candidate, f"state_{next_state}")
+        cancellation = (
+            _prepared_reserved_action_cancellation(
+                directory,
+                reason=f"Objective {next_state}；未 start Action 已取消",
+            )
+            if next_state in {"paused", "stopped"}
+            else None
+        )
+        return _commit_event(
+            directory,
+            candidate,
+            f"state_{next_state}",
+            action_cancellation=cancellation,
+        )
 
     if dry_run:
         current = get_objective(config, objective_id, recover=False)
@@ -649,12 +856,13 @@ def assert_legacy_scheduler_allowed(config: Config, task_ids: Iterable[str]) -> 
     requested = {validate_id(task_id, "任务 ID") for task_id in task_ids}
     if not requested:
         return
-    for record in list_objectives(config):
-        if record.owns_mutation_scope and requested & set(record.scope):
-            raise DyroError(
-                f"任务位于 active Objective {record.objective.id} 的 mutation scope；"
-                "请使用 plan-only Objective 命令，旧 task loop/daemon 不能绕过 ownership"
-            )
+    with _objective_lock(config, create=False):
+        for record in _list_objectives_unlocked(config, recover=True):
+            if _retains_mutation_scope(config, record) and requested & set(record.scope):
+                raise DyroError(
+                    f"任务位于受保护 Objective {record.objective.id} 的 mutation scope；"
+                    "请使用 plan-only Objective 命令，旧 task loop/daemon 不能绕过 ownership"
+                )
 
 
 @contextmanager

--- a/tests/test_continuation_actions.py
+++ b/tests/test_continuation_actions.py
@@ -653,7 +653,7 @@ class ActionJournalTests(WorkspaceCase):
                 )
             action_file = self.config.objectives_dir / "release" / "actions" / "action-open.json"
             action_file.write_bytes((b"[" * 10_000) + (b"]" * 10_000))
-            with self.assertRaisesRegex(ValidationError, "JSON"):
+            with self.assertRaisesRegex(ValidationError, "JSON|结构无效"):
                 read_action(directory, "action-open")
 
     def test_orphan_start_or_receipt_fails_closed(self) -> None:

--- a/tests/test_continuation_actions.py
+++ b/tests/test_continuation_actions.py
@@ -1,0 +1,673 @@
+from __future__ import annotations
+
+from dataclasses import replace
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+import shutil
+import unittest
+from unittest.mock import patch
+
+from dyro.config import load
+from dyro.continuation import objective_storage as storage_module
+from dyro.continuation import owner_lease as owner_lease_module
+from dyro.continuation.actions import (
+    ActionIntent,
+    ActionReceipt,
+    ActionStatus,
+    acquire_owner_lease,
+    list_actions,
+    read_action,
+    read_owner_lease,
+    record_action_receipt,
+    release_owner_lease,
+    renew_owner_lease,
+    reserve_action,
+    start_action,
+)
+from dyro.continuation.budgets import BudgetReservation
+from dyro.continuation.models import ActionKind
+from dyro.continuation.objective_storage import open_objective_directory
+from dyro.continuation.store import (
+    add_objective_target,
+    acquire_objective_owner_lease,
+    create_objective,
+    get_objective,
+    get_objective_action,
+    list_objective_actions,
+    pause_objective,
+    record_objective_action_receipt,
+    reconcile_objective,
+    remove_objective_target,
+    resume_objective,
+    reserve_objective_action,
+    start_objective_action,
+)
+from dyro.errors import DyroError, ValidationError
+from dyro.tasks import task_template
+from dyro.workspace import create_line
+
+from .support import WorkspaceCase
+
+
+def _contract(objective_id: str, target: str) -> str:
+    return f'''schema_version = 1
+id = "{objective_id}"
+title = "Objective {objective_id}"
+line = "alpha"
+targets = ["{target}"]
+
+[continuation]
+requested_mode = "supervised"
+operations = ["execute", "review"]
+'''
+
+
+class ActionJournalTests(WorkspaceCase):
+    def setUp(self) -> None:
+        super().setUp()
+        self.config = load(self.root)
+        create_line(self.config, line_id="alpha", branch="feat/alpha", base="main")
+        self._write_task("TASK-A")
+        self.record = create_objective(self.config, _contract("release", "TASK-A"))
+        self.now = datetime(2026, 8, 4, 12, 0, tzinfo=timezone.utc)
+
+    def _write_task(self, task_id: str) -> Path:
+        directory = self.config.task_specs_dir / task_id
+        directory.mkdir(parents=True)
+        manifest = task_template(task_id, f"Task {task_id}", "alpha", "api", "services/api")
+        directory.joinpath("task.toml").write_text(
+            manifest.replace('agent = "codex"', 'agent = "noop"'), encoding="utf-8"
+        )
+        directory.joinpath("handoff.md").write_text("# handoff\n", encoding="utf-8")
+        return directory
+
+    def _intent(self, *, action_id: str, generation: int) -> ActionIntent:
+        return ActionIntent(
+            action_id=action_id,
+            objective_id="release",
+            objective_revision=self.record.revision,
+            objective_event_seq=self.record.event_seq,
+            objective_event_sha256=self.record.event_sha256,
+            scope_sha256=self.record.scope_sha256,
+            snapshot_sha256="a" * 64,
+            plan_sha256="b" * 64,
+            operation=ActionKind.EXECUTE_TASK,
+            subject_id="TASK-A",
+            owner_generation=generation,
+            expected_operation_generation=0,
+            authority_sha256="c" * 64,
+            budget_reservation=BudgetReservation("release", "TASK-A"),
+            created_at=self.now,
+        )
+
+    def _intent_for(self, *, action_id: str, generation: int, operation: ActionKind, subject_id: str) -> ActionIntent:
+        return ActionIntent(
+            action_id=action_id,
+            objective_id="release",
+            objective_revision=self.record.revision,
+            objective_event_seq=self.record.event_seq,
+            objective_event_sha256=self.record.event_sha256,
+            scope_sha256=self.record.scope_sha256,
+            snapshot_sha256="a" * 64,
+            plan_sha256="b" * 64,
+            operation=operation,
+            subject_id=subject_id,
+            owner_generation=generation,
+            expected_operation_generation=0,
+            authority_sha256="c" * 64,
+            budget_reservation=BudgetReservation("release", subject_id),
+            created_at=self.now,
+        )
+
+    def _acquire(self, directory, *, now: datetime | None = None, token: str = "1" * 64):
+        return acquire_owner_lease(
+            directory,
+            objective_id="release",
+            now=now or self.now,
+            ttl_seconds=30,
+            pid=123,
+            process_start="boot-1",
+            owner_token=token,
+        )
+
+    def test_create_only_intent_start_and_receipt_are_idempotent(self) -> None:
+        with open_objective_directory(self.config, "release") as directory:
+            grant = self._acquire(directory)
+            intent = self._intent(action_id="action-1", generation=grant.lease.generation)
+            reserved = reserve_action(directory, intent)
+            self.assertEqual(reserved.status, ActionStatus.RESERVED)
+            self.assertEqual(reserve_action(directory, intent), reserved)
+            retried = reserve_action(
+                directory,
+                replace(intent, action_id="action-duplicate", created_at=self.now + timedelta(seconds=1)),
+            )
+            self.assertEqual(retried, reserved)
+
+            started = start_action(directory, action_id="action-1", grant=grant, now=self.now + timedelta(seconds=1))
+            self.assertEqual(started.status, ActionStatus.UNCERTAIN)
+            repeated_start = start_action(directory, action_id="action-1", grant=grant, now=self.now + timedelta(seconds=2))
+            self.assertEqual(repeated_start.start, started.start)
+
+            receipt = ActionReceipt(
+                action_id="action-1",
+                idempotency_key=intent.idempotency_key,
+                owner_generation=grant.lease.generation,
+                status=ActionStatus.SUCCEEDED,
+                summary="gate-passed",
+                recorded_at=self.now + timedelta(seconds=3),
+            )
+            completed = record_action_receipt(directory, receipt)
+            self.assertEqual(completed.status, ActionStatus.SUCCEEDED)
+            self.assertEqual(record_action_receipt(directory, receipt).receipt, receipt)
+            self.assertEqual(list_actions(directory), (completed,))
+
+    def test_fencing_blocks_old_start_but_accepts_old_started_receipt(self) -> None:
+        with open_objective_directory(self.config, "release") as directory:
+            first = self._acquire(directory, token="1" * 64)
+            first_intent = self._intent(action_id="action-old", generation=first.lease.generation)
+            reserve_action(directory, first_intent)
+            start_action(directory, action_id="action-old", grant=first, now=self.now + timedelta(seconds=1))
+
+            second = self._acquire(directory, now=self.now + timedelta(seconds=31), token="2" * 64)
+            self.assertEqual(second.lease.generation, 2)
+            next_intent = self._intent(action_id="action-new", generation=second.lease.generation)
+            reserve_action(directory, next_intent)
+            with self.assertRaisesRegex(DyroError, "失效|围栏"):
+                start_action(directory, action_id="action-new", grant=first, now=self.now + timedelta(seconds=32))
+
+            finished = record_action_receipt(
+                directory,
+                ActionReceipt(
+                    action_id="action-old",
+                    idempotency_key=first_intent.idempotency_key,
+                    owner_generation=first.lease.generation,
+                    status=ActionStatus.FAILED,
+                    summary="runner-exited",
+                    recorded_at=self.now + timedelta(seconds=32),
+                ),
+            )
+            self.assertEqual(finished.status, ActionStatus.FAILED)
+
+    def test_control_plane_facade_rechecks_objective_and_lease_bindings(self) -> None:
+        grant = acquire_objective_owner_lease(
+            self.config,
+            "release",
+            now=self.now,
+            ttl_seconds=30,
+            pid=123,
+            process_start="boot-1",
+            owner_token="1" * 64,
+        )
+        intent = self._intent(action_id="action-facade", generation=grant.lease.generation)
+        reserved = reserve_objective_action(
+            self.config,
+            "release",
+            intent=intent,
+            grant=grant,
+            now=self.now,
+        )
+        self.assertEqual(reserved.status, ActionStatus.RESERVED)
+        started = start_objective_action(
+            self.config,
+            "release",
+            action_id="action-facade",
+            grant=grant,
+            now=self.now + timedelta(seconds=1),
+        )
+        self.assertEqual(started.status, ActionStatus.UNCERTAIN)
+        completed = record_objective_action_receipt(
+            self.config,
+            "release",
+            receipt=ActionReceipt(
+                action_id="action-facade",
+                idempotency_key=intent.idempotency_key,
+                owner_generation=grant.lease.generation,
+                status=ActionStatus.SUCCEEDED,
+                summary="facade-complete",
+                recorded_at=self.now + timedelta(seconds=2),
+            ),
+        )
+        self.assertEqual(list_objective_actions(self.config, "release"), (completed,))
+
+    def test_control_plane_facade_requires_current_owner_to_cancel_unstarted_action(self) -> None:
+        grant = acquire_objective_owner_lease(
+            self.config,
+            "release",
+            now=self.now,
+            ttl_seconds=30,
+            pid=123,
+            process_start="boot-1",
+            owner_token="1" * 64,
+        )
+        intent = self._intent(action_id="action-facade-cancel", generation=grant.lease.generation)
+        reserve_objective_action(self.config, "release", intent=intent, grant=grant, now=self.now)
+        receipt = ActionReceipt(
+            action_id=intent.action_id,
+            idempotency_key=intent.idempotency_key,
+            owner_generation=grant.lease.generation,
+            status=ActionStatus.CANCELLED,
+            summary="cancelled-before-start",
+            recorded_at=self.now + timedelta(seconds=1),
+        )
+        with self.assertRaisesRegex(DyroError, "owner grant"):
+            record_objective_action_receipt(self.config, "release", receipt=receipt)
+        cancelled = record_objective_action_receipt(
+            self.config,
+            "release",
+            receipt=receipt,
+            grant=grant,
+            now=self.now + timedelta(seconds=1),
+        )
+        self.assertEqual(cancelled.status, ActionStatus.CANCELLED)
+
+    def test_idempotency_key_binds_authority_budget_and_active_objective(self) -> None:
+        with open_objective_directory(self.config, "release") as directory:
+            grant = self._acquire(directory)
+            intent = self._intent(action_id="action-bound", generation=grant.lease.generation)
+            changed_authority = replace(intent, action_id="action-authority", authority_sha256="d" * 64, idempotency_key="")
+            changed_budget = replace(
+                intent,
+                action_id="action-budget",
+                budget_reservation=BudgetReservation("release", "TASK-A", attempts=2),
+                idempotency_key="",
+            )
+            self.assertNotEqual(intent.idempotency_key, changed_authority.idempotency_key)
+            self.assertNotEqual(intent.idempotency_key, changed_budget.idempotency_key)
+
+        pause_objective(self.config, "release")
+        with self.assertRaisesRegex(DyroError, "未处于 active"):
+            acquire_objective_owner_lease(
+                self.config,
+                "release",
+                now=self.now,
+                ttl_seconds=30,
+                pid=123,
+                process_start="boot-1",
+                owner_token="2" * 64,
+            )
+
+    def test_control_plane_facade_rejects_out_of_scope_or_unauthorized_operations(self) -> None:
+        grant = acquire_objective_owner_lease(
+            self.config,
+            "release",
+            now=self.now,
+            ttl_seconds=30,
+            pid=123,
+            process_start="boot-1",
+            owner_token="1" * 64,
+        )
+        outside = self._intent_for(
+            action_id="action-outside",
+            generation=grant.lease.generation,
+            operation=ActionKind.EXECUTE_TASK,
+            subject_id="OUTSIDE-TASK",
+        )
+        with self.assertRaisesRegex(DyroError, "mutation scope"):
+            reserve_objective_action(self.config, "release", intent=outside, grant=grant, now=self.now)
+        unauthorized = self._intent_for(
+            action_id="action-merge",
+            generation=grant.lease.generation,
+            operation=ActionKind.MERGE_TASK,
+            subject_id="TASK-A",
+        )
+        with self.assertRaisesRegex(DyroError, "未获"):
+            reserve_objective_action(self.config, "release", intent=unauthorized, grant=grant, now=self.now)
+
+    def test_pause_resume_fences_unstarted_action_from_the_prior_objective_event(self) -> None:
+        grant = acquire_objective_owner_lease(
+            self.config,
+            "release",
+            now=self.now,
+            ttl_seconds=30,
+            pid=123,
+            process_start="boot-1",
+            owner_token="1" * 64,
+        )
+        intent = self._intent(action_id="action-paused", generation=grant.lease.generation)
+        reserve_objective_action(self.config, "release", intent=intent, grant=grant, now=self.now)
+        pause_objective(self.config, "release")
+        self.assertEqual(get_objective_action(self.config, "release", "action-paused").status, ActionStatus.CANCELLED)
+        resume_objective(self.config, "release")
+        with self.assertRaisesRegex(DyroError, "事件"):
+            start_objective_action(
+                self.config,
+                "release",
+                action_id="action-paused",
+                grant=grant,
+                now=self.now + timedelta(seconds=1),
+            )
+
+    def test_lease_takeover_cancels_reserved_actions(self) -> None:
+        first = acquire_objective_owner_lease(
+            self.config,
+            "release",
+            now=self.now,
+            ttl_seconds=30,
+            pid=123,
+            process_start="boot-1",
+            owner_token="1" * 64,
+        )
+        intent = self._intent(action_id="action-takeover", generation=first.lease.generation)
+        reserve_objective_action(self.config, "release", intent=intent, grant=first, now=self.now)
+        second = acquire_objective_owner_lease(
+            self.config,
+            "release",
+            now=self.now + timedelta(seconds=31),
+            ttl_seconds=30,
+            pid=456,
+            process_start="boot-2",
+            owner_token="2" * 64,
+        )
+        self.assertEqual(second.lease.generation, 2)
+        self.assertEqual(get_objective_action(self.config, "release", intent.action_id).status, ActionStatus.CANCELLED)
+
+    def test_lease_takeover_cancellation_recovers_after_owner_lease_is_durable(self) -> None:
+        first = acquire_objective_owner_lease(
+            self.config,
+            "release",
+            now=self.now,
+            ttl_seconds=30,
+            pid=123,
+            process_start="boot-1",
+            owner_token="1" * 64,
+        )
+        intent = self._intent(action_id="action-takeover-recovery", generation=first.lease.generation)
+        reserve_objective_action(self.config, "release", intent=intent, grant=first, now=self.now)
+        with patch.object(owner_lease_module, "apply_action_cancellation", side_effect=DyroError("simulated crash")):
+            with self.assertRaisesRegex(DyroError, "simulated crash"):
+                acquire_objective_owner_lease(
+                    self.config,
+                    "release",
+                    now=self.now + timedelta(seconds=31),
+                    ttl_seconds=30,
+                    pid=456,
+                    process_start="boot-2",
+                    owner_token="2" * 64,
+                )
+        self.assertEqual(get_objective_action(self.config, "release", intent.action_id).status, ActionStatus.RESERVED)
+        with open_objective_directory(self.config, "release") as directory:
+            recovered = read_owner_lease(directory)
+        assert recovered is not None
+        self.assertEqual(recovered.generation, 2)
+        self.assertEqual(get_objective_action(self.config, "release", intent.action_id).status, ActionStatus.CANCELLED)
+
+    def test_owner_takeover_recovery_accepts_only_the_exact_prior_lease(self) -> None:
+        first = acquire_objective_owner_lease(
+            self.config,
+            "release",
+            now=self.now,
+            ttl_seconds=30,
+            pid=123,
+            process_start="boot-1",
+            owner_token="1" * 64,
+        )
+        second = acquire_objective_owner_lease(
+            self.config,
+            "release",
+            now=self.now + timedelta(seconds=31),
+            ttl_seconds=30,
+            pid=456,
+            process_start="boot-2",
+            owner_token="2" * 64,
+        )
+        intent = self._intent(action_id="action-takeover-rollback", generation=second.lease.generation)
+        reserve_objective_action(
+            self.config,
+            "release",
+            intent=intent,
+            grant=second,
+            now=self.now + timedelta(seconds=32),
+        )
+        with patch.object(owner_lease_module, "_replace_json", side_effect=DyroError("simulated pre-lease crash")):
+            with self.assertRaisesRegex(DyroError, "simulated pre-lease crash"):
+                acquire_objective_owner_lease(
+                    self.config,
+                    "release",
+                    now=self.now + timedelta(seconds=62),
+                    ttl_seconds=30,
+                    pid=789,
+                    process_start="boot-3",
+                    owner_token="3" * 64,
+                )
+        with open_objective_directory(self.config, "release") as directory:
+            owner_lease_module._replace_json(
+                directory.fd,
+                "scheduler-owner.json",
+                owner_lease_module._lease_payload(first.lease),
+                "test unexpected rollback",
+            )
+            pending = owner_lease_module._read_json(
+                directory.fd,
+                "scheduler-owner-pending.json",
+                "test takeover pending",
+            )
+            assert isinstance(pending, dict)
+            pending["previous_lease"] = owner_lease_module._lease_payload(first.lease)
+            owner_lease_module._replace_json(
+                directory.fd,
+                "scheduler-owner-pending.json",
+                pending,
+                "test tampered takeover pending",
+            )
+            with self.assertRaisesRegex(ValidationError, "takeover pending"):
+                read_owner_lease(directory)
+        self.assertEqual(get_objective_action(self.config, "release", intent.action_id).status, ActionStatus.RESERVED)
+
+    def test_rejected_objective_mutations_do_not_cancel_reserved_actions(self) -> None:
+        grant = acquire_objective_owner_lease(
+            self.config,
+            "release",
+            now=self.now,
+            ttl_seconds=30,
+            pid=123,
+            process_start="boot-1",
+            owner_token="1" * 64,
+        )
+        first = self._intent(action_id="action-survive-add", generation=grant.lease.generation)
+        reserve_objective_action(self.config, "release", intent=first, grant=grant, now=self.now)
+        with self.assertRaisesRegex(ValidationError, "TaskGraph"):
+            add_objective_target(self.config, "release", "UNKNOWN-TASK")
+        self.assertEqual(get_objective_action(self.config, "release", first.action_id).status, ActionStatus.RESERVED)
+
+        self._write_task("TASK-B")
+        self.record = add_objective_target(self.config, "release", "TASK-B")
+        self.assertEqual(get_objective_action(self.config, "release", first.action_id).status, ActionStatus.CANCELLED)
+        second = self._intent(action_id="action-survive-reject", generation=grant.lease.generation)
+        reserve_objective_action(self.config, "release", intent=second, grant=grant, now=self.now)
+        with self.assertRaisesRegex(DyroError, "target 不存在"):
+            remove_objective_target(self.config, "release", "UNKNOWN-TASK")
+        self.assertEqual(get_objective_action(self.config, "release", second.action_id).status, ActionStatus.RESERVED)
+
+        (self.config.task_specs_dir / "TASK-A" / "task.toml").unlink()
+        with self.assertRaisesRegex(ValidationError, "缺少 TaskGraph"):
+            reconcile_objective(self.config, "release")
+        self.assertEqual(get_objective_action(self.config, "release", second.action_id).status, ActionStatus.RESERVED)
+
+    def test_rejected_pause_does_not_cancel_reserved_action(self) -> None:
+        grant = acquire_objective_owner_lease(
+            self.config,
+            "release",
+            now=self.now,
+            ttl_seconds=30,
+            pid=123,
+            process_start="boot-1",
+            owner_token="1" * 64,
+        )
+        intent = self._intent(action_id="action-survive-pause", generation=grant.lease.generation)
+        reserve_objective_action(self.config, "release", intent=intent, grant=grant, now=self.now)
+        self.config.task_specs_dir.joinpath("TASK-A", "status").write_text("in_progress\n", encoding="utf-8")
+        with self.assertRaisesRegex(DyroError, "拒绝变更"):
+            pause_objective(self.config, "release")
+        self.assertEqual(get_objective_action(self.config, "release", intent.action_id).status, ActionStatus.RESERVED)
+
+    def test_lifecycle_cancellation_recovers_only_after_its_event_is_durable(self) -> None:
+        grant = acquire_objective_owner_lease(
+            self.config,
+            "release",
+            now=self.now,
+            ttl_seconds=30,
+            pid=123,
+            process_start="boot-1",
+            owner_token="1" * 64,
+        )
+        intent = self._intent(action_id="action-transactional-pause", generation=grant.lease.generation)
+        reserve_objective_action(self.config, "release", intent=intent, grant=grant, now=self.now)
+        with patch.object(storage_module, "_apply_pending_action_cancellation", side_effect=DyroError("simulated crash")):
+            with self.assertRaisesRegex(DyroError, "simulated crash"):
+                pause_objective(self.config, "release")
+        self.assertEqual(get_objective_action(self.config, "release", intent.action_id).status, ActionStatus.RESERVED)
+        self.assertEqual(get_objective(self.config, "release").operator_state, "paused")
+        self.assertEqual(get_objective_action(self.config, "release", intent.action_id).status, ActionStatus.CANCELLED)
+
+    def test_uncertain_action_retains_scope_and_blocks_reconcile(self) -> None:
+        grant = acquire_objective_owner_lease(
+            self.config,
+            "release",
+            now=self.now,
+            ttl_seconds=30,
+            pid=123,
+            process_start="boot-1",
+            owner_token="1" * 64,
+        )
+        intent = self._intent(action_id="action-uncertain", generation=grant.lease.generation)
+        reserve_objective_action(self.config, "release", intent=intent, grant=grant, now=self.now)
+        start_objective_action(
+            self.config,
+            "release",
+            action_id=intent.action_id,
+            grant=grant,
+            now=self.now + timedelta(seconds=1),
+        )
+        pause_objective(self.config, "release")
+        with self.assertRaisesRegex(DyroError, "uncertain"):
+            reconcile_objective(self.config, "release")
+        with self.assertRaisesRegex(DyroError, "mutation scope"):
+            create_objective(self.config, _contract("overlap", "TASK-A"))
+        record_objective_action_receipt(
+            self.config,
+            "release",
+            receipt=ActionReceipt(
+                action_id=intent.action_id,
+                idempotency_key=intent.idempotency_key,
+                owner_generation=grant.lease.generation,
+                status=ActionStatus.FAILED,
+                summary="runner-exited",
+                recorded_at=self.now + timedelta(seconds=2),
+            ),
+        )
+        self.assertEqual(create_objective(self.config, _contract("overlap", "TASK-A")).objective.id, "overlap")
+
+    def test_renew_release_and_unstarted_cancellation_are_bound_to_owner(self) -> None:
+        with open_objective_directory(self.config, "release") as directory:
+            grant = self._acquire(directory)
+            renewed = renew_owner_lease(directory, grant=grant, now=self.now + timedelta(seconds=1), ttl_seconds=30)
+            self.assertEqual(renewed.lease.generation, grant.lease.generation)
+
+            intent = self._intent(action_id="action-cancel", generation=renewed.lease.generation)
+            reserve_action(directory, intent)
+            cancelled = record_action_receipt(
+                directory,
+                ActionReceipt(
+                    action_id="action-cancel",
+                    idempotency_key=intent.idempotency_key,
+                    owner_generation=renewed.lease.generation,
+                    status=ActionStatus.CANCELLED,
+                    summary="paused-before-start",
+                    recorded_at=self.now + timedelta(seconds=2),
+                ),
+                grant=renewed,
+                now=self.now + timedelta(seconds=2),
+            )
+            self.assertEqual(cancelled.status, ActionStatus.CANCELLED)
+            released = release_owner_lease(directory, grant=renewed, now=self.now + timedelta(seconds=3))
+            self.assertFalse(released.active)
+            self.assertEqual(
+                record_action_receipt(
+                    directory,
+                    ActionReceipt(
+                        action_id="action-cancel",
+                        idempotency_key=intent.idempotency_key,
+                        owner_generation=renewed.lease.generation,
+                        status=ActionStatus.CANCELLED,
+                        summary="paused-before-start",
+                        recorded_at=self.now + timedelta(seconds=2),
+                    ),
+                ).receipt.status,
+                ActionStatus.CANCELLED,
+            )
+            next_grant = self._acquire(directory, now=self.now + timedelta(seconds=4), token="2" * 64)
+            self.assertEqual(next_grant.lease.generation, 2)
+
+    @unittest.skipUnless(hasattr(Path, "symlink_to"), "symlink support is required")
+    def test_symlinked_action_directory_and_bad_json_fail_closed(self) -> None:
+        with open_objective_directory(self.config, "release") as directory:
+            grant = self._acquire(directory)
+            intent = self._intent(action_id="action-safe", generation=grant.lease.generation)
+            reserve_action(directory, intent)
+
+        action_directory = self.config.objectives_dir / "release" / "actions"
+        outside = self.root / "outside-actions"
+        outside.mkdir()
+        shutil.rmtree(action_directory)
+        action_directory.symlink_to(outside, target_is_directory=True)
+        with open_objective_directory(self.config, "release") as directory:
+            with self.assertRaisesRegex(ValidationError, "目录"):
+                list_actions(directory)
+        self.assertFalse(any(outside.iterdir()))
+
+    def test_incompatible_or_unstarted_receipts_fail_closed(self) -> None:
+        with open_objective_directory(self.config, "release") as directory:
+            grant = self._acquire(directory)
+            intent = self._intent(action_id="action-open", generation=grant.lease.generation)
+            reserve_action(directory, intent)
+            with self.assertRaisesRegex(DyroError, "未 start"):
+                record_action_receipt(
+                    directory,
+                    ActionReceipt(
+                        action_id="action-open",
+                        idempotency_key=intent.idempotency_key,
+                        owner_generation=grant.lease.generation,
+                        status=ActionStatus.SUCCEEDED,
+                        summary="must-not-complete",
+                        recorded_at=self.now,
+                    ),
+                )
+            with self.assertRaisesRegex(DyroError, "owner grant"):
+                record_action_receipt(
+                    directory,
+                    ActionReceipt(
+                        action_id="action-open",
+                        idempotency_key=intent.idempotency_key,
+                        owner_generation=grant.lease.generation,
+                        status=ActionStatus.CANCELLED,
+                        summary="unauthorized-cancel",
+                        recorded_at=self.now,
+                    ),
+                )
+            with self.assertRaisesRegex(ValidationError, "idempotency_key"):
+                ActionIntent(
+                    **{
+                        **self._intent(action_id="action-bad", generation=grant.lease.generation).__dict__,
+                        "idempotency_key": "0" * 64,
+                    }
+                )
+            action_file = self.config.objectives_dir / "release" / "actions" / "action-open.json"
+            action_file.write_bytes((b"[" * 10_000) + (b"]" * 10_000))
+            with self.assertRaisesRegex(ValidationError, "JSON"):
+                read_action(directory, "action-open")
+
+    def test_orphan_start_or_receipt_fails_closed(self) -> None:
+        with open_objective_directory(self.config, "release") as directory:
+            grant = self._acquire(directory)
+            intent = self._intent(action_id="action-valid", generation=grant.lease.generation)
+            reserve_action(directory, intent)
+        orphan = self.config.objectives_dir / "release" / "action-starts"
+        orphan.mkdir()
+        orphan.joinpath("action-orphan.json").write_text("{}", encoding="utf-8")
+        with open_objective_directory(self.config, "release") as directory:
+            with self.assertRaisesRegex(ValidationError, "没有 intent"):
+                list_actions(directory)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 摘要
- 持久化 ActionIntent、start barrier、terminal receipt 与 idempotency binding
- 增加单调 fencing owner lease、接管恢复和未启动动作取消
- 将生命周期取消纳入 Objective pending transaction，未解决动作保留 mutation scope
- 拆分 immutable models、Journal 存储、owner lease 恢复与兼容 façade

## 验证
- `python -m unittest -q`
- `ruff check src tests`
- `python -m build`
- 在干净 venv 安装 wheel 后导入动作、Journal 与 lease 模块

## 安全边界
- 本 PR 只记录与验证 authority，不执行 task、review、merge、push 或外部 provider 调用。