### PR TITLE
feat(续航): 增加有界调度波次预览

### DIFF
--- a/docs/designs/native-continuation-engine.md
+++ b/docs/designs/native-continuation-engine.md
@@ -434,7 +434,7 @@ lease 接管使用独立 pending record 绑定新 lease 的完整内容；先持
 
 ### 7.3 并发资源
 
-Action 在启动前声明资源：`task:<id>`、`conflict:<group>`、`agent:<id>`、`line:<id>:merge`。Planner 先生成完整 ready set，再按资源和预算选择 wave；apply 阶段仍重新获取现有 task、dispatch 和 merge locks，防止计划与执行之间的竞态。
+Action 在启动前声明资源：`task:<id>`、`conflict:<group>`、`agent:<id>`、`line:<id>:merge`。Planner 先生成完整 ready set；`objective tick` 再从同一快照生成可复核、无写入的 wave 预览，按资源和当前并行容量选择候选。已 `in_progress` 的 scope Task 和有效外部 claim 会先占用该 Objective 的并行容量。延期投影只公开受限的 resource class（task、conflict、agent、line），绝不公开资源值。后续 apply 阶段必须重新校验授权、预算、资源与现有 task、dispatch、merge locks，防止计划与执行之间的竞态。预览的 `tick_sha256` 绑定 snapshot、plan、容量、wave 和延期原因，不能当作执行授权或绕过重新校验。
 
 一个 Task 可以被多个 observe-only Objective 引用，但同一时刻最多只有一个 active Objective
 取得其 targets 加依赖闭包的 mutation ownership。ownership 在 workspace Objective 锁下预留；

--- a/src/dyro/cli.py
+++ b/src/dyro/cli.py
@@ -22,6 +22,11 @@ from .blueprint import (
 )
 from .changesets import create_changeset, get_changeset, list_changesets, verify_changeset
 from .config import CONFIG_NAME, Config, load, validate_id
+from .continuation.engine import (
+    build_scheduler_tick,
+    render_scheduler_tick_json,
+    render_scheduler_tick_text,
+)
 from .continuation.models import Operation, RequestedMode
 from .continuation.planner import (
     build_continuation_plan,
@@ -1778,6 +1783,19 @@ def cmd_objective_graph(args: argparse.Namespace) -> None:
     print(render_projection_mermaid(projection))
 
 
+def cmd_objective_tick(args: argparse.Namespace) -> None:
+    """Preview the next bounded Objective mutation wave without applying it."""
+    config = _config(args)
+    record = get_objective(config, args.id, recover=False)
+    snapshot = build_scheduler_snapshot(config, objective=record)
+    plan = build_continuation_plan(snapshot)
+    tick = build_scheduler_tick(snapshot, plan, max_parallel=record.objective.budget.max_parallel)
+    if args.format == "json":
+        print(render_scheduler_tick_json(tick))
+        return
+    print(render_scheduler_tick_text(tick))
+
+
 def _trigger_cli_time(value: str | None, label: str) -> datetime | None:
     if value is None:
         return None
@@ -2344,6 +2362,12 @@ def build_parser() -> argparse.ArgumentParser:
     objective_graph.add_argument("id")
     objective_graph.add_argument("--format", choices=("mermaid", "json"), default="mermaid")
     objective_graph.set_defaults(func=cmd_objective_graph)
+    objective_tick = objective_sub.add_parser(
+        "tick", help="预览下一组有界 Objective Action；不创建 intent 或执行任务"
+    )
+    objective_tick.add_argument("id")
+    objective_tick.add_argument("--format", choices=("text", "json"), default="text")
+    objective_tick.set_defaults(func=cmd_objective_tick)
     for command, function, help_text in (
         ("pause", cmd_objective_pause, "暂停后续推进，不写完成状态"),
         ("resume", cmd_objective_resume, "恢复 paused Objective 的 ownership"),

--- a/src/dyro/continuation/__init__.py
+++ b/src/dyro/continuation/__init__.py
@@ -6,6 +6,7 @@ stages through explicit Core-owned modules.
 """
 
 from .contracts import canonical_contract, contract_sha256, parse_contract, validate_objective_scope
+from .engine import SchedulerTick, WaveDeferral, WaveDeferralReason, build_scheduler_tick, scheduler_tick_payload
 from .models import (
     ActionKind,
     AttentionItem,
@@ -44,10 +45,15 @@ __all__ = (
     "SchedulerEdge",
     "SchedulerNode",
     "SchedulerReadProjection",
+    "SchedulerTick",
     "TriggerObservation",
     "TriggerState",
+    "WaveDeferral",
+    "WaveDeferralReason",
+    "build_scheduler_tick",
     "canonical_contract",
     "contract_sha256",
     "parse_contract",
+    "scheduler_tick_payload",
     "validate_objective_scope",
 )

--- a/src/dyro/continuation/engine.py
+++ b/src/dyro/continuation/engine.py
@@ -1,0 +1,369 @@
+"""Pure, bounded scheduler ticks for supervised continuation.
+
+This module turns a complete deterministic plan into one *proposed* mutation
+wave.  It never reserves an ActionIntent, changes a Task, starts an Agent, or
+opens a workspace.  The later apply boundary must re-read authority, budget,
+locks, and the Action Journal before it may perform any of those operations.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+import hashlib
+import json
+from typing import Iterable
+
+from ..canonical import canonical_json_bytes
+from ..errors import ValidationError
+from .models import ActionKind, ContinuationPlan, PlannedAction
+from .snapshot import SchedulerSnapshot
+
+
+class WaveDeferralReason(str, Enum):
+    """Locale-free reasons why a planned mutation is not in this wave."""
+
+    RESOURCE_CONFLICT = "RESOURCE_CONFLICT"
+    PARALLEL_CAPACITY = "PARALLEL_CAPACITY"
+
+
+_MUTATING_ACTIONS = frozenset(
+    {ActionKind.EXECUTE_TASK, ActionKind.REVIEW_TASK, ActionKind.MERGE_TASK}
+)
+_RESOURCE_CLASSES = frozenset({"task", "conflict", "agent", "line"})
+
+
+def _facts(**values: object) -> tuple[tuple[str, str], ...]:
+    return tuple(
+        sorted((name, str(value)) for name, value in values.items() if value != "")
+    )
+
+
+def _action_payload(action: PlannedAction) -> dict[str, object]:
+    return {
+        "kind": action.kind.value,
+        "subject_id": action.subject_id,
+        "reason": action.reason.value,
+        "facts": dict(action.facts),
+    }
+
+
+@dataclass(frozen=True)
+class WaveDeferral:
+    """One planned mutation intentionally left for a later scheduler tick."""
+
+    action: PlannedAction
+    reason: WaveDeferralReason
+    facts: tuple[tuple[str, str], ...] = ()
+
+    def __post_init__(self) -> None:
+        if self.action.kind not in _MUTATING_ACTIONS:
+            raise TypeError("WaveDeferral.action 必须是可变更 Action")
+        if not isinstance(self.reason, WaveDeferralReason):
+            raise TypeError("WaveDeferral.reason 必须是 WaveDeferralReason")
+        facts = tuple(self.facts)
+        if not all(
+            isinstance(item, tuple)
+            and len(item) == 2
+            and all(isinstance(part, str) for part in item)
+            for item in facts
+        ):
+            raise TypeError("WaveDeferral.facts 必须只包含两个字符串组成的键值对")
+        object.__setattr__(self, "facts", tuple(sorted(facts)))
+
+
+@dataclass(frozen=True)
+class SchedulerTick:
+    """A deterministic, path-free preview of one bounded action wave."""
+
+    objective_id: str
+    snapshot_sha256: str
+    plan_sha256: str
+    max_parallel: int
+    active_parallel: int
+    available_parallel: int
+    wave: tuple[PlannedAction, ...] = ()
+    deferred: tuple[WaveDeferral, ...] = ()
+    non_mutating_actions: tuple[PlannedAction, ...] = ()
+    tick_sha256: str = ""
+
+    def __post_init__(self) -> None:
+        if not self.objective_id:
+            raise TypeError("SchedulerTick.objective_id 不能为空")
+        if type(self.max_parallel) is not int or self.max_parallel < 1:
+            raise TypeError("SchedulerTick.max_parallel 必须是正整数")
+        if type(self.active_parallel) is not int or self.active_parallel < 0:
+            raise TypeError("SchedulerTick.active_parallel 必须是非负整数")
+        if type(self.available_parallel) is not int or self.available_parallel < 0:
+            raise TypeError("SchedulerTick.available_parallel 必须是非负整数")
+        if self.available_parallel != max(0, self.max_parallel - self.active_parallel):
+            raise ValidationError("SchedulerTick.available_parallel 与并行容量不匹配")
+        for digest, label in (
+            (self.snapshot_sha256, "snapshot_sha256"),
+            (self.plan_sha256, "plan_sha256"),
+        ):
+            if (
+                not isinstance(digest, str)
+                or len(digest) != 64
+                or any(char not in "0123456789abcdef" for char in digest)
+            ):
+                raise TypeError(f"SchedulerTick.{label} 必须是 SHA-256 十六进制摘要")
+        wave = tuple(self.wave)
+        deferred = tuple(self.deferred)
+        passive = tuple(self.non_mutating_actions)
+        if not all(action.kind in _MUTATING_ACTIONS for action in wave):
+            raise TypeError("SchedulerTick.wave 必须只包含可变更 Action")
+        if not all(isinstance(item, WaveDeferral) for item in deferred):
+            raise TypeError("SchedulerTick.deferred 必须只包含 WaveDeferral")
+        if not all(action.kind not in _MUTATING_ACTIONS for action in passive):
+            raise TypeError("SchedulerTick.non_mutating_actions 不能包含可变更 Action")
+        action_keys = [
+            (action.kind.value, action.subject_id)
+            for action in (*wave, *(item.action for item in deferred))
+        ]
+        if len(set(action_keys)) != len(action_keys):
+            raise TypeError("SchedulerTick mutation Action 不能重复")
+        expected = _tick_sha256(
+            self.objective_id,
+            self.snapshot_sha256,
+            self.plan_sha256,
+            self.max_parallel,
+            self.active_parallel,
+            self.available_parallel,
+            wave,
+            deferred,
+            passive,
+        )
+        if self.tick_sha256 and self.tick_sha256 != expected:
+            raise ValidationError("SchedulerTick.tick_sha256 与内容不匹配")
+        object.__setattr__(self, "wave", wave)
+        object.__setattr__(self, "deferred", deferred)
+        object.__setattr__(self, "non_mutating_actions", passive)
+        object.__setattr__(self, "tick_sha256", expected)
+
+
+def _tick_sha256(
+    objective_id: str,
+    snapshot_sha256: str,
+    plan_sha256: str,
+    max_parallel: int,
+    active_parallel: int,
+    available_parallel: int,
+    wave: Iterable[PlannedAction],
+    deferred: Iterable[WaveDeferral],
+    passive: Iterable[PlannedAction],
+) -> str:
+    payload = {
+        "schema_version": 1,
+        "objective_id": objective_id,
+        "snapshot_sha256": snapshot_sha256,
+        "plan_sha256": plan_sha256,
+        "max_parallel": max_parallel,
+        "active_parallel": active_parallel,
+        "available_parallel": available_parallel,
+        "wave": [_action_payload(action) for action in wave],
+        "deferred": [
+            {
+                "action": _action_payload(item.action),
+                "reason": item.reason.value,
+                "facts": dict(item.facts),
+            }
+            for item in deferred
+        ],
+        "non_mutating_actions": [_action_payload(action) for action in passive],
+    }
+    return hashlib.sha256(canonical_json_bytes(payload)).hexdigest()
+
+
+def _action_resources(
+    snapshot: SchedulerSnapshot, action: PlannedAction
+) -> tuple[str, ...]:
+    """Return the resource declarations for one planned mutation.
+
+    The resource names remain internal to the selector.  Public projections
+    expose only a conflict's safe class and selected subject ID, not task
+    directories, argv, prompts, environment, or tool configuration.
+    """
+    task = snapshot.tasks_by_id.get(action.subject_id)
+    if task is None:
+        raise ValidationError(
+            f"计划 Action subject 不在调度快照中：{action.subject_id}"
+        )
+    if action.kind is ActionKind.EXECUTE_TASK:
+        resources = [f"task:{task.task.id}", f"agent:{task.task.executor}"]
+        if task.task.conflict_group:
+            resources.append(f"conflict:{task.task.conflict_group}")
+        return tuple(sorted(resources))
+    if action.kind is ActionKind.REVIEW_TASK:
+        return tuple(sorted((f"task:{task.task.id}", f"agent:{task.task.reviewer}")))
+    if action.kind is ActionKind.MERGE_TASK:
+        return tuple(sorted((f"task:{task.task.id}", f"line:{task.task.line}:merge")))
+    raise TypeError("只有可变更 Action 可以声明 scheduler resource")
+
+
+def _resource_class(resource: str) -> str:
+    """Map an internal resource name to its public, safe category only."""
+    resource_class, separator, _value = resource.partition(":")
+    if not separator or resource_class not in _RESOURCE_CLASSES:
+        raise ValidationError("SchedulerTick 内部 resource 类别无效")
+    return resource_class
+
+
+def _active_parallel(snapshot: SchedulerSnapshot) -> int:
+    """Count Objective work already occupying a bounded mutation slot.
+
+    An in-progress local Task and an active external claim both consume a
+    slot.  Only the accepted Objective scope is counted: unrelated workspace
+    work belongs to the later workspace-wide budget check, not this pure
+    Objective tick preview.
+    """
+    scope = set(snapshot.objective_scope)
+    return sum(
+        item.task.id in scope
+        and (
+            item.status == "in_progress"
+            or (item.status == "assigned" and item.external_claim_active)
+        )
+        for item in snapshot.tasks
+    )
+
+
+def build_scheduler_tick(
+    snapshot: SchedulerSnapshot,
+    plan: ContinuationPlan,
+    *,
+    max_parallel: int,
+) -> SchedulerTick:
+    """Select one deterministic mutation wave from a fixed plan and snapshot.
+
+    Selection is deliberately stricter than planning: every action first gets
+    a task, conflict-group or agent/line resource.  It then competes for the
+    Objective's bounded parallel capacity.  The output is still a preview;
+    using it never creates an ActionIntent or delivery side effect.
+    """
+    if plan.objective_id != snapshot.objective_id:
+        raise ValidationError("SchedulerTick 计划与快照 Objective 不匹配")
+    if plan.snapshot_sha256 != snapshot.snapshot_sha256:
+        raise ValidationError("SchedulerTick 计划与快照摘要不匹配")
+    if type(max_parallel) is not int or max_parallel < 1:
+        raise ValidationError("SchedulerTick max_parallel 必须是正整数")
+
+    active_parallel = _active_parallel(snapshot)
+    available_parallel = max(0, max_parallel - active_parallel)
+    selected = tuple(
+        sorted(
+            plan.selected_actions, key=lambda item: (item.kind.value, item.subject_id)
+        )
+    )
+    mutation_keys = [
+        (item.kind.value, item.subject_id)
+        for item in selected
+        if item.kind in _MUTATING_ACTIONS
+    ]
+    if len(set(mutation_keys)) != len(mutation_keys):
+        raise ValidationError("SchedulerTick 计划不能含重复 mutation Action")
+    resources: dict[str, str] = {}
+    wave: list[PlannedAction] = []
+    deferred: list[WaveDeferral] = []
+    passive: list[PlannedAction] = []
+    for action in selected:
+        if action.kind not in _MUTATING_ACTIONS:
+            passive.append(action)
+            continue
+        claims = _action_resources(snapshot, action)
+        collision = next((claim for claim in claims if claim in resources), "")
+        if collision:
+            deferred.append(
+                WaveDeferral(
+                    action,
+                    WaveDeferralReason.RESOURCE_CONFLICT,
+                    _facts(
+                        resource_class=_resource_class(collision),
+                        selected_subject_id=resources[collision],
+                    ),
+                )
+            )
+            continue
+        if len(wave) >= available_parallel:
+            deferred.append(
+                WaveDeferral(
+                    action,
+                    WaveDeferralReason.PARALLEL_CAPACITY,
+                    _facts(
+                        max_parallel=max_parallel,
+                        active_parallel=active_parallel,
+                        available_parallel=available_parallel,
+                    ),
+                )
+            )
+            continue
+        wave.append(action)
+        resources.update({claim: action.subject_id for claim in claims})
+    return SchedulerTick(
+        objective_id=plan.objective_id,
+        snapshot_sha256=plan.snapshot_sha256,
+        plan_sha256=plan.plan_sha256,
+        max_parallel=max_parallel,
+        active_parallel=active_parallel,
+        available_parallel=available_parallel,
+        wave=tuple(wave),
+        deferred=tuple(deferred),
+        non_mutating_actions=tuple(passive),
+    )
+
+
+def scheduler_tick_payload(tick: SchedulerTick) -> dict[str, object]:
+    """Return the safe JSON representation shared by CLI and future Console."""
+    return {
+        "schema_version": 1,
+        "objective_id": tick.objective_id,
+        "snapshot_sha256": tick.snapshot_sha256,
+        "plan_sha256": tick.plan_sha256,
+        "tick_sha256": tick.tick_sha256,
+        "max_parallel": tick.max_parallel,
+        "active_parallel": tick.active_parallel,
+        "available_parallel": tick.available_parallel,
+        "wave": [_action_payload(action) for action in tick.wave],
+        "deferred": [
+            {
+                "action": _action_payload(item.action),
+                "reason": item.reason.value,
+                "facts": dict(item.facts),
+            }
+            for item in tick.deferred
+        ],
+        "non_mutating_actions": [
+            _action_payload(action) for action in tick.non_mutating_actions
+        ],
+    }
+
+
+def render_scheduler_tick_text(tick: SchedulerTick) -> str:
+    """Render a concise human preview without implying execution occurred."""
+    lines = [
+        f"Objective: {tick.objective_id}",
+        f"Tick SHA-256: {tick.tick_sha256}",
+        (
+            f"Mutation wave: {len(tick.wave)}/{tick.available_parallel} "
+            f"（总容量 {tick.max_parallel}，已占用 {tick.active_parallel}；仅预览，未执行）"
+        ),
+    ]
+    for action in tick.wave:
+        lines.append(
+            f"Wave: {action.kind.value} {action.subject_id} ({action.reason.value})"
+        )
+    for item in tick.deferred:
+        lines.append(
+            f"Deferred: {item.action.kind.value} {item.action.subject_id} ({item.reason.value})"
+        )
+    for action in tick.non_mutating_actions:
+        lines.append(
+            f"Notice: {action.kind.value} {action.subject_id} ({action.reason.value})"
+        )
+    return "\n".join(lines)
+
+
+def render_scheduler_tick_json(tick: SchedulerTick) -> str:
+    return json.dumps(
+        scheduler_tick_payload(tick), ensure_ascii=False, sort_keys=True, indent=2
+    )

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -454,7 +454,7 @@ class ObjectiveCliTests(WorkspaceCase):
             main(["--root", root, "objective", "status", "release"])
         self.assertIn("Derived result: incomplete", output.getvalue())
 
-    def test_objective_read_only_plan_explain_and_graph_do_not_mutate_state(self) -> None:
+    def test_objective_read_only_plan_explain_graph_and_tick_do_not_mutate_state(self) -> None:
         root = str(self.root)
         main(
             [
@@ -487,6 +487,11 @@ class ObjectiveCliTests(WorkspaceCase):
         with redirect_stdout(graph_output):
             main(["--root", root, "objective", "graph", "release", "--format", "mermaid"])
         self.assertIn("flowchart LR", graph_output.getvalue())
+        tick_output = StringIO()
+        with redirect_stdout(tick_output):
+            main(["--root", root, "objective", "tick", "release", "--format", "json"])
+        self.assertIn('"tick_sha256"', tick_output.getvalue())
+        self.assertIn('"wave"', tick_output.getvalue())
         after = {path.relative_to(objective_dir): path.read_bytes() for path in objective_dir.rglob("*") if path.is_file()}
         self.assertEqual(before, after)
 

--- a/tests/test_continuation_engine.py
+++ b/tests/test_continuation_engine.py
@@ -1,0 +1,240 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+import tempfile
+import unittest
+from pathlib import Path
+
+from dyro.continuation.engine import (
+    WaveDeferralReason,
+    build_scheduler_tick,
+    scheduler_tick_payload,
+)
+from dyro.continuation.models import (
+    ActionKind,
+    AttentionItem,
+    AttentionKind,
+    ContinuationPlan,
+    PlanCompletion,
+    PlannedAction,
+    ReasonCode,
+)
+from dyro.continuation.snapshot import SchedulerSnapshot, SchedulerTaskSnapshot
+from dyro.tasks import Task
+
+
+class SchedulerTickTests(unittest.TestCase):
+    def test_tick_selects_one_deterministic_wave_and_defers_conflicts(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            sensitive_agent = "runner --token=do-not-disclose"
+            snapshot = self._snapshot(
+                Path(temporary),
+                (
+                    self._task(
+                        Path(temporary),
+                        "TASK-A",
+                        conflict_group="release",
+                        executor=sensitive_agent,
+                    ),
+                    self._task(
+                        Path(temporary),
+                        "TASK-B",
+                        conflict_group="release",
+                        executor="cursor",
+                    ),
+                    self._task(Path(temporary), "TASK-C", executor=sensitive_agent),
+                ),
+            )
+            plan = self._plan(
+                PlannedAction(ActionKind.EXECUTE_TASK, "TASK-A", ReasonCode.TASK_READY),
+                PlannedAction(ActionKind.EXECUTE_TASK, "TASK-B", ReasonCode.TASK_READY),
+                PlannedAction(ActionKind.EXECUTE_TASK, "TASK-C", ReasonCode.TASK_READY),
+            )
+
+            tick = build_scheduler_tick(snapshot, plan, max_parallel=3)
+
+            self.assertEqual([item.subject_id for item in tick.wave], ["TASK-A"])
+            self.assertEqual(
+                [item.action.subject_id for item in tick.deferred], ["TASK-B", "TASK-C"]
+            )
+            self.assertEqual(
+                tick.deferred[0].reason, WaveDeferralReason.RESOURCE_CONFLICT
+            )
+            self.assertEqual(
+                dict(tick.deferred[0].facts),
+                {
+                    "resource_class": "conflict",
+                    "selected_subject_id": "TASK-A",
+                },
+            )
+            self.assertEqual(
+                tick.deferred[1].reason, WaveDeferralReason.RESOURCE_CONFLICT
+            )
+            self.assertEqual(dict(tick.deferred[1].facts)["resource_class"], "agent")
+            self.assertNotIn(sensitive_agent, str(scheduler_tick_payload(tick)))
+
+    def test_capacity_is_enforced_after_resource_admission(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            snapshot = self._snapshot(
+                root,
+                (
+                    self._task(root, "TASK-A", executor="codex"),
+                    self._task(root, "TASK-B", executor="cursor"),
+                ),
+            )
+            plan = self._plan(
+                PlannedAction(ActionKind.EXECUTE_TASK, "TASK-A", ReasonCode.TASK_READY),
+                PlannedAction(ActionKind.EXECUTE_TASK, "TASK-B", ReasonCode.TASK_READY),
+            )
+
+            tick = build_scheduler_tick(snapshot, plan, max_parallel=1)
+
+            self.assertEqual([item.subject_id for item in tick.wave], ["TASK-A"])
+            self.assertEqual(
+                tick.deferred[0].reason, WaveDeferralReason.PARALLEL_CAPACITY
+            )
+            self.assertEqual(
+                dict(tick.deferred[0].facts),
+                {
+                    "active_parallel": "0",
+                    "available_parallel": "1",
+                    "max_parallel": "1",
+                },
+            )
+
+    def test_observed_running_task_exhausts_wave_capacity(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            running = self._task(root, "TASK-A", executor="codex")
+            ready = self._task(root, "TASK-B", executor="cursor")
+            snapshot = SchedulerSnapshot(
+                observed_at=datetime(2026, 8, 4, 8, 0, tzinfo=timezone.utc),
+                tasks=(
+                    SchedulerTaskSnapshot(
+                        running, "in_progress", False, "not_required"
+                    ),
+                    SchedulerTaskSnapshot(ready, "backlog", False, "not_required"),
+                ),
+                decisions=(),
+                execution_mode="local",
+                candidate_ids=("TASK-A", "TASK-B"),
+                snapshot_sha256="a" * 64,
+                objective_id="release",
+                objective_revision=1,
+                objective_state="active",
+                objective_scope=("TASK-A", "TASK-B"),
+                objective_targets=("TASK-B",),
+                objective_requested_mode="supervised",
+                objective_operations=("execute", "review"),
+            )
+            plan = self._plan(
+                PlannedAction(ActionKind.EXECUTE_TASK, "TASK-B", ReasonCode.TASK_READY)
+            )
+
+            tick = build_scheduler_tick(snapshot, plan, max_parallel=1)
+
+            self.assertEqual(tick.wave, ())
+            self.assertEqual(tick.active_parallel, 1)
+            self.assertEqual(tick.available_parallel, 0)
+            self.assertEqual(
+                tick.deferred[0].reason, WaveDeferralReason.PARALLEL_CAPACITY
+            )
+            self.assertEqual(
+                dict(tick.deferred[0].facts),
+                {
+                    "active_parallel": "1",
+                    "available_parallel": "0",
+                    "max_parallel": "1",
+                },
+            )
+
+    def test_non_mutating_actions_remain_visible_but_never_enter_mutation_wave(
+        self,
+    ) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            snapshot = self._snapshot(root, (self._task(root, "TASK-A"),))
+            ask = PlannedAction(
+                ActionKind.ASK_USER, "TASK-A", ReasonCode.ANSWER_REQUIRED
+            )
+            plan = self._plan(ask)
+
+            tick = build_scheduler_tick(snapshot, plan, max_parallel=1)
+
+            self.assertEqual(tick.wave, ())
+            self.assertEqual(tick.deferred, ())
+            self.assertEqual(tick.non_mutating_actions, (ask,))
+
+    def test_tick_payload_is_deterministic_and_path_free(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            snapshot = self._snapshot(root, (self._task(root, "TASK-A"),))
+            plan = self._plan(
+                PlannedAction(ActionKind.EXECUTE_TASK, "TASK-A", ReasonCode.TASK_READY)
+            )
+
+            first = build_scheduler_tick(snapshot, plan, max_parallel=1)
+            second = build_scheduler_tick(snapshot, plan, max_parallel=1)
+            payload = scheduler_tick_payload(first)
+
+            self.assertEqual(first, second)
+            self.assertEqual(first.tick_sha256, second.tick_sha256)
+            self.assertNotIn(str(root), str(payload))
+            self.assertEqual(payload["wave"][0]["subject_id"], "TASK-A")
+
+    @staticmethod
+    def _task(
+        root: Path, task_id: str, *, conflict_group: str = "", executor: str = "noop"
+    ) -> Task:
+        return Task(
+            id=task_id,
+            title=task_id,
+            line="alpha",
+            risk="write",
+            executor=executor,
+            reviewer="reviewer",
+            repositories=("api",),
+            conflict_group=conflict_group,
+            directory=root / task_id,
+        )
+
+    @staticmethod
+    def _snapshot(root: Path, tasks: tuple[Task, ...]) -> SchedulerSnapshot:
+        return SchedulerSnapshot(
+            observed_at=datetime(2026, 8, 4, 8, 0, tzinfo=timezone.utc),
+            tasks=tuple(
+                SchedulerTaskSnapshot(task, "backlog", False, "not_required")
+                for task in tasks
+            ),
+            decisions=(),
+            execution_mode="local",
+            candidate_ids=tuple(task.id for task in tasks),
+            snapshot_sha256="a" * 64,
+            objective_id="release",
+            objective_revision=1,
+            objective_state="active",
+            objective_scope=tuple(task.id for task in tasks),
+            objective_targets=(tasks[0].id,),
+            objective_requested_mode="supervised",
+            objective_operations=("execute", "review"),
+        )
+
+    @staticmethod
+    def _plan(*actions: PlannedAction) -> ContinuationPlan:
+        return ContinuationPlan(
+            objective_id="release",
+            snapshot_sha256="a" * 64,
+            plan_sha256="b" * 64,
+            completion=PlanCompletion.INCOMPLETE,
+            selected_actions=actions,
+            attention=(
+                AttentionItem(
+                    "ready:TASK-A", AttentionKind.READY, "TASK-A", ReasonCode.TASK_READY
+                ),
+            ),
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 概要

- 新增纯只读 `objective tick`，从固定 snapshot/plan 选择一个有界 Action wave。
- 资源仲裁覆盖 task、conflict、agent、line；已运行任务与有效外部 claim 先占用 Objective 并行容量。
- tick SHA 绑定 snapshot、plan、容量、wave 与延期原因；公开 JSON 只输出资源类别，不泄露资源值。
- 默认不执行、不创建 ActionIntent、不触发 Agent 或 Task mutation。

## 验证

- `uv run python -m unittest -q`
- `uv run ruff check src tests`
- `git diff --check`
- wheel/sdist 构建，并在 checkout 外的 Python 3.13 venv 安装验证导入与 CLI parser。

## 评审

- 独立安全复审发现并关闭两项 HIGH：已运行/外部 claim 容量计入，以及 deferred 投影资源值泄露。最终结论：APPROVE。