### PR TITLE
feat(续航): 增加受监督 Action 执行

### DIFF
--- a/docs/designs/native-continuation-engine.md
+++ b/docs/designs/native-continuation-engine.md
@@ -440,6 +440,14 @@ lease 接管使用独立 pending record 绑定新 lease 的完整内容；先持
 
 Action 在启动前声明资源：`task:<id>`、`conflict:<group>`、`agent:<id>`、`line:<id>:merge`。Planner 先生成完整 ready set；`objective tick` 再从同一快照生成可复核、无写入的 wave 预览，按资源和当前并行容量选择候选。已 `in_progress` 的 scope Task 和有效外部 claim 会先占用该 Objective 的并行容量。延期投影只公开受限的 resource class（task、conflict、agent、line），绝不公开资源值。后续 apply 阶段必须重新校验授权、预算、资源与现有 task、dispatch、merge locks，防止计划与执行之间的竞态。预览的 `tick_sha256` 绑定 snapshot、plan、容量、wave 和延期原因，不能当作执行授权或绕过重新校验。
 
+当前监督阶段由 `objective apply` 落地：它先显示精确 wave；交互式用户逐项确认，非交互调用必须显式给出
+`--yes --confirm-sha`。确认摘要排除单次采样时钟，但绑定 Objective revision/event/scope、任务状态与合约、
+决策、容量和精确 Action；因此可跨命令复制，任一语义变化都会拒绝。每个 Action 在真正调用既有 `task run` 或 `task review` 前都会重新规划、重新读取
+Task contract、在 workspace Objective 锁内重验预算并写入 create-only `ActionIntent`，随后才跨越
+`action-start`。执行期间仍由既有 Task/dispatch/review 锁校验状态、依赖和冲突组。Task API 抛错或返回
+非受限结果时写入 `uncertain`，绝不重放；未跨越 `action-start` 的失败才可取消。该阶段只串行调用
+`execute_task` 与 `review_task`；即使 Objective 配置了更高并行上限，也不会隐式启动并发、merge 或 push。
+
 一个 Task 可以被多个 observe-only Objective 引用，但同一时刻最多只有一个 active Objective
 取得其 targets 加依赖闭包的 mutation ownership。ownership 在 workspace Objective 锁下预留；
 重叠 Objective 只能观察并显示 `OBJECTIVE_SCOPE_CONFLICT`。执行 Task API 时不持有 Objective

--- a/src/dyro/cli.py
+++ b/src/dyro/cli.py
@@ -55,6 +55,14 @@ from .continuation.store import (
     resume_objective,
     stop_objective,
 )
+from .continuation.supervision import (
+    apply_supervised_wave,
+    build_supervised_wave,
+    render_supervised_outcomes,
+    render_supervised_wave_text,
+    supervised_outcomes_payload,
+    supervised_wave_payload,
+)
 from .continuation.triggers import TriggerConfig, TriggerKind, TriggerProbeInput, probe_builtin
 from .evidence import build_execution_bundle, unpack_execution_bundle
 from .errors import DyroError, ValidationError
@@ -1820,6 +1828,40 @@ def cmd_objective_attention(args: argparse.Namespace) -> None:
     print(render_attention_text(projection))
 
 
+def cmd_objective_apply(args: argparse.Namespace) -> None:
+    """Display an exact supervised wave, then apply it only after confirmation."""
+    config = _config(args)
+    wave = build_supervised_wave(config, args.id)
+    if args.format == "text":
+        print(render_supervised_wave_text(wave))
+    if args.dry_run:
+        if args.format == "json":
+            print(json.dumps({"wave": supervised_wave_payload(wave), "dry_run": True}, ensure_ascii=False, sort_keys=True, indent=2))
+        else:
+            print("DRY RUN: 未创建 owner lease、Action intent、Action-start 或 Task 执行。")
+        return
+    if args.yes and args.confirm_sha != wave.confirmation_sha256:
+        raise DyroError("--yes 必须同时提供当前 Confirmation SHA-256；请先运行 objective apply --dry-run 后复制摘要")
+    if not args.yes:
+        if not (sys.stdin.isatty() and sys.stdout.isatty()):
+            raise DyroError("非交互执行必须提供 --yes 与 --confirm-sha；先使用 --dry-run 查看精确 wave")
+        if not _ask_yes_no("确认按上述顺序执行该受监督 Action wave", default=False):
+            print("已取消；未写入 Objective 或 Task 状态。")
+            return
+    outcomes = apply_supervised_wave(config, wave)
+    if args.format == "json":
+        print(
+            json.dumps(
+                {"wave": supervised_wave_payload(wave), "dry_run": False, "outcomes": supervised_outcomes_payload(outcomes)},
+                ensure_ascii=False,
+                sort_keys=True,
+                indent=2,
+            )
+        )
+    elif outcomes:
+        print(render_supervised_outcomes(outcomes))
+
+
 def _trigger_cli_time(value: str | None, label: str) -> datetime | None:
     if value is None:
         return None
@@ -2398,6 +2440,15 @@ def build_parser() -> argparse.ArgumentParser:
     objective_attention.add_argument("id")
     objective_attention.add_argument("--format", choices=("text", "json"), default="text")
     objective_attention.set_defaults(func=cmd_objective_attention)
+    objective_apply = objective_sub.add_parser(
+        "apply",
+        help="显示精确 Action wave；确认后仅受监督地执行 execute/review，不 merge 或 push",
+    )
+    objective_apply.add_argument("id")
+    objective_apply.add_argument("--confirm-sha", help="非交互 --yes 必填；必须等于当前 Confirmation SHA-256")
+    objective_apply.add_argument("--yes", action="store_true", help="确认当前显示的精确 wave 后执行")
+    objective_apply.add_argument("--format", choices=("text", "json"), default="text")
+    objective_apply.set_defaults(func=cmd_objective_apply)
     for command, function, help_text in (
         ("pause", cmd_objective_pause, "暂停后续推进，不写完成状态"),
         ("resume", cmd_objective_resume, "恢复 paused Objective 的 ownership"),

--- a/src/dyro/continuation/budgets.py
+++ b/src/dyro/continuation/budgets.py
@@ -181,7 +181,11 @@ class BudgetRequest:
             raise TypeError("BudgetRequest.task_id 不能为空")
         for field in ("actions", "attempts", "failures", "parallel", "provider_usage"):
             value = _non_negative(getattr(self, field), f"BudgetRequest.{field}")
-            if field in {"actions", "attempts", "parallel"} and value < 1:
+            # A review consumes an Action and a scheduler slot but is not a
+            # new execution attempt.  Keep that distinction expressible at
+            # the budget boundary instead of charging reviews against the
+            # per-task execution-attempt ceiling.
+            if field in {"actions", "parallel"} and value < 1:
                 raise TypeError(f"BudgetRequest.{field} 必须是正整数")
         if type(self.provider_usage_trusted) is not bool:
             raise TypeError("BudgetRequest.provider_usage_trusted 必须是 bool")

--- a/src/dyro/continuation/store.py
+++ b/src/dyro/continuation/store.py
@@ -43,6 +43,7 @@ from .actions import (
     verify_owner_lease as _verify_owner_lease,
 )
 from .contracts import canonical_contract, contract_sha256, parse_contract, validate_objective_scope
+from .budgets import BudgetCaps, BudgetDecision, BudgetDecisionInput, BudgetRequest, BudgetReservation, BudgetUsage, decide_budget
 from .models import ActionKind, Objective, Operation, RequestedMode
 from .objective_storage import (
     OBJECTIVE_STORE_SCHEMA_VERSION,
@@ -565,6 +566,129 @@ def reserve_objective_action(
             if intent.owner_generation != lease.generation:
                 raise DyroError("Action intent owner_generation 与当前 Scheduler lease 不匹配")
             return _reserve_action(directory, intent)
+
+
+def _budget_usage(records: Iterable[ActionRecord], *, objective_id: str | None) -> BudgetUsage:
+    """Derive conservative committed usage from durable Action records only.
+
+    A start has crossed the durable side-effect barrier, so it is charged even
+    when its terminal receipt is still missing.  Only not-started intents are
+    treated as reservations by the caller.  ``uncertain`` deliberately counts
+    as a failure: it may have produced a side effect and must never make the
+    next Action look safer than it is.
+    """
+    selected = tuple(
+        record for record in records
+        if objective_id is None or record.intent.objective_id == objective_id
+    )
+    started = tuple(record for record in selected if record.start is not None)
+    attempts: dict[str, int] = {}
+    for record in started:
+        reservation = record.intent.budget_reservation
+        attempts[reservation.task_id] = attempts.get(reservation.task_id, 0) + reservation.attempts
+    terminal = tuple(
+        sorted(
+            (record for record in started if record.receipt is not None),
+            key=lambda record: (record.receipt.recorded_at, record.intent.action_id),  # type: ignore[union-attr]
+        )
+    )
+    failures = sum(
+        record.intent.budget_reservation.failures
+        for record in terminal
+        if record.receipt is not None and record.receipt.status in {ActionStatus.FAILED, ActionStatus.UNCERTAIN}
+    )
+    consecutive = 0
+    for record in terminal:
+        if record.receipt is not None and record.receipt.status in {ActionStatus.FAILED, ActionStatus.UNCERTAIN}:
+            consecutive += record.intent.budget_reservation.failures
+        else:
+            consecutive = 0
+    return BudgetUsage(
+        actions=sum(record.intent.budget_reservation.actions for record in started),
+        failures=failures,
+        consecutive_failures=consecutive,
+        active_parallel=sum(
+            record.intent.budget_reservation.parallel
+            for record in started
+            if record.receipt is None
+        ),
+        attempts_by_task=tuple(sorted(attempts.items())),
+    )
+
+
+def _reserved_budgets(records: Iterable[ActionRecord]) -> tuple[BudgetReservation, ...]:
+    """Return only intents that have not crossed the Action-start barrier."""
+    return tuple(
+        record.intent.budget_reservation
+        for record in records
+        if record.start is None and record.receipt is None
+    )
+
+
+def _all_action_records_unlocked(config: Config) -> tuple[ActionRecord, ...]:
+    """Read every durable Action Journal while the workspace Objective lock is held."""
+    actions: list[ActionRecord] = []
+    for stored in _list_objectives_unlocked(config, recover=False):
+        with open_objective_directory(config, stored.objective.id) as directory:
+            actions.extend(_list_actions(directory))
+    return tuple(actions)
+
+
+def _budget_request(intent: ActionIntent) -> BudgetRequest:
+    """Fix the conservative charge for each supported supervised operation."""
+    if intent.operation is ActionKind.EXECUTE_TASK:
+        return BudgetRequest(intent.subject_id, actions=1, attempts=1, failures=1, parallel=1)
+    if intent.operation is ActionKind.REVIEW_TASK:
+        return BudgetRequest(intent.subject_id, actions=1, attempts=0, failures=1, parallel=1)
+    raise DyroError("受监督执行当前只支持 execute_task 与 review_task")
+
+
+def reserve_supervised_objective_action(
+    config: Config,
+    objective_id: str,
+    *,
+    intent: ActionIntent,
+    grant: OwnerLeaseGrant,
+    now: datetime,
+) -> tuple[ActionRecord, BudgetDecision]:
+    """Atomically recheck durable budgets and reserve one supervised Action.
+
+    This is intentionally separate from the low-level Action-Journal façade:
+    external callers cannot smuggle a smaller reservation between a preview and
+    the create-only intent write.  Workspace-wide accounting runs under the
+    same Objective lock as intent publication, closing the concurrent planner
+    race without holding any Task, dispatch, merge, or Agent lock.
+    """
+    with _objective_lock(config):
+        all_records = _all_action_records_unlocked(config)
+        with open_objective_directory(config, objective_id) as directory:
+            record = _require_actionable_objective(config, objective_id, directory)
+            _assert_action_is_authorized(record, intent)
+            _assert_no_unresolved_actions(directory, operation="创建下一 Action")
+            lease = _verify_owner_lease(directory, grant=grant, now=now)
+            if intent.owner_generation != lease.generation:
+                raise DyroError("Action intent owner_generation 与当前 Scheduler lease 不匹配")
+            request = _budget_request(intent)
+            decision = decide_budget(
+                BudgetDecisionInput(
+                    objective_id=objective_id,
+                    requested=record.objective.budget,
+                    workspace=BudgetCaps(),
+                    activation=None,
+                    usage=_budget_usage(all_records, objective_id=objective_id),
+                    workspace_usage=_budget_usage(all_records, objective_id=None),
+                    reservations=_reserved_budgets(all_records),
+                    now=now,
+                    request=request,
+                    automatic=False,
+                )
+            )
+            if intent.budget_reservation != decision.reservation:
+                raise DyroError("Action intent budget_reservation 未使用受监督操作的固定保守预算")
+            if not decision.allowed:
+                reasons = ", ".join(reason.value for reason in decision.reasons)
+                raise DyroError(f"Objective 预算拒绝此 Action：{reasons}")
+            return _reserve_action(directory, intent), decision
 
 
 def start_objective_action(

--- a/src/dyro/continuation/supervision.py
+++ b/src/dyro/continuation/supervision.py
@@ -1,0 +1,531 @@
+"""The explicit-confirmation apply boundary for supervised Objectives.
+
+Planning remains pure.  This module is the narrow bridge from a user-confirmed
+wave to the existing Task APIs: it re-plans every action, writes a fenced
+ActionIntent, crosses the durable Action-start barrier, and only then invokes
+the Task operation.  It never calls merge or push, and any failure after the
+start barrier is recorded as ``uncertain`` rather than replayed.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timezone
+import hashlib
+import json
+import os
+import secrets
+from typing import Callable
+
+from ..canonical import canonical_json_bytes
+from ..config import Config
+from ..errors import DyroError, ValidationError
+from ..tasks import Task, review_task, run_task
+from .action_models import ActionIntent, ActionReceipt, ActionStatus
+from .budgets import BudgetReservation
+from .engine import SchedulerTick, build_scheduler_tick
+from .models import ActionKind, PlannedAction, RequestedMode
+from .planner import build_continuation_plan
+from .snapshot import SchedulerSnapshot, build_scheduler_snapshot
+from .store import (
+    acquire_objective_owner_lease,
+    get_objective,
+    get_objective_action,
+    list_objective_actions,
+    record_objective_action_receipt,
+    release_objective_owner_lease,
+    reserve_supervised_objective_action,
+    start_objective_action,
+)
+
+
+SUPERVISION_LEASE_SECONDS = 3_600
+_SUPPORTED_ACTIONS = frozenset({ActionKind.EXECUTE_TASK, ActionKind.REVIEW_TASK})
+
+
+def _utc(value: datetime) -> datetime:
+    if not isinstance(value, datetime) or value.tzinfo is None:
+        raise TypeError("监督执行时钟必须带时区")
+    return value.astimezone(timezone.utc)
+
+
+def _action_payload(action: PlannedAction) -> dict[str, object]:
+    return {
+        "kind": action.kind.value,
+        "subject_id": action.subject_id,
+        "reason": action.reason.value,
+        "facts": dict(action.facts),
+    }
+
+
+@dataclass(frozen=True)
+class SupervisedWave:
+    """A user-visible, immutable proposal; building it has zero side effects."""
+
+    objective_id: str
+    snapshot_sha256: str
+    plan_sha256: str
+    tick_sha256: str
+    confirmation_sha256: str
+    actions: tuple[PlannedAction, ...]
+
+    def __post_init__(self) -> None:
+        if not self.objective_id:
+            raise TypeError("SupervisedWave.objective_id 不能为空")
+        for value, label in (
+            (self.snapshot_sha256, "snapshot_sha256"),
+            (self.plan_sha256, "plan_sha256"),
+            (self.tick_sha256, "tick_sha256"),
+            (self.confirmation_sha256, "confirmation_sha256"),
+        ):
+            if not isinstance(value, str) or len(value) != 64 or any(char not in "0123456789abcdef" for char in value):
+                raise TypeError(f"SupervisedWave.{label} 必须是 SHA-256 十六进制摘要")
+        actions = tuple(self.actions)
+        if not actions or not all(action.kind in _SUPPORTED_ACTIONS for action in actions):
+            raise TypeError("SupervisedWave.actions 必须包含 execute_task 或 review_task")
+        if len({(action.kind, action.subject_id) for action in actions}) != len(actions):
+            raise ValidationError("SupervisedWave.actions 不能重复")
+        object.__setattr__(self, "actions", actions)
+
+
+@dataclass(frozen=True)
+class SupervisedOutcome:
+    """A path-free Action result safe for CLI and future Console projections."""
+
+    action_id: str
+    operation: ActionKind
+    subject_id: str
+    status: ActionStatus
+    result: str
+
+    def __post_init__(self) -> None:
+        if not self.action_id or self.operation not in _SUPPORTED_ACTIONS or not self.subject_id:
+            raise TypeError("SupervisedOutcome 字段无效")
+        if self.status not in {ActionStatus.SUCCEEDED, ActionStatus.FAILED, ActionStatus.UNCERTAIN}:
+            raise TypeError("SupervisedOutcome.status 必须是已执行终态")
+        if not self.result or len(self.result) > 64:
+            raise TypeError("SupervisedOutcome.result 无效")
+
+
+def _confirmation_sha256(
+    *,
+    objective: object,
+    snapshot: SchedulerSnapshot,
+    tick: SchedulerTick,
+    actions: tuple[PlannedAction, ...],
+) -> str:
+    """Hash the confirmed semantics while deliberately excluding sample time.
+
+    ``snapshot_sha256`` and ``tick_sha256`` correctly include ``observed_at``
+    for audit binding, but therefore cannot be copied from a preview into a
+    later command.  This digest captures every safety-relevant fact used for a
+    supervised wave without that wall-clock sample, so a user can confirm the
+    displayed proposal across processes and any semantic drift is rejected.
+    """
+    payload = {
+        "schema_version": 1,
+        "objective": {
+            "id": objective.objective.id,
+            "revision": objective.revision,
+            "event_seq": objective.event_seq,
+            "event_sha256": objective.event_sha256,
+            "scope_sha256": objective.scope_sha256,
+        },
+        "snapshot": {
+            "execution_mode": snapshot.execution_mode,
+            "candidate_ids": list(snapshot.candidate_ids),
+            "tasks": [
+                {
+                    "id": item.task.id,
+                    "line": item.task.line,
+                    "status": item.status,
+                    "depends_on": list(item.task.depends_on),
+                    "blocked_on": list(item.task.blocked_on),
+                    "conflict_group": item.task.conflict_group,
+                    "external_claim_active": item.external_claim_active,
+                    "integration_state": item.integration_state,
+                    "contract_sha256": item.contract_sha256,
+                }
+                for item in snapshot.tasks
+            ],
+            "decisions": [list(item) for item in snapshot.decisions],
+            "objective_state": snapshot.objective_state,
+            "objective_scope": list(snapshot.objective_scope),
+            "objective_targets": list(snapshot.objective_targets),
+            "objective_requested_mode": snapshot.objective_requested_mode,
+            "objective_operations": list(snapshot.objective_operations),
+            "objective_drifted": snapshot.objective_drifted,
+        },
+        "wave": {
+            "max_parallel": tick.max_parallel,
+            "active_parallel": tick.active_parallel,
+            "available_parallel": tick.available_parallel,
+            "actions": [_action_payload(action) for action in actions],
+        },
+    }
+    return hashlib.sha256(canonical_json_bytes(payload)).hexdigest()
+
+
+def build_supervised_wave(
+    config: Config,
+    objective_id: str,
+    *,
+    clock: Callable[[], datetime] = lambda: datetime.now(timezone.utc),
+) -> SupervisedWave:
+    """Create one exact, read-only confirmation proposal from current state."""
+    record = get_objective(config, objective_id, recover=False)
+    if record.objective.requested_mode is not RequestedMode.SUPERVISED:
+        raise DyroError("当前 Objective 不是 supervised 模式；拒绝使用受监督 apply")
+    snapshot = build_scheduler_snapshot(config, objective=record, clock=clock)
+    plan = build_continuation_plan(snapshot)
+    tick = build_scheduler_tick(snapshot, plan, max_parallel=record.objective.budget.max_parallel)
+    actions = tuple(action for action in tick.wave if action.kind in _SUPPORTED_ACTIONS)
+    if len(actions) != len(tick.wave):
+        raise DyroError("当前 wave 含尚未获受监督执行支持的 Action；拒绝部分执行")
+    if not actions:
+        raise DyroError("当前没有可由受监督阶段执行的 Action；请运行 objective attention 或 tick 查看原因")
+    return SupervisedWave(
+        objective_id=record.objective.id,
+        snapshot_sha256=snapshot.snapshot_sha256,
+        plan_sha256=plan.plan_sha256,
+        tick_sha256=tick.tick_sha256,
+        confirmation_sha256=_confirmation_sha256(
+            objective=record,
+            snapshot=snapshot,
+            tick=tick,
+            actions=actions,
+        ),
+        actions=actions,
+    )
+
+
+def supervised_wave_payload(wave: SupervisedWave) -> dict[str, object]:
+    return {
+        "schema_version": 1,
+        "objective_id": wave.objective_id,
+        "snapshot_sha256": wave.snapshot_sha256,
+        "plan_sha256": wave.plan_sha256,
+        "tick_sha256": wave.tick_sha256,
+        "confirmation_sha256": wave.confirmation_sha256,
+        "actions": [_action_payload(action) for action in wave.actions],
+        "execution": "serial_supervised",
+        "merge": "not_supported",
+        "push": "not_supported",
+    }
+
+
+def render_supervised_wave_text(wave: SupervisedWave) -> str:
+    lines = [
+        f"Objective: {wave.objective_id}",
+        f"Tick SHA-256: {wave.tick_sha256}",
+        f"Confirmation SHA-256: {wave.confirmation_sha256}",
+        f"Supervised Action wave: {len(wave.actions)}（按顺序执行；每项均在 durable Action-start 后才调用 Task API）",
+    ]
+    lines.extend(
+        f"Action: {action.kind.value} {action.subject_id} ({action.reason.value})"
+        for action in wave.actions
+    )
+    lines.append("不会自动 merge 或 push；非交互执行必须显式确认该 Confirmation SHA-256。")
+    return "\n".join(lines)
+
+
+def render_supervised_wave_json(wave: SupervisedWave) -> str:
+    return json.dumps(supervised_wave_payload(wave), ensure_ascii=False, sort_keys=True, indent=2)
+
+
+def _current_action(
+    config: Config,
+    objective_id: str,
+    expected: PlannedAction,
+    *,
+    clock: Callable[[], datetime],
+) -> tuple[object, SchedulerSnapshot, SchedulerTick, PlannedAction, Task]:
+    """Re-plan before each mutation and retain only the confirmed exact Action."""
+    record = get_objective(config, objective_id, recover=False)
+    if record.objective.requested_mode is not RequestedMode.SUPERVISED:
+        raise DyroError("Objective 模式已变化；拒绝执行已确认 Action")
+    snapshot = build_scheduler_snapshot(config, objective=record, clock=clock)
+    plan = build_continuation_plan(snapshot)
+    tick = build_scheduler_tick(snapshot, plan, max_parallel=record.objective.budget.max_parallel)
+    actual = next((action for action in tick.wave if action == expected), None)
+    if actual is None:
+        raise DyroError("确认后的 Action 已不再位于当前安全 wave；请重新运行 objective apply")
+    task_snapshot = snapshot.tasks_by_id.get(actual.subject_id)
+    if task_snapshot is None or not task_snapshot.contract_sha256:
+        raise DyroError("当前 Action 缺少已固定的 Task contract 摘要；拒绝执行")
+    return record, snapshot, tick, actual, task_snapshot.task
+
+
+def _operation_generation(config: Config, objective_id: str, action: PlannedAction) -> int:
+    return sum(
+        record.start is not None
+        and record.intent.operation is action.kind
+        and record.intent.subject_id == action.subject_id
+        for record in list_objective_actions(config, objective_id)
+    )
+
+
+def _reservation(objective_id: str, action: PlannedAction) -> BudgetReservation:
+    if action.kind is ActionKind.EXECUTE_TASK:
+        return BudgetReservation(objective_id, action.subject_id, actions=1, attempts=1, failures=1, parallel=1)
+    if action.kind is ActionKind.REVIEW_TASK:
+        return BudgetReservation(objective_id, action.subject_id, actions=1, attempts=0, failures=1, parallel=1)
+    raise DyroError("受监督执行只支持 execute_task 与 review_task")
+
+
+def _authority_sha256(
+    *,
+    objective: object,
+    snapshot: SchedulerSnapshot,
+    tick: SchedulerTick,
+    action: PlannedAction,
+    operation_generation: int,
+) -> str:
+    # StoredObjective is intentionally duck-typed here so this module never
+    # exposes storage implementation details through its public API.
+    payload = {
+        "schema_version": 1,
+        "mode": RequestedMode.SUPERVISED.value,
+        "objective_id": objective.objective.id,
+        "objective_revision": objective.revision,
+        "objective_event_seq": objective.event_seq,
+        "objective_event_sha256": objective.event_sha256,
+        "scope_sha256": objective.scope_sha256,
+        "snapshot_sha256": snapshot.snapshot_sha256,
+        "tick_sha256": tick.tick_sha256,
+        "operation_generation": operation_generation,
+        "action": _action_payload(action),
+    }
+    return hashlib.sha256(canonical_json_bytes(payload)).hexdigest()
+
+
+def _intent(
+    *,
+    objective: object,
+    snapshot: SchedulerSnapshot,
+    plan_sha256: str,
+    tick: SchedulerTick,
+    action: PlannedAction,
+    generation: int,
+    operation_generation: int,
+    now: datetime,
+) -> ActionIntent:
+    authority_sha256 = _authority_sha256(
+        objective=objective,
+        snapshot=snapshot,
+        tick=tick,
+        action=action,
+        operation_generation=operation_generation,
+    )
+    return ActionIntent(
+        action_id=f"action-{authority_sha256[:40]}",
+        objective_id=objective.objective.id,
+        objective_revision=objective.revision,
+        objective_event_seq=objective.event_seq,
+        objective_event_sha256=objective.event_sha256,
+        scope_sha256=objective.scope_sha256,
+        snapshot_sha256=snapshot.snapshot_sha256,
+        plan_sha256=plan_sha256,
+        operation=action.kind,
+        subject_id=action.subject_id,
+        owner_generation=generation,
+        expected_operation_generation=operation_generation,
+        authority_sha256=authority_sha256,
+        budget_reservation=_reservation(objective.objective.id, action),
+        created_at=now,
+    )
+
+
+def _task_result_status(action: PlannedAction, result: object) -> tuple[ActionStatus, str]:
+    if not isinstance(result, str):
+        return ActionStatus.UNCERTAIN, "unrecognized_task_result"
+    expected_success = {
+        ActionKind.EXECUTE_TASK: frozenset({"review", "waiting_answer"}),
+        ActionKind.REVIEW_TASK: frozenset({"done", "review_pending_signoff"}),
+    }
+    expected_failure = {
+        ActionKind.EXECUTE_TASK: frozenset({"failed"}),
+        ActionKind.REVIEW_TASK: frozenset({"review", "failed"}),
+    }
+    if result in expected_success[action.kind]:
+        return ActionStatus.SUCCEEDED, result
+    if result in expected_failure[action.kind]:
+        return ActionStatus.FAILED, result
+    return ActionStatus.UNCERTAIN, "unrecognized_task_result"
+
+
+def _dispatch(config: Config, action: PlannedAction, task: Task, *, expected_contract_sha256: str) -> object:
+    if action.kind is ActionKind.EXECUTE_TASK:
+        return run_task(config, task, expected_contract_sha256=expected_contract_sha256)
+    if action.kind is ActionKind.REVIEW_TASK:
+        return review_task(config, task, expected_contract_sha256=expected_contract_sha256)
+    raise DyroError("受监督执行只支持 execute_task 与 review_task")
+
+
+def apply_supervised_wave(
+    config: Config,
+    wave: SupervisedWave,
+    *,
+    clock: Callable[[], datetime] = lambda: datetime.now(timezone.utc),
+) -> tuple[SupervisedOutcome, ...]:
+    """Apply a user-confirmed wave serially through the durable Action Journal.
+
+    A serial launcher is deliberate in the initial supervised stage: it keeps
+    Task API compatibility while still enforcing the planner's resource and
+    parallel bounds.  Future automatic execution needs a separate process
+    barrier and must not change this explicit-confirmation path.
+    """
+    # Rebuild the whole semantic wave before writing an owner lease.  This
+    # closes both the preview-to-apply race and a direct API caller trying to
+    # provide only a safe-looking subset of actions.  The separate per-action
+    # replan below still protects longer serial waves as preceding actions
+    # change Task state.
+    current = build_supervised_wave(config, wave.objective_id, clock=clock)
+    if (
+        current.confirmation_sha256 != wave.confirmation_sha256
+        or current.actions != wave.actions
+    ):
+        raise DyroError("确认后的 wave 已发生语义变化；请重新运行 objective apply --dry-run")
+
+    acquired_at = _utc(clock())
+    grant = acquire_objective_owner_lease(
+        config,
+        wave.objective_id,
+        now=acquired_at,
+        ttl_seconds=SUPERVISION_LEASE_SECONDS,
+        pid=os.getpid(),
+        process_start=f"supervised-{os.getpid()}-{secrets.token_hex(8)}",
+    )
+    outcomes: list[SupervisedOutcome] = []
+    primary_error: BaseException | None = None
+    try:
+        for expected in wave.actions:
+            record, snapshot, tick, action, task = _current_action(
+                config, wave.objective_id, expected, clock=clock
+            )
+            now = _utc(clock())
+            operation_generation = _operation_generation(config, wave.objective_id, action)
+            intent = _intent(
+                objective=record,
+                snapshot=snapshot,
+                plan_sha256=tick.plan_sha256,
+                tick=tick,
+                action=action,
+                generation=grant.lease.generation,
+                operation_generation=operation_generation,
+                now=now,
+            )
+            reserved = reserve_supervised_objective_action(
+                config,
+                wave.objective_id,
+                intent=intent,
+                grant=grant,
+                now=now,
+            )
+            if reserved[0].receipt is not None:
+                raise DyroError("Action idempotency key 已有终态 receipt；请重新规划")
+            try:
+                start_objective_action(
+                    config,
+                    wave.objective_id,
+                    action_id=intent.action_id,
+                    grant=grant,
+                    now=_utc(clock()),
+                )
+            except BaseException as exc:
+                # The normal failure path has not invoked a Task API or child
+                # process.  Still inspect durable state first: an I/O failure
+                # after a create-only start write is uncertain, never
+                # cancellable.
+                started = get_objective_action(config, wave.objective_id, intent.action_id).start is not None
+                try:
+                    record_objective_action_receipt(
+                        config,
+                        wave.objective_id,
+                        receipt=ActionReceipt(
+                            intent.action_id,
+                            intent.idempotency_key,
+                            intent.owner_generation,
+                            ActionStatus.UNCERTAIN if started else ActionStatus.CANCELLED,
+                            "action_start_write_uncertain" if started else "action_start_rejected_before_task_invocation",
+                            _utc(clock()),
+                        ),
+                        grant=None if started else grant,
+                        now=None if started else _utc(clock()),
+                    )
+                except Exception as receipt_exc:
+                    exc.add_note(f"Action-start recovery receipt also failed: {receipt_exc}")
+                    raise exc
+                raise
+            contract_sha256 = snapshot.tasks_by_id[action.subject_id].contract_sha256
+            try:
+                result = _dispatch(config, action, task, expected_contract_sha256=contract_sha256)
+            except BaseException as exc:
+                receipt = ActionReceipt(
+                    intent.action_id,
+                    intent.idempotency_key,
+                    intent.owner_generation,
+                    ActionStatus.UNCERTAIN,
+                    "task_api_raised_after_action_start",
+                    _utc(clock()),
+                )
+                try:
+                    record_objective_action_receipt(config, wave.objective_id, receipt=receipt)
+                except Exception as receipt_exc:
+                    exc.add_note(f"uncertain Action receipt also failed: {receipt_exc}")
+                    raise exc
+                outcomes.append(SupervisedOutcome(intent.action_id, action.kind, action.subject_id, receipt.status, "uncertain"))
+                if not isinstance(exc, Exception):
+                    raise
+                break
+            receipt_status, rendered_result = _task_result_status(action, result)
+            receipt = ActionReceipt(
+                intent.action_id,
+                intent.idempotency_key,
+                intent.owner_generation,
+                receipt_status,
+                f"{action.kind.value}:{rendered_result}",
+                _utc(clock()),
+            )
+            record_objective_action_receipt(config, wave.objective_id, receipt=receipt)
+            outcomes.append(SupervisedOutcome(intent.action_id, action.kind, action.subject_id, receipt.status, rendered_result))
+            if receipt_status is ActionStatus.UNCERTAIN:
+                break
+    except BaseException as exc:
+        primary_error = exc
+        raise
+    finally:
+        try:
+            release_objective_owner_lease(
+                config,
+                wave.objective_id,
+                grant=grant,
+                now=_utc(clock()),
+            )
+        except Exception:
+            # A lease-release failure is safe (the lease expires) but must not
+            # hide an Action failure or turn it into a misleading success.
+            if primary_error is None:
+                raise
+    return tuple(outcomes)
+
+
+def render_supervised_outcomes(outcomes: tuple[SupervisedOutcome, ...]) -> str:
+    return "\n".join(
+        f"Action: {item.operation.value} {item.subject_id} -> {item.status.value} ({item.result})"
+        for item in outcomes
+    )
+
+
+def supervised_outcomes_payload(outcomes: tuple[SupervisedOutcome, ...]) -> list[dict[str, str]]:
+    """Return a JSON-safe terminal projection without Journal internals."""
+    return [
+        {
+            "action_id": item.action_id,
+            "operation": item.operation.value,
+            "subject_id": item.subject_id,
+            "status": item.status.value,
+            "result": item.result,
+        }
+        for item in outcomes
+    ]

--- a/src/dyro/tasks.py
+++ b/src/dyro/tasks.py
@@ -780,10 +780,12 @@ def _reserve_local_execution(
     action: str,
     dry_run: bool,
     legacy_scheduler: bool = False,
+    expected_contract_sha256: str | None = None,
 ) -> None:
     """Check dispatch constraints and atomically reserve the task before starting an Agent."""
     def reserve() -> None:
         with exclusive_lock(_state_lock_path(task)):
+            _assert_expected_task_contract(task, expected_contract_sha256)
             current = status(config, task)
             if current not in allowed:
                 raise DyroError(f"任务 {task.id} 当前为 {current}，不能{action}")
@@ -803,6 +805,29 @@ def _reserve_local_execution(
         return
     with exclusive_lock(_dispatch_lock_path(config)):
         reserve()
+
+
+def _assert_expected_task_contract(task: Task, expected_contract_sha256: str | None) -> None:
+    """Fail closed when a supervised Action's pinned Task contract drifted.
+
+    This executes under the Task state lock for execution and immediately
+    before review dispatch.  Direct operator Task commands pass ``None`` and
+    retain their established explicit-command behaviour.
+    """
+    if expected_contract_sha256 is None:
+        return
+    if (
+        not isinstance(expected_contract_sha256, str)
+        or len(expected_contract_sha256) != 64
+        or any(character not in "0123456789abcdef" for character in expected_contract_sha256)
+    ):
+        raise ValidationError("受监督 Action 的 Task contract 摘要无效")
+    try:
+        actual = hashlib.sha256((task.directory / "task.toml").read_bytes()).hexdigest()
+    except OSError as exc:
+        raise ValidationError(f"无法读取任务 {task.id} contract") from exc
+    if actual != expected_contract_sha256:
+        raise DyroError("Task contract 已在受监督 Action 确认后变化；请 objective reconcile 后重新确认")
 
 
 def worktree_root(config: Config, task: Task) -> Path:
@@ -1308,9 +1333,11 @@ def run_task(
     *,
     dry_run: bool = False,
     legacy_scheduler: bool = False,
+    expected_contract_sha256: str | None = None,
 ) -> str:
     _require_local_execution(config, "任务", dry_run=dry_run)
     if dry_run:
+        _assert_expected_task_contract(task, expected_contract_sha256)
         return _run_task(config, task, dry_run=True)
     with exclusive_lock(_execution_lock_path(task), timeout_seconds=1.0):
         try:
@@ -1321,6 +1348,7 @@ def run_task(
                 action="启动执行",
                 dry_run=False,
                 legacy_scheduler=legacy_scheduler,
+                expected_contract_sha256=expected_contract_sha256,
             )
             attempt = begin_execution_attempt(
                 task.directory,
@@ -1678,15 +1706,28 @@ def _apply_review_decision(config: Config, task: Task, *, dry_run: bool = False)
     return "review"
 
 
-def review_task(config: Config, task: Task, *, dry_run: bool = False) -> str:
+def review_task(
+    config: Config,
+    task: Task,
+    *,
+    dry_run: bool = False,
+    expected_contract_sha256: str | None = None,
+) -> str:
     _require_local_execution(config, "复核", dry_run=dry_run)
     if dry_run:
-        return _review_task(config, task, dry_run=True)
+        return _review_task(config, task, dry_run=True, expected_contract_sha256=expected_contract_sha256)
     with exclusive_lock(_review_lock_path(task), timeout_seconds=1.0):
-        return _review_task(config, task, dry_run=False)
+        return _review_task(config, task, dry_run=False, expected_contract_sha256=expected_contract_sha256)
 
 
-def _review_task(config: Config, task: Task, *, dry_run: bool) -> str:
+def _review_task(
+    config: Config,
+    task: Task,
+    *,
+    dry_run: bool,
+    expected_contract_sha256: str | None = None,
+) -> str:
+    _assert_expected_task_contract(task, expected_contract_sha256)
     if status(config, task) != "review":
         raise DyroError(f"仅 review 任务可启动复核：{task.id}")
     workspace = worktree_root(config, task)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+import json
 import tempfile
 import unittest
 from contextlib import redirect_stderr, redirect_stdout
@@ -499,6 +500,81 @@ class ObjectiveCliTests(WorkspaceCase):
         self.assertIn('"items"', attention_output.getvalue())
         after = {path.relative_to(objective_dir): path.read_bytes() for path in objective_dir.rglob("*") if path.is_file()}
         self.assertEqual(before, after)
+
+    def test_objective_apply_dry_run_shows_the_exact_wave_without_writing(self) -> None:
+        root = str(self.root)
+        main(
+            [
+                "--root", root, "objective", "start", "--id", "release", "--title", "Release",
+                "--line", "alpha", "--targets", "TASK-A", "--yes",
+            ]
+        )
+        objective_dir = self.config.objectives_dir / "release"
+        before = {path.relative_to(objective_dir): path.read_bytes() for path in objective_dir.rglob("*") if path.is_file()}
+        output = StringIO()
+        with redirect_stdout(output):
+            main(["--root", root, "--dry-run", "objective", "apply", "release"])
+        after = {path.relative_to(objective_dir): path.read_bytes() for path in objective_dir.rglob("*") if path.is_file()}
+        self.assertIn("Tick SHA-256", output.getvalue())
+        self.assertIn("DRY RUN", output.getvalue())
+        self.assertEqual(before, after)
+
+    def test_objective_apply_noninteractive_uses_stable_confirmation_and_json_envelope(self) -> None:
+        from dyro.continuation.supervision import build_supervised_wave
+
+        root = str(self.root)
+        main(
+            [
+                "--root", root, "objective", "start", "--id", "release", "--title", "Release",
+                "--line", "alpha", "--targets", "TASK-A", "--yes",
+            ]
+        )
+        confirmation = build_supervised_wave(self.config, "release").confirmation_sha256
+        output = StringIO()
+        with (
+            patch("dyro.cli.apply_supervised_wave", return_value=()) as apply,
+            redirect_stdout(output),
+        ):
+            main(
+                [
+                    "--root", root, "objective", "apply", "release", "--yes",
+                    "--confirm-sha", confirmation, "--format", "json",
+                ]
+            )
+        payload = json.loads(output.getvalue())
+        self.assertFalse(payload["dry_run"])
+        self.assertEqual(payload["outcomes"], [])
+        self.assertIn("confirmation_sha256", payload["wave"])
+        apply.assert_called_once()
+
+    def test_objective_apply_rejects_a_semantically_stale_confirmation(self) -> None:
+        from dyro.continuation.supervision import build_supervised_wave
+        from dyro.tasks import set_status
+
+        root = str(self.root)
+        main(
+            [
+                "--root", root, "objective", "start", "--id", "release", "--title", "Release",
+                "--line", "alpha", "--targets", "TASK-A", "--yes",
+            ]
+        )
+        confirmation = build_supervised_wave(self.config, "release").confirmation_sha256
+        set_status(self.config, load_task(self.config, "TASK-A"), "assigned")
+        stderr = StringIO()
+        with (
+            patch("dyro.cli.apply_supervised_wave") as apply,
+            redirect_stderr(stderr),
+            self.assertRaises(SystemExit) as rejected,
+        ):
+            main(
+                [
+                    "--root", root, "objective", "apply", "release", "--yes",
+                    "--confirm-sha", confirmation,
+                ]
+            )
+        self.assertEqual(rejected.exception.code, 2)
+        self.assertIn("Confirmation SHA-256", stderr.getvalue())
+        apply.assert_not_called()
 
 
 class DaemonSelectionTests(WorkspaceCase):

--- a/tests/test_continuation_supervision.py
+++ b/tests/test_continuation_supervision.py
@@ -1,0 +1,193 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from pathlib import Path
+import unittest
+from unittest.mock import patch
+
+from dyro.config import load
+from dyro.continuation.actions import ActionStatus
+from dyro.continuation.store import (
+    create_objective,
+    get_objective_action,
+    list_objective_actions,
+    pause_objective,
+    resume_objective,
+    start_objective_action as store_start_objective_action,
+)
+from dyro.continuation.supervision import apply_supervised_wave, build_supervised_wave
+from dyro.errors import DyroError
+from dyro.tasks import load_task, set_status, status, task_template
+from dyro.workspace import create_line
+
+from .support import WorkspaceCase
+
+
+def _contract(*, max_actions: int = 20) -> str:
+    return f'''schema_version = 1
+id = "release"
+title = "Release"
+line = "alpha"
+targets = ["TASK-A"]
+
+[continuation]
+requested_mode = "supervised"
+operations = ["execute", "review"]
+
+[budget]
+max_actions = {max_actions}
+max_attempts_per_task = 2
+max_failures = 3
+max_no_progress_cycles = 2
+max_parallel = 1
+'''
+
+
+class SupervisedContinuationTests(WorkspaceCase):
+    def setUp(self) -> None:
+        super().setUp()
+        self.config = load(self.root)
+        create_line(self.config, line_id="alpha", branch="feat/alpha", base="main")
+        self.task_directory = self._write_task("TASK-A")
+        self.now = datetime(2026, 8, 4, 12, 0, tzinfo=timezone.utc)
+
+    def _write_task(self, task_id: str) -> Path:
+        directory = self.config.task_specs_dir / task_id
+        directory.mkdir(parents=True)
+        directory.joinpath("task.toml").write_text(
+            task_template(task_id, "Task A", "alpha", "api", "services/api").replace(
+                'agent = "codex"', 'agent = "noop"'
+            ),
+            encoding="utf-8",
+        )
+        directory.joinpath("handoff.md").write_text("# handoff\n", encoding="utf-8")
+        return directory
+
+    def _wave(self, *, max_actions: int = 20):
+        create_objective(self.config, _contract(max_actions=max_actions))
+        return build_supervised_wave(self.config, "release", clock=lambda: self.now)
+
+    def test_action_start_precedes_task_api_and_success_receipt_is_bound(self) -> None:
+        wave = self._wave()
+
+        def invoke(config, task, *, expected_contract_sha256):
+            records = list_objective_actions(config, "release")
+            self.assertEqual(len(records), 1)
+            self.assertIsNotNone(records[0].start)
+            self.assertEqual(len(expected_contract_sha256), 64)
+            return "review"
+
+        with patch("dyro.continuation.supervision.run_task", side_effect=invoke):
+            outcomes = apply_supervised_wave(self.config, wave, clock=lambda: self.now)
+
+        self.assertEqual(len(outcomes), 1)
+        self.assertEqual(outcomes[0].status, ActionStatus.SUCCEEDED)
+        record = get_objective_action(self.config, "release", outcomes[0].action_id)
+        self.assertIsNotNone(record.start)
+        self.assertEqual(record.receipt.status, ActionStatus.SUCCEEDED)
+        self.assertEqual(record.intent.budget_reservation.attempts, 1)
+
+    def test_supervised_execute_uses_the_real_local_task_path_after_action_start(self) -> None:
+        self.task_directory.joinpath("receipt.md").write_text("result: DONE\n", encoding="utf-8")
+        wave = self._wave()
+
+        outcomes = apply_supervised_wave(self.config, wave, clock=lambda: self.now)
+
+        self.assertEqual([(item.status, item.result) for item in outcomes], [(ActionStatus.SUCCEEDED, "review")])
+        self.assertEqual(status(self.config, load_task(self.config, "TASK-A")), "review")
+        record = get_objective_action(self.config, "release", outcomes[0].action_id)
+        self.assertIsNotNone(record.start)
+        self.assertEqual(record.receipt.status, ActionStatus.SUCCEEDED)
+
+    def test_contract_drift_before_apply_creates_no_action_or_owner_lease(self) -> None:
+        wave = self._wave()
+        self.task_directory.joinpath("task.toml").write_text(
+            self.task_directory.joinpath("task.toml").read_text(encoding="utf-8") + "\n# drift\n",
+            encoding="utf-8",
+        )
+
+        with self.assertRaisesRegex(DyroError, "没有可由受监督阶段执行"):
+            apply_supervised_wave(self.config, wave, clock=lambda: self.now)
+
+        objective_dir = self.config.objectives_dir / "release"
+        self.assertEqual(list_objective_actions(self.config, "release"), ())
+        self.assertFalse(objective_dir.joinpath("scheduler-owner.json").exists())
+
+    def test_objective_event_change_before_apply_creates_no_action_or_owner_lease(self) -> None:
+        wave = self._wave()
+        pause_objective(self.config, "release")
+        resume_objective(self.config, "release")
+
+        with self.assertRaisesRegex(DyroError, "语义变化"):
+            apply_supervised_wave(self.config, wave, clock=lambda: self.now)
+
+        objective_dir = self.config.objectives_dir / "release"
+        self.assertEqual(list_objective_actions(self.config, "release"), ())
+        self.assertFalse(objective_dir.joinpath("scheduler-owner.json").exists())
+
+    def test_task_exception_after_action_start_is_uncertain_and_blocks_replay(self) -> None:
+        wave = self._wave()
+        with patch("dyro.continuation.supervision.run_task", side_effect=RuntimeError("runner interrupted")):
+            outcomes = apply_supervised_wave(self.config, wave, clock=lambda: self.now)
+
+        self.assertEqual([(item.status, item.result) for item in outcomes], [(ActionStatus.UNCERTAIN, "uncertain")])
+        record = get_objective_action(self.config, "release", outcomes[0].action_id)
+        self.assertEqual(record.receipt.status, ActionStatus.UNCERTAIN)
+        with self.assertRaisesRegex(DyroError, "uncertain"):
+            apply_supervised_wave(self.config, wave, clock=lambda: self.now)
+
+    def test_keyboard_interrupt_after_action_start_writes_uncertain_receipt_then_reraises(self) -> None:
+        wave = self._wave()
+        with patch("dyro.continuation.supervision.run_task", side_effect=KeyboardInterrupt):
+            with self.assertRaises(KeyboardInterrupt):
+                apply_supervised_wave(self.config, wave, clock=lambda: self.now)
+
+        records = list_objective_actions(self.config, "release")
+        self.assertEqual(len(records), 1)
+        self.assertEqual(records[0].receipt.status, ActionStatus.UNCERTAIN)
+
+    def test_keyboard_interrupt_after_start_write_recovers_uncertain_then_reraises(self) -> None:
+        wave = self._wave()
+
+        def interrupt_after_start(*args, **kwargs):
+            store_start_objective_action(*args, **kwargs)
+            raise KeyboardInterrupt
+
+        with patch("dyro.continuation.supervision.start_objective_action", side_effect=interrupt_after_start):
+            with self.assertRaises(KeyboardInterrupt):
+                apply_supervised_wave(self.config, wave, clock=lambda: self.now)
+
+        records = list_objective_actions(self.config, "release")
+        self.assertEqual(len(records), 1)
+        self.assertIsNotNone(records[0].start)
+        self.assertEqual(records[0].receipt.status, ActionStatus.UNCERTAIN)
+
+    def test_confirmation_digest_is_stable_across_sampling_time_but_changes_with_task_state(self) -> None:
+        create_objective(self.config, _contract())
+        first = build_supervised_wave(self.config, "release", clock=lambda: self.now)
+        later = build_supervised_wave(
+            self.config,
+            "release",
+            clock=lambda: datetime(2026, 8, 4, 12, 1, tzinfo=timezone.utc),
+        )
+        self.assertNotEqual(first.tick_sha256, later.tick_sha256)
+        self.assertEqual(first.confirmation_sha256, later.confirmation_sha256)
+
+        set_status(self.config, load_task(self.config, "TASK-A"), "assigned")
+        changed = build_supervised_wave(self.config, "release", clock=lambda: self.now)
+        self.assertNotEqual(first.confirmation_sha256, changed.confirmation_sha256)
+
+    def test_started_action_consumes_budget_before_any_replay(self) -> None:
+        wave = self._wave(max_actions=1)
+        with patch("dyro.continuation.supervision.run_task", return_value="review") as runner:
+            first = apply_supervised_wave(self.config, wave, clock=lambda: self.now)
+            replay = build_supervised_wave(self.config, "release", clock=lambda: self.now)
+            with self.assertRaisesRegex(DyroError, "ACTION_LIMIT"):
+                apply_supervised_wave(self.config, replay, clock=lambda: self.now)
+
+        self.assertEqual(first[0].status, ActionStatus.SUCCEEDED)
+        self.assertEqual(runner.call_count, 1)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 变更
- 新增 objective apply：交互确认或非交互 --yes --confirm-sha 后，只串行执行 execute/review。
- ActionIntent、预算、owner lease 与 Task contract 在执行前重新校验；Action-start 后的异常或中断保守记为 uncertain。
- 默认不支持自动 merge、push 或并发启动；JSON 输出为单一 envelope。

## 验证
- 全量 unittest discover
- Ruff 检查
- Python 源码编译
- git diff --check
- 对抗复审已处理确认摘要、TOCTOU、BaseException/KeyboardInterrupt、预算与 JSON 边界问题。