### PR TITLE
feat(控制台): 增加只读工作区快照

### DIFF
--- a/docs/designs/local-web-console.md
+++ b/docs/designs/local-web-console.md
@@ -176,6 +176,20 @@ overview、workspace、Objective、Task、graph 与 activity endpoint 只能切�
 不得各自重算 readiness、attention、completion、evidence validity 或 health。读取不能触发 lazy
 index、偏好更新、Git 锁写入或其他 hydration mutation。
 
+### 4.1 C01 已落地的读取契约
+
+首个实现仅建立 Core capture 与 Console DTO 边界，尚未启动 HTTP listener 或浏览器：
+
+- `dyro.observations.capture_workspace_read_snapshot()` 只组合既有 TaskGraph、Objective、
+  scheduler 和 Attention 读取；它不调用编码工具、网络、更新检查、CLI 子进程或任何 mutation API；
+- 读取失败收敛为稳定的组件 code，例如 `TASKS_UNAVAILABLE` 与
+  `OBJECTIVES_UNAVAILABLE`，不返回异常文字、路径或解析原文；一个 Objective 组件失败不得抹掉
+  已捕获的任务和开发线；
+- `dyro.console.workspace_envelope()` 只接受该不可变 snapshot，逐字段白名单化后生成统一封套；
+  `snapshot_sha256` 只覆盖脱敏后的事实，不覆盖 `captured_at`，因此相同状态的轮询可复用 ETag；
+- C01 不发布 action receipt、ledger、gate 输出、agent argv、adapter 环境、仓库路径或 remote。
+  后续阶段若要扩充字段，必须先扩充显式 DTO 与脱敏测试，而不能把 Core dataclass 直接 JSON 化。
+
 ## 5. 模块设计
 
 建议模块边界：

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,6 +47,7 @@ dev = ["build==1.3.0", "ruff==0.15.2", "twine==6.2.0"]
 [tool.setuptools]
 packages = [
   "dyro",
+  "dyro.console",
   "dyro.continuation",
   "experiments",
   "experiments.local_agent_dispatch",

--- a/src/dyro/console/__init__.py
+++ b/src/dyro/console/__init__.py
@@ -1,0 +1,9 @@
+"""Local Console presentation boundary.
+
+The package starts with read-model composition only.  It deliberately exposes
+no listener, session, browser, subprocess, or mutation capability.
+"""
+
+from .read_model import workspace_envelope
+
+__all__ = ["workspace_envelope"]

--- a/src/dyro/console/models.py
+++ b/src/dyro/console/models.py
@@ -1,0 +1,39 @@
+"""Versioned Console DTO primitives.
+
+The mapping returned by :meth:`ConsoleEnvelope.to_payload` is intentionally a
+fresh JSON-compatible value.  The immutable dataclass is the internal contract
+shared by subsequent HTTP endpoints.
+"""
+
+from __future__ import annotations
+
+from copy import deepcopy
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Mapping
+
+
+CONSOLE_SCHEMA_VERSION = 1
+
+
+@dataclass(frozen=True)
+class ConsoleEnvelope:
+    captured_at: datetime
+    snapshot_sha256: str
+    freshness_state: str
+    partial: bool
+    warnings: tuple[str, ...]
+    data: Mapping[str, object]
+
+    def to_payload(self) -> dict[str, object]:
+        return {
+            "schema_version": CONSOLE_SCHEMA_VERSION,
+            "captured_at": self.captured_at.isoformat(),
+            "snapshot_sha256": self.snapshot_sha256,
+            "freshness": {
+                "state": self.freshness_state,
+                "partial": self.partial,
+                "warnings": [{"code": code} for code in self.warnings],
+            },
+            "data": deepcopy(dict(self.data)),
+        }

--- a/src/dyro/console/read_model.py
+++ b/src/dyro/console/read_model.py
@@ -1,0 +1,109 @@
+"""Explicit, path-free Console projection of Core workspace observations."""
+
+from __future__ import annotations
+
+import hashlib
+
+from ..canonical import canonical_json_bytes
+from ..observations import WorkspaceReadSnapshot
+from .models import ConsoleEnvelope
+from .redaction import safe_branch, safe_id, safe_sha256, safe_title
+
+
+def _action_payload(action: object) -> dict[str, str]:
+    return {
+        "kind": safe_id(action.kind),
+        "subject_id": safe_id(action.subject_id),
+        "reason": safe_id(action.reason),
+    }
+
+
+def _attention_payload(item: object) -> dict[str, str]:
+    return {
+        "kind": safe_id(item.kind),
+        "subject_id": safe_id(item.subject_id),
+        "reason": safe_id(item.reason),
+    }
+
+
+def _data(snapshot: WorkspaceReadSnapshot) -> dict[str, object]:
+    status_counts: dict[str, int] = {}
+    for task in snapshot.tasks:
+        status = safe_id(task.status)
+        status_counts[status] = status_counts.get(status, 0) + 1
+    return {
+        "workspace": {
+            "name": safe_title(snapshot.workspace_name),
+            "workspace_revision": safe_sha256(snapshot.workspace_revision),
+            "completeness": snapshot.completeness if snapshot.completeness in {"complete", "partial", "unavailable"} else "unavailable",
+        },
+        "task_status_counts": dict(sorted(status_counts.items())),
+        "lines": [
+            {
+                "id": safe_id(line.id),
+                "kind": safe_id(line.kind),
+                "branch": safe_branch(line.branch),
+                "base": safe_branch(line.base),
+                "repository_count": line.repository_count,
+            }
+            for line in snapshot.lines
+        ],
+        "tasks": [
+            {
+                "id": safe_id(task.id),
+                "title": safe_title(task.title),
+                "line": safe_id(task.line),
+                "status": safe_id(task.status),
+                "risk": safe_id(task.risk),
+                "depends_on": [safe_id(item) for item in task.depends_on],
+                "blocked_on": [safe_id(item) for item in task.blocked_on],
+                "conflict_group": safe_id(task.conflict_group) if task.conflict_group else "",
+                "executor": safe_id(task.executor),
+                "reviewer": safe_id(task.reviewer),
+                "integration_state": safe_id(task.integration_state),
+                "external_claim_active": task.external_claim_active,
+            }
+            for task in snapshot.tasks
+        ],
+        "objectives": [
+            {
+                "id": safe_id(objective.id),
+                "title": safe_title(objective.title),
+                "line": safe_id(objective.line),
+                "revision": objective.revision,
+                "operator_state": safe_id(objective.operator_state),
+                "derived_result": safe_id(objective.derived_result),
+                "requested_mode": safe_id(objective.requested_mode),
+                "operations": [safe_id(operation) for operation in objective.operations],
+                "scope_count": objective.scope_count,
+                "budget": dict(objective.budget),
+                "selected_actions": [_action_payload(item) for item in objective.selected_actions],
+                "blocked_actions": [_action_payload(item) for item in objective.blocked_actions],
+                "attention": [_attention_payload(item) for item in objective.attention],
+                "contract_sha256": safe_sha256(objective.contract_sha256),
+                "scope_sha256": safe_sha256(objective.scope_sha256),
+                "event_sha256": safe_sha256(objective.event_sha256),
+            }
+            for objective in snapshot.objectives
+        ],
+    }
+
+
+def workspace_envelope(snapshot: WorkspaceReadSnapshot) -> dict[str, object]:
+    """Return the shared Console response envelope for one Core capture.
+
+    The digest binds only the sanitized presentation facts.  A fresh sampling
+    timestamp or future browser locale selection cannot invalidate an ETag.
+    """
+    data = _data(snapshot)
+    digest = hashlib.sha256(canonical_json_bytes(data)).hexdigest()
+    warnings = tuple(sorted({failure.code for failure in snapshot.failures}))
+    partial = snapshot.completeness != "complete"
+    return ConsoleEnvelope(
+        captured_at=snapshot.observed_at,
+        snapshot_sha256=digest,
+        freshness_state="partial" if partial else "fresh",
+        partial=partial,
+        warnings=warnings,
+        data=data,
+    ).to_payload()

--- a/src/dyro/console/redaction.py
+++ b/src/dyro/console/redaction.py
@@ -1,0 +1,72 @@
+"""Small, explicit display-field whitelist for the local Console."""
+
+from __future__ import annotations
+
+import re
+import unicodedata
+
+
+REDACTED = "REDACTED"
+_SAFE_ID = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]{0,79}$")
+_SAFE_BRANCH = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._/-]{0,127}$")
+_SHA256 = re.compile(r"^[0-9a-f]{64}$")
+_CONTROL = re.compile(r"[\x00-\x1f\x7f-\x9f]")
+_CREDENTIAL = re.compile(
+    r"(?i)(?:"
+    r"(?:token|secret|password|api[_-]?key|authorization)\s*(?:=|:)"
+    r"|(?:token|secret|password|api[_-]?key|authorization)\s+[A-Za-z0-9._-]{8,}"
+    r"|(?:token|secret|password|api[_-]?key|authorization)[._-][A-Za-z0-9._-]{6,}"
+    r"|bearer\s+[A-Za-z0-9._-]{8,}"
+    r"|xox[abprs]-[A-Za-z0-9-]{10,}"
+    r"|(?:sk|rk|pk|ghp|gho|ghs|ghu|github_pat|glpat|npm|pypi|AIza)[_-][A-Za-z0-9._-]{6,}"
+    r"|AKIA[A-Z0-9]{16}"
+    r"|ya29\.[A-Za-z0-9._-]{8,}"
+    r")"
+)
+_REMOTE = re.compile(r"(?i)(?:[a-z][a-z0-9+.-]*://|git@[^\s:]+:)")
+_ABSOLUTE_PATH = re.compile(r"(?:^|[^A-Za-z0-9._-])(?:~|/|[A-Za-z]:[\\/])")
+
+
+def _safe_text(value: object, *, limit: int) -> str:
+    if not isinstance(value, str):
+        return REDACTED
+    normalized = unicodedata.normalize("NFC", value).strip()
+    if (
+        not normalized
+        or len(normalized) > limit
+        or _CONTROL.search(normalized)
+        or _CREDENTIAL.search(normalized)
+        or _REMOTE.search(normalized)
+        or _ABSOLUTE_PATH.search(normalized)
+    ):
+        return REDACTED
+    return normalized
+
+
+def safe_title(value: object) -> str:
+    return _safe_text(value, limit=160)
+
+
+def safe_id(value: object) -> str:
+    return (
+        value
+        if isinstance(value, str)
+        and _SAFE_ID.fullmatch(value)
+        and not _CREDENTIAL.search(value)
+        else REDACTED
+    )
+
+
+def safe_branch(value: object) -> str:
+    if (
+        not isinstance(value, str)
+        or not _SAFE_BRANCH.fullmatch(value)
+        or ".." in value
+        or _CREDENTIAL.search(value)
+    ):
+        return REDACTED
+    return value
+
+
+def safe_sha256(value: object) -> str:
+    return value if isinstance(value, str) and _SHA256.fullmatch(value) else REDACTED

--- a/src/dyro/continuation/planner.py
+++ b/src/dyro/continuation/planner.py
@@ -340,7 +340,13 @@ def build_continuation_plan(snapshot: SchedulerSnapshot) -> ContinuationPlan:
             )
         elif item.status == "done" and item.integration_state != "integrated":
             blocked.append(
-                _action(ActionKind.MERGE_TASK, task_id, ReasonCode.TASK_INTEGRATION_PENDING)
+                _action(
+                    ActionKind.WAIT
+                    if item.integration_state == "not_inspected"
+                    else ActionKind.MERGE_TASK,
+                    task_id,
+                    ReasonCode.TASK_INTEGRATION_PENDING,
+                )
             )
     if not selected and not blocked and not attention:
         selected.append(_action(ActionKind.WAIT, snapshot.objective_id, ReasonCode.NO_PROGRESS))

--- a/src/dyro/continuation/snapshot.py
+++ b/src/dyro/continuation/snapshot.py
@@ -40,7 +40,12 @@ class SchedulerTaskSnapshot:
     contract_sha256: str = ""
 
     def __post_init__(self) -> None:
-        if self.integration_state not in {"not_required", "integrated", "pending"}:
+        if self.integration_state not in {
+            "not_required",
+            "not_inspected",
+            "integrated",
+            "pending",
+        }:
             raise TypeError("调度快照 integration_state 无效")
 
 
@@ -165,9 +170,15 @@ def _integration_state(
     task_status: str,
     *,
     required: bool,
+    inspect: bool,
 ) -> str:
     if task_status != "done" or not required:
         return "not_required"
+    if not inspect:
+        # Summary-only Console captures never start a Git subprocess.  This is
+        # distinct from ``pending``: the fact was not inspected, not judged
+        # broken or healthy.
+        return "not_inspected"
     try:
         task_module._assert_dependency_integrated(config, task)
     except (DyroError, ValidationError):
@@ -180,6 +191,7 @@ def build_scheduler_snapshot(
     *,
     objective: StoredObjective | None = None,
     candidates: Iterable[Task] | None = None,
+    inspect_integration: bool = True,
     clock: Callable[[], datetime] = lambda: datetime.now(timezone.utc),
 ) -> SchedulerSnapshot:
     """Read the task graph exactly once and publish canonical, immutable facts."""
@@ -226,6 +238,7 @@ def build_scheduler_snapshot(
                 task,
                 statuses[task.id],
                 required=task.id in integration_required_ids,
+                inspect=inspect_integration,
             ),
             contract_sha256=contract_sha256_by_id.get(task.id, ""),
         )

--- a/src/dyro/observations.py
+++ b/src/dyro/observations.py
@@ -1,0 +1,360 @@
+"""Immutable, read-only workspace observations shared by presentation layers.
+
+The Console must never obtain facts by parsing CLI text or by reimplementing
+the scheduler.  This module is the Core-owned composition point: it samples
+the existing task and Objective readers, performs no mutation, and returns
+only immutable domain observations.  A presentation boundary must still apply
+its own explicit field whitelist before exposing an observation to a browser.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timezone
+import hashlib
+from typing import Callable
+
+from .canonical import canonical_json_bytes
+from .config import Config
+from .continuation.attention import build_attention_projection
+from .continuation.planner import build_continuation_plan, build_scheduler_projection
+from .continuation.snapshot import build_scheduler_snapshot
+from .continuation.store import list_objectives
+from .errors import DyroError, ValidationError
+from .workspace import list_lines
+
+
+READ_SNAPSHOT_SCHEMA_VERSION = 1
+
+
+@dataclass(frozen=True)
+class ReadFailure:
+    """A deliberately terse component failure suitable for a later DTO."""
+
+    component: str
+    code: str
+
+
+@dataclass(frozen=True)
+class WorkspaceLineObservation:
+    id: str
+    kind: str
+    branch: str
+    base: str
+    repository_count: int
+
+
+@dataclass(frozen=True)
+class WorkspaceTaskObservation:
+    id: str
+    title: str
+    line: str
+    status: str
+    risk: str
+    depends_on: tuple[str, ...]
+    blocked_on: tuple[str, ...]
+    conflict_group: str
+    executor: str
+    reviewer: str
+    integration_state: str
+    external_claim_active: bool
+
+
+@dataclass(frozen=True)
+class ObjectiveActionObservation:
+    kind: str
+    subject_id: str
+    reason: str
+
+
+@dataclass(frozen=True)
+class ObjectiveAttentionObservation:
+    kind: str
+    subject_id: str
+    reason: str
+
+
+@dataclass(frozen=True)
+class WorkspaceObjectiveObservation:
+    id: str
+    title: str
+    line: str
+    revision: int
+    operator_state: str
+    derived_result: str
+    requested_mode: str
+    operations: tuple[str, ...]
+    scope_count: int
+    budget: tuple[tuple[str, int], ...]
+    selected_actions: tuple[ObjectiveActionObservation, ...]
+    blocked_actions: tuple[ObjectiveActionObservation, ...]
+    attention: tuple[ObjectiveAttentionObservation, ...]
+    contract_sha256: str
+    scope_sha256: str
+    event_sha256: str
+
+
+@dataclass(frozen=True)
+class WorkspaceReadSnapshot:
+    """One immutable capture of Core facts for future Console endpoints.
+
+    ``workspace_revision`` deliberately excludes ``observed_at``.  It changes
+    when captured domain facts change, while a later HTTP ETag remains stable
+    across otherwise identical polling captures.
+    """
+
+    schema_version: int
+    workspace_name: str
+    observed_at: datetime
+    capture_id: str
+    workspace_revision: str
+    source_digests: tuple[tuple[str, str], ...]
+    completeness: str
+    lines: tuple[WorkspaceLineObservation, ...]
+    tasks: tuple[WorkspaceTaskObservation, ...]
+    objectives: tuple[WorkspaceObjectiveObservation, ...]
+    failures: tuple[ReadFailure, ...] = ()
+
+
+def _utc(value: datetime) -> datetime:
+    if not isinstance(value, datetime) or value.tzinfo is None:
+        raise ValidationError("工作区读取时钟必须提供带时区的 datetime")
+    return value.astimezone(timezone.utc)
+
+
+def _task_observation(item: object) -> WorkspaceTaskObservation:
+    # ``SchedulerTaskSnapshot`` is intentionally kept internal to the
+    # scheduler.  This tiny adapter avoids leaking its Task.directory path.
+    task = item.task  # type: ignore[attr-defined]
+    return WorkspaceTaskObservation(
+        id=task.id,
+        title=task.title,
+        line=task.line,
+        status=item.status,  # type: ignore[attr-defined]
+        risk=task.risk,
+        depends_on=tuple(task.depends_on),
+        blocked_on=tuple(task.blocked_on),
+        conflict_group=task.conflict_group,
+        executor=task.executor,
+        reviewer=task.reviewer,
+        integration_state=item.integration_state,  # type: ignore[attr-defined]
+        external_claim_active=item.external_claim_active,  # type: ignore[attr-defined]
+    )
+
+
+def _objective_observation(config: Config, record: object, *, clock: Callable[[], datetime]) -> WorkspaceObjectiveObservation:
+    snapshot = build_scheduler_snapshot(
+        config,
+        objective=record,
+        clock=clock,
+        inspect_integration=False,
+    )
+    plan = build_continuation_plan(snapshot)
+    scheduler = build_scheduler_projection(snapshot, plan)
+    attention = build_attention_projection(
+        snapshot,
+        plan,
+        scheduler,
+        budget=record.objective.budget,  # type: ignore[attr-defined]
+    )
+    objective = record.objective  # type: ignore[attr-defined]
+    return WorkspaceObjectiveObservation(
+        id=objective.id,
+        title=objective.title,
+        line=objective.line,
+        revision=record.revision,  # type: ignore[attr-defined]
+        operator_state=record.operator_state,  # type: ignore[attr-defined]
+        derived_result=plan.completion.value,
+        requested_mode=objective.requested_mode.value,
+        operations=tuple(operation.value for operation in objective.operations),
+        scope_count=len(record.scope),  # type: ignore[attr-defined]
+        budget=(
+            ("max_actions", objective.budget.max_actions),
+            ("max_attempts_per_task", objective.budget.max_attempts_per_task),
+            ("max_failures", objective.budget.max_failures),
+            ("max_no_progress_cycles", objective.budget.max_no_progress_cycles),
+            ("max_parallel", objective.budget.max_parallel),
+        ),
+        selected_actions=tuple(
+            ObjectiveActionObservation(action.kind.value, action.subject_id, action.reason.value)
+            for action in plan.selected_actions
+        ),
+        blocked_actions=tuple(
+            ObjectiveActionObservation(action.kind.value, action.subject_id, action.reason.value)
+            for action in plan.blocked
+        ),
+        attention=tuple(
+            ObjectiveAttentionObservation(item.kind.value, item.subject_id, item.reason.value)
+            for item in attention.items
+        ),
+        contract_sha256=record.contract_sha256,  # type: ignore[attr-defined]
+        scope_sha256=record.scope_sha256,  # type: ignore[attr-defined]
+        event_sha256=record.event_sha256,  # type: ignore[attr-defined]
+    )
+
+
+def _revision_payload(
+    *,
+    workspace_name: str,
+    lines: tuple[WorkspaceLineObservation, ...],
+    tasks: tuple[WorkspaceTaskObservation, ...],
+    objectives: tuple[WorkspaceObjectiveObservation, ...],
+    failures: tuple[ReadFailure, ...],
+) -> dict[str, object]:
+    return {
+        "schema_version": READ_SNAPSHOT_SCHEMA_VERSION,
+        "workspace_name": workspace_name,
+        "lines": [
+            {
+                "id": item.id,
+                "kind": item.kind,
+                "branch": item.branch,
+                "base": item.base,
+                "repository_count": item.repository_count,
+            }
+            for item in lines
+        ],
+        "tasks": [
+            {
+                "id": item.id,
+                "title": item.title,
+                "line": item.line,
+                "status": item.status,
+                "risk": item.risk,
+                "depends_on": list(item.depends_on),
+                "blocked_on": list(item.blocked_on),
+                "conflict_group": item.conflict_group,
+                "executor": item.executor,
+                "reviewer": item.reviewer,
+                "integration_state": item.integration_state,
+                "external_claim_active": item.external_claim_active,
+            }
+            for item in tasks
+        ],
+        "objectives": [
+            {
+                "id": item.id,
+                "title": item.title,
+                "line": item.line,
+                "revision": item.revision,
+                "operator_state": item.operator_state,
+                "derived_result": item.derived_result,
+                "requested_mode": item.requested_mode,
+                "operations": list(item.operations),
+                "scope_count": item.scope_count,
+                "budget": dict(item.budget),
+                "selected_actions": [action.__dict__ for action in item.selected_actions],
+                "blocked_actions": [action.__dict__ for action in item.blocked_actions],
+                "attention": [attention.__dict__ for attention in item.attention],
+                "contract_sha256": item.contract_sha256,
+                "scope_sha256": item.scope_sha256,
+                "event_sha256": item.event_sha256,
+            }
+            for item in objectives
+        ],
+        "failures": [failure.__dict__ for failure in failures],
+    }
+
+
+def capture_workspace_read_snapshot(
+    config: Config,
+    *,
+    clock: Callable[[], datetime] = lambda: datetime.now(timezone.utc),
+) -> WorkspaceReadSnapshot:
+    """Capture Core facts without writing state, calling agents, or networking.
+
+    Component failures remain scoped: a malformed Objective cannot erase task
+    state from the Console.  We intentionally publish stable codes only; raw
+    exception text can contain local paths or untrusted workspace content.
+    """
+    observed_at = _utc(clock())
+
+    def sample_clock() -> datetime:
+        return observed_at
+
+    failures: list[ReadFailure] = []
+    source_digests: list[tuple[str, str]] = []
+
+    try:
+        scheduler_snapshot = build_scheduler_snapshot(
+            config,
+            clock=sample_clock,
+            inspect_integration=False,
+        )
+        tasks = tuple(_task_observation(item) for item in scheduler_snapshot.tasks)
+        source_digests.append(("tasks", scheduler_snapshot.snapshot_sha256))
+    except (DyroError, ValidationError, OSError, UnicodeError):
+        tasks = ()
+        failures.append(ReadFailure("tasks", "TASKS_UNAVAILABLE"))
+
+    try:
+        lines = tuple(
+            WorkspaceLineObservation(
+                id=line.id,
+                kind=line.kind,
+                branch=line.branch,
+                base=line.base,
+                repository_count=len(line.repositories),
+            )
+            for line in list_lines(config)
+        )
+        source_digests.append(
+            (
+                "lines",
+                hashlib.sha256(
+                    canonical_json_bytes(
+                        [
+                            {
+                                "id": item.id,
+                                "kind": item.kind,
+                                "branch": item.branch,
+                                "base": item.base,
+                                "repository_count": item.repository_count,
+                            }
+                            for item in lines
+                        ]
+                    )
+                ).hexdigest(),
+            )
+        )
+    except (DyroError, ValidationError, OSError, UnicodeError):
+        lines = ()
+        failures.append(ReadFailure("lines", "LINES_UNAVAILABLE"))
+
+    objectives: tuple[WorkspaceObjectiveObservation, ...]
+    try:
+        records = list_objectives(config, recover=False)
+        objectives = tuple(
+            _objective_observation(config, record, clock=sample_clock)
+            for record in records
+        )
+        source_digests.extend(
+            (f"objective:{item.id}", item.event_sha256) for item in objectives
+        )
+    except (DyroError, ValidationError, OSError, UnicodeError):
+        objectives = ()
+        failures.append(ReadFailure("objectives", "OBJECTIVES_UNAVAILABLE"))
+
+    frozen_failures = tuple(sorted(failures, key=lambda item: (item.component, item.code)))
+    payload = _revision_payload(
+        workspace_name=config.name,
+        lines=lines,
+        tasks=tasks,
+        objectives=objectives,
+        failures=frozen_failures,
+    )
+    revision = hashlib.sha256(canonical_json_bytes(payload)).hexdigest()
+    frozen_sources = tuple(sorted(source_digests))
+    return WorkspaceReadSnapshot(
+        schema_version=READ_SNAPSHOT_SCHEMA_VERSION,
+        workspace_name=config.name,
+        observed_at=observed_at,
+        capture_id=f"capture-{revision[:24]}",
+        workspace_revision=revision,
+        source_digests=frozen_sources,
+        completeness="complete" if not frozen_failures else "partial",
+        lines=lines,
+        tasks=tasks,
+        objectives=objectives,
+        failures=frozen_failures,
+    )

--- a/tests/test_console_read_model.py
+++ b/tests/test_console_read_model.py
@@ -1,0 +1,194 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+import unittest
+from unittest.mock import patch
+
+from dyro.config import load
+from dyro.console.read_model import workspace_envelope
+from dyro.console.models import ConsoleEnvelope
+from dyro.console.redaction import safe_branch, safe_id, safe_title
+from dyro.continuation.store import create_objective
+from dyro.observations import capture_workspace_read_snapshot
+from dyro.tasks import task_template
+from dyro.workspace import create_line
+
+from .support import WorkspaceCase
+
+
+class ConsoleReadModelTests(WorkspaceCase):
+    def setUp(self) -> None:
+        super().setUp()
+        self.config = load(self.root)
+        create_line(self.config, line_id="alpha", branch="feat/alpha", base="main")
+        task = self.config.task_specs_dir / "TASK-A"
+        task.mkdir(parents=True)
+        task.joinpath("task.toml").write_text(
+            task_template("TASK-A", "Prepare release", "alpha", "api", "services/api"),
+            encoding="utf-8",
+        )
+        task.joinpath("handoff.md").write_text("# handoff\n", encoding="utf-8")
+
+    def _objective(self, *, target: str = "TASK-A") -> None:
+        create_objective(
+            self.config,
+            f'''schema_version = 1
+id = "release"
+title = "Release readiness"
+line = "alpha"
+targets = ["{target}"]
+
+[continuation]
+requested_mode = "supervised"
+operations = ["execute", "review"]
+
+[budget]
+max_actions = 5
+max_attempts_per_task = 2
+max_failures = 2
+max_no_progress_cycles = 2
+max_parallel = 1
+''',
+        )
+
+    def test_capture_is_read_only_and_preserves_authoritative_core_facts(self) -> None:
+        self._objective()
+        before = {
+            path.relative_to(self.root): path.read_bytes()
+            for path in self.root.rglob("*")
+            if path.is_file()
+        }
+
+        snapshot = capture_workspace_read_snapshot(
+            self.config,
+            clock=lambda: datetime(2026, 8, 4, 12, 0, tzinfo=timezone.utc),
+        )
+
+        after = {
+            path.relative_to(self.root): path.read_bytes()
+            for path in self.root.rglob("*")
+            if path.is_file()
+        }
+        self.assertEqual(before, after)
+        self.assertEqual(snapshot.workspace_name, "test-workspace")
+        self.assertEqual([(item.id, item.status) for item in snapshot.tasks], [("TASK-A", "backlog")])
+        self.assertEqual([(item.id, item.derived_result) for item in snapshot.objectives], [("release", "incomplete")])
+        self.assertEqual(snapshot.objectives[0].attention[0].reason, "TASK_READY")
+
+    def test_envelope_is_path_free_redacted_and_capture_time_does_not_change_digest(self) -> None:
+        task_manifest = self.config.task_specs_dir / "TASK-A" / "task.toml"
+        task_manifest.write_text(
+            task_manifest.read_text(encoding="utf-8").replace(
+                'title = "Prepare release"',
+                'title = "Copy /Users/alice/private token=top-secret"',
+            ),
+            encoding="utf-8",
+        )
+        first = workspace_envelope(
+            capture_workspace_read_snapshot(
+                self.config,
+                clock=lambda: datetime(2026, 8, 4, 12, 0, tzinfo=timezone.utc),
+            )
+        )
+        second = workspace_envelope(
+            capture_workspace_read_snapshot(
+                self.config,
+                clock=lambda: datetime(2026, 8, 4, 12, 1, tzinfo=timezone.utc),
+            )
+        )
+
+        rendered = repr(first)
+        self.assertNotIn(str(self.root), rendered)
+        self.assertNotIn("/Users/alice/private", rendered)
+        self.assertNotIn("top-secret", rendered)
+        self.assertEqual(first["snapshot_sha256"], second["snapshot_sha256"])
+        self.assertNotEqual(first["captured_at"], second["captured_at"])
+        task = first["data"]["tasks"][0]
+        self.assertEqual(task["title"], "REDACTED")
+
+        task_manifest.write_text(
+            task_manifest.read_text(encoding="utf-8").replace(
+                'title = "Copy /Users/alice/private token=top-secret"',
+                'title = "Inspect(path=/private/var/db)"',
+            ),
+            encoding="utf-8",
+        )
+        nested_path = workspace_envelope(
+            capture_workspace_read_snapshot(
+                self.config,
+                clock=lambda: datetime(2026, 8, 4, 12, 2, tzinfo=timezone.utc),
+            )
+        )
+        self.assertEqual(nested_path["data"]["tasks"][0]["title"], "REDACTED")
+        self.assertEqual(safe_title("Rotate token sk-proj-THIS_IS_A_SECRET"), "REDACTED")
+        self.assertEqual(safe_id("secret_token_ABC123"), "REDACTED")
+        self.assertEqual(safe_branch("feat/secret-token-ABC123"), "REDACTED")
+        slack_like = "xoxb-" + "123456789012-1234567890123-abcdefabcdefabcdefabcdef"
+        self.assertEqual(safe_title(f"Rotate {slack_like}"), "REDACTED")
+
+    def test_summary_capture_does_not_start_an_integration_probe(self) -> None:
+        dependent = self.config.task_specs_dir / "TASK-B"
+        dependent.mkdir(parents=True)
+        dependent.joinpath("task.toml").write_text(
+            task_template("TASK-B", "Dependent task", "alpha", "api", "services/api").replace(
+                "depends_on = []", 'depends_on = ["TASK-A"]'
+            ),
+            encoding="utf-8",
+        )
+        dependent.joinpath("handoff.md").write_text("# handoff\n", encoding="utf-8")
+        self.config.task_specs_dir.joinpath("TASK-A", "status").write_text(
+            "done\n", encoding="utf-8"
+        )
+        self._objective(target="TASK-B")
+
+        with patch(
+            "dyro.continuation.snapshot.task_module._assert_dependency_integrated",
+            side_effect=AssertionError("Console C01 must not probe Git"),
+        ) as probe:
+            snapshot = capture_workspace_read_snapshot(
+                self.config,
+                clock=lambda: datetime(2026, 8, 4, 12, 0, tzinfo=timezone.utc),
+            )
+
+        self.assertFalse(probe.called)
+        task_a = next(item for item in snapshot.tasks if item.id == "TASK-A")
+        self.assertEqual(task_a.integration_state, "not_inspected")
+        self.assertEqual(
+            snapshot.objectives[0].blocked_actions[0].reason,
+            "TASK_INTEGRATION_PENDING",
+        )
+
+    def test_envelope_returns_a_deeply_fresh_json_value(self) -> None:
+        envelope = ConsoleEnvelope(
+            captured_at=datetime(2026, 8, 4, 12, 0, tzinfo=timezone.utc),
+            snapshot_sha256="a" * 64,
+            freshness_state="fresh",
+            partial=False,
+            warnings=(),
+            data={"nested": {"items": ["safe"]}},
+        )
+        first = envelope.to_payload()
+        first["data"]["nested"]["items"].append("changed")
+
+        second = envelope.to_payload()
+        self.assertEqual(second["data"]["nested"]["items"], ["safe"])
+
+    def test_objective_failure_is_component_scoped_without_leaking_exception_text(self) -> None:
+        self._objective()
+        events = self.config.objectives_dir / "release" / "events.jsonl"
+        events.write_text("not-json\n", encoding="utf-8")
+
+        envelope = workspace_envelope(
+            capture_workspace_read_snapshot(
+                self.config,
+                clock=lambda: datetime(2026, 8, 4, 12, 0, tzinfo=timezone.utc),
+            )
+        )
+
+        self.assertEqual(envelope["freshness"]["state"], "partial")
+        self.assertEqual(envelope["freshness"]["warnings"], [{"code": "OBJECTIVES_UNAVAILABLE"}])
+        self.assertNotIn("events.jsonl", repr(envelope))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 范围

- 新增 Core WorkspaceReadSnapshot 和 Console 脱敏展示封套。
- C01 仅查询既有 TaskGraph、Objective、scheduler 与 Attention；不启动 listener、浏览器、Agent、网络或 Git 探测。
- 集成状态未探测时显式为 not_inspected，并只形成 WAIT，不进入 mutation wave。
- DTO 拒绝路径、remote、argv、prompt、常见 token/secret 格式。

## 验证

- 全量 unittest discover
- ruff check src tests
- compileall、diff check、术语扫描
- clean wheel 安装后导入 dyro.console 与 dyro.observations
- 安全复审通过。