### PR TITLE
feat(控制台): 增加多工作区只读概览

### DIFF
--- a/docs/designs/local-web-console.md
+++ b/docs/designs/local-web-console.md
@@ -203,6 +203,22 @@ C02 只提供无项目数据的静态 shell、一次性 session 交换和认证�
 - C02 没有 CLI `console` 命令、浏览器打开、资源文件读取或 workspace API。它的唯一目的，是在
   接入真实 read model 前先固定并测试本地 HTTP 安全边界。
 
+### 4.3 C03 已落地的全局概览契约
+
+C03 在 listener 外新增 `ConsoleOverviewService`，把既有 registry 与每个工作区的一次
+`WorkspaceReadSnapshot` 投影为只读、分页的 overview：
+
+- listener 只验证 bearer、参数和 ETag；它不拥有 registry、Config 或 workspace 路径。概览服务
+  是可注入的读取边界，后续 worker 化不会改变 HTTP DTO；
+- 工作区按 `repair_required`、`needs_user`、active、paused、waiting、其余健康项目的固定优先级
+  排序。每张卡片只含 alias、已净化展示名、计数、attention、一个安全 CLI 恢复建议和摘要 digest；
+- registry 读取失败收敛为 `REGISTRY_UNAVAILABLE`。单个 Profile 或 snapshot 失败保留
+  `unavailable` 卡片和 `WORKSPACE_UNAVAILABLE`，不会影响其它工作区，也不返回根路径或原始错误；
+- `GET /api/v1/overview` 需要 bearer，`limit` 最大 100。下一页 cursor 与完整的当前概览 digest
+  以进程内 256-bit key 认证；篡改或状态变化后的 cursor 返回稳定错误，绝不退化为不透明 offset；
+- overview 的 `snapshot_sha256` 可作为 ETag 使用；同一脱敏页面带精确 `If-None-Match` 时返回
+  304。C03 仍没有 CLI、浏览器、静态资源或详情 API。
+
 ## 5. 模块设计
 
 建议模块边界：

--- a/src/dyro/console/__init__.py
+++ b/src/dyro/console/__init__.py
@@ -1,10 +1,11 @@
-"""Local Console presentation boundary.
+"""Local Console read-side and loopback presentation boundary.
 
-The package starts with read-model composition only.  It deliberately exposes
-no listener, session, browser, subprocess, or mutation capability.
+The package deliberately exposes no browser launcher, subprocess execution,
+workspace mutation, or Core scheduling authority.
 """
 
+from .overview import ConsoleOverviewService
 from .read_model import workspace_envelope
 from .server import create_console_http_server
 
-__all__ = ["create_console_http_server", "workspace_envelope"]
+__all__ = ["ConsoleOverviewService", "create_console_http_server", "workspace_envelope"]

--- a/src/dyro/console/overview.py
+++ b/src/dyro/console/overview.py
@@ -1,0 +1,386 @@
+"""Path-free, paginated global Console overview projection.
+
+The HTTP listener supplies authentication and transport validation only.  This
+module owns no listener and performs no mutation: it reads the existing
+registry, captures the Core-owned workspace snapshot once per workspace, and
+projects an explicitly whitelisted summary for the Console.
+"""
+
+from __future__ import annotations
+
+import base64
+from collections.abc import Callable
+from datetime import datetime, timezone
+import hashlib
+import hmac
+import json
+from pathlib import Path
+import secrets
+from typing import Any
+
+from ..canonical import canonical_json_bytes
+from ..config import Config, load
+from ..errors import DyroError, ValidationError
+from ..hub import WorkspaceRegistry, load_registry
+from ..observations import WorkspaceReadSnapshot, capture_workspace_read_snapshot
+from .models import ConsoleEnvelope
+from .read_model import workspace_envelope
+from .redaction import REDACTED, safe_id, safe_title
+
+
+_PAGE_SCHEMA_VERSION = 1
+_DEFAULT_LIMIT = 20
+_MAX_LIMIT = 100
+_CURSOR_MAX_LENGTH = 512
+_ATTENTION_PRIORITY = {
+    "repair_required": 0,
+    "needs_user": 1,
+    "ready": 2,
+    "paused": 3,
+    "waiting": 4,
+}
+
+
+class ConsoleOverviewError(Exception):
+    """A stable, path-free error that can cross the local HTTP boundary."""
+
+    def __init__(self, code: str) -> None:
+        self.code = code
+        super().__init__(code)
+
+
+def _utc_now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _stable_json(value: object) -> bytes:
+    return canonical_json_bytes(value)
+
+
+def _sha256(value: object) -> str:
+    return hashlib.sha256(_stable_json(value)).hexdigest()
+
+
+def _safe_code(value: object) -> str:
+    code = safe_id(value)
+    return code if code != REDACTED else "REDACTED"
+
+
+def _safe_mapping(value: object) -> dict[str, object]:
+    return dict(value) if isinstance(value, dict) else {}
+
+
+def _safe_list(value: object) -> list[dict[str, object]]:
+    if not isinstance(value, list):
+        return []
+    return [dict(item) for item in value if isinstance(item, dict)]
+
+
+class ConsoleOverviewService:
+    """Read and project registered workspaces without changing their state."""
+
+    def __init__(
+        self,
+        *,
+        registry_loader: Callable[[], WorkspaceRegistry] = load_registry,
+        config_loader: Callable[[Path], Config] = load,
+        snapshot_loader: Callable[[Config], WorkspaceReadSnapshot] = capture_workspace_read_snapshot,
+        clock: Callable[[], datetime] = _utc_now,
+        cursor_secret: bytes | None = None,
+    ) -> None:
+        if cursor_secret is not None and (
+            not isinstance(cursor_secret, bytes) or len(cursor_secret) < 32
+        ):
+            raise ValueError("Console overview cursor secret 必须至少为 256 bit")
+        self._registry_loader = registry_loader
+        self._config_loader = config_loader
+        self._snapshot_loader = snapshot_loader
+        self._clock = clock
+        self._cursor_secret = cursor_secret or secrets.token_bytes(32)
+
+    def page(
+        self,
+        *,
+        cursor: str | None = None,
+        limit: int = _DEFAULT_LIMIT,
+    ) -> dict[str, object]:
+        """Return a deterministic, paginated overview envelope.
+
+        A cursor is authenticated against the complete current summary.  A
+        changed registry or workspace snapshot therefore cannot make an old
+        offset silently point at a different project.
+        """
+        if type(limit) is not int or not 1 <= limit <= _MAX_LIMIT:
+            raise ConsoleOverviewError("OVERVIEW_LIMIT_INVALID")
+        registry = self._load_registry()
+        summaries, warning_codes = self._summaries(registry)
+        aggregate = {
+            "schema_version": _PAGE_SCHEMA_VERSION,
+            "default_workspace": _safe_code(registry.default) if registry.default else "",
+            "workspaces": summaries,
+        }
+        aggregate_sha256 = _sha256(aggregate)
+        offset = self._decode_cursor(cursor, aggregate_sha256) if cursor else 0
+        if offset > len(summaries):
+            raise ConsoleOverviewError("OVERVIEW_CURSOR_INVALID")
+        items = summaries[offset : offset + limit]
+        next_offset = offset + len(items)
+        next_cursor = (
+            self._encode_cursor(next_offset, aggregate_sha256)
+            if next_offset < len(summaries)
+            else None
+        )
+        attention_counts = self._attention_counts(summaries)
+        data = {
+            "default_workspace": _safe_code(registry.default) if registry.default else "",
+            "total_workspaces": len(summaries),
+            "workspaces": items,
+            "next_cursor": next_cursor,
+            "attention_counts": attention_counts,
+            "highest_priority": self._highest_priority(summaries),
+        }
+        partial = bool(warning_codes)
+        return ConsoleEnvelope(
+            captured_at=self._capture_time(),
+            snapshot_sha256=_sha256(data),
+            freshness_state="partial" if partial else "fresh",
+            partial=partial,
+            warnings=tuple(sorted(warning_codes)),
+            data=data,
+        ).to_payload()
+
+    def _load_registry(self) -> WorkspaceRegistry:
+        try:
+            registry = self._registry_loader()
+        except (DyroError, ValidationError, OSError, UnicodeError):
+            raise ConsoleOverviewError("REGISTRY_UNAVAILABLE") from None
+        if not isinstance(registry, WorkspaceRegistry):
+            raise ConsoleOverviewError("REGISTRY_UNAVAILABLE")
+        return registry
+
+    def _capture_time(self) -> datetime:
+        value = self._clock()
+        if not isinstance(value, datetime) or value.tzinfo is None:
+            raise ConsoleOverviewError("OVERVIEW_UNAVAILABLE")
+        return value.astimezone(timezone.utc)
+
+    def _summaries(
+        self, registry: WorkspaceRegistry
+    ) -> tuple[list[dict[str, object]], set[str]]:
+        summaries: list[dict[str, object]] = []
+        warnings: set[str] = set()
+        for record in registry.workspaces:
+            summary, codes = self._summary(record.name, record.root, record.name == registry.default)
+            summaries.append(summary)
+            warnings.update(codes)
+        summaries.sort(key=self._summary_sort_key)
+        return summaries, warnings
+
+    def _summary(
+        self, alias: str, root: Path, is_default: bool
+    ) -> tuple[dict[str, object], set[str]]:
+        safe_alias = _safe_code(alias)
+        try:
+            config = self._config_loader(root)
+            snapshot = self._snapshot_loader(config)
+            envelope = workspace_envelope(snapshot)
+        except (DyroError, ValidationError, OSError, UnicodeError):
+            return (
+                {
+                    "alias": safe_alias,
+                    "display_name": safe_alias,
+                    "is_default": is_default,
+                    "availability": "unavailable",
+                    "health": "unavailable",
+                    "freshness": "partial",
+                    "repository_count": 0,
+                    "line_count": 0,
+                    "objective_count": 0,
+                    "active_objective_count": 0,
+                    "task_count": 0,
+                    "task_status_counts": {},
+                    "attention_counts": self._empty_attention_counts(),
+                    "recommendation": {
+                        "reason": "WORKSPACE_UNAVAILABLE",
+                        "command": f"dyro --workspace {safe_alias} doctor",
+                    },
+                    "snapshot_sha256": "",
+                },
+                {"WORKSPACE_UNAVAILABLE"},
+            )
+
+        data = _safe_mapping(envelope.get("data"))
+        workspace = _safe_mapping(data.get("workspace"))
+        tasks = _safe_list(data.get("tasks"))
+        objectives = _safe_list(data.get("objectives"))
+        lines = _safe_list(data.get("lines"))
+        freshness = _safe_mapping(envelope.get("freshness"))
+        warning_codes = {
+            _safe_code(item.get("code"))
+            for item in _safe_list(freshness.get("warnings"))
+        }
+        warning_codes.discard("REDACTED")
+        task_status_counts: dict[str, int] = {}
+        for task in tasks:
+            status = _safe_code(task.get("status"))
+            task_status_counts[status] = task_status_counts.get(status, 0) + 1
+        attention = self._workspace_attention(objectives)
+        partial = freshness.get("state") != "fresh"
+        health = "degraded" if partial else "healthy"
+        summary = {
+            "alias": safe_alias,
+            "display_name": safe_title(getattr(config, "name", workspace.get("name"))),
+            "is_default": is_default,
+            "availability": "available",
+            "health": health,
+            "freshness": "partial" if partial else "fresh",
+            "repository_count": len(getattr(config, "repositories", {})),
+            "line_count": len(lines),
+            "objective_count": len(objectives),
+            "active_objective_count": sum(
+                1 for item in objectives if item.get("operator_state") == "active"
+            ),
+            "task_count": len(tasks),
+            "task_status_counts": dict(sorted(task_status_counts.items())),
+            "attention_counts": attention["counts"],
+            "recommendation": self._recommendation(safe_alias, attention["items"]),
+            "snapshot_sha256": str(envelope.get("snapshot_sha256", "")),
+        }
+        return summary, warning_codes
+
+    @staticmethod
+    def _empty_attention_counts() -> dict[str, int]:
+        return {kind: 0 for kind in _ATTENTION_PRIORITY}
+
+    def _workspace_attention(
+        self, objectives: list[dict[str, object]]
+    ) -> dict[str, object]:
+        counts = self._empty_attention_counts()
+        items: list[dict[str, str]] = []
+        for objective in objectives:
+            objective_id = _safe_code(objective.get("id"))
+            for raw in _safe_list(objective.get("attention")):
+                kind = _safe_code(raw.get("kind"))
+                if kind not in _ATTENTION_PRIORITY:
+                    continue
+                counts[kind] += 1
+                items.append(
+                    {
+                        "objective_id": objective_id,
+                        "kind": kind,
+                        "subject_id": _safe_code(raw.get("subject_id")),
+                        "reason": _safe_code(raw.get("reason")),
+                    }
+                )
+        items.sort(
+            key=lambda item: (
+                _ATTENTION_PRIORITY[item["kind"]],
+                item["objective_id"],
+                item["subject_id"],
+                item["reason"],
+            )
+        )
+        return {"counts": counts, "items": items}
+
+    def _recommendation(
+        self, alias: str, attention: object
+    ) -> dict[str, str] | None:
+        if not isinstance(attention, list) or not attention:
+            return {"reason": "NO_ATTENTION", "command": f"dyro --workspace {alias} task next"}
+        item = attention[0]
+        if not isinstance(item, dict):
+            return None
+        objective_id = _safe_code(item.get("objective_id"))
+        return {
+            "reason": _safe_code(item.get("reason")),
+            "command": f"dyro --workspace {alias} objective explain {objective_id}",
+        }
+
+    def _attention_counts(self, summaries: list[dict[str, object]]) -> dict[str, int]:
+        counts = self._empty_attention_counts()
+        for summary in summaries:
+            for kind, value in _safe_mapping(summary.get("attention_counts")).items():
+                if kind in counts and type(value) is int and value >= 0:
+                    counts[kind] += value
+        return counts
+
+    def _highest_priority(self, summaries: list[dict[str, object]]) -> dict[str, str] | None:
+        candidates: list[tuple[int, str, dict[str, str]]] = []
+        for summary in summaries:
+            recommendation = summary.get("recommendation")
+            counts = _safe_mapping(summary.get("attention_counts"))
+            if not isinstance(recommendation, dict):
+                continue
+            for kind, priority in _ATTENTION_PRIORITY.items():
+                if counts.get(kind, 0):
+                    candidates.append(
+                        (
+                            priority,
+                            str(summary.get("alias", "")),
+                            {
+                                "alias": _safe_code(summary.get("alias")),
+                                "kind": kind,
+                                "reason": _safe_code(recommendation.get("reason")),
+                            },
+                        )
+                    )
+                    break
+        if not candidates:
+            return None
+        return min(candidates, key=lambda item: (item[0], item[1]))[2]
+
+    @staticmethod
+    def _summary_sort_key(summary: dict[str, object]) -> tuple[int, str]:
+        counts = _safe_mapping(summary.get("attention_counts"))
+        if summary.get("availability") == "unavailable" or counts.get("repair_required", 0):
+            priority = 0
+        elif counts.get("needs_user", 0):
+            priority = 1
+        elif summary.get("active_objective_count", 0) or summary.get("task_status_counts", {}).get("in_progress", 0):
+            priority = 2
+        elif counts.get("paused", 0):
+            priority = 3
+        elif counts.get("waiting", 0):
+            priority = 4
+        else:
+            priority = 5
+        return priority, str(summary.get("alias", ""))
+
+    def _encode_cursor(self, offset: int, aggregate_sha256: str) -> str:
+        body = _stable_json(
+            {
+                "schema_version": _PAGE_SCHEMA_VERSION,
+                "offset": offset,
+                "aggregate_sha256": aggregate_sha256,
+            }
+        )
+        signature = hmac.new(self._cursor_secret, body, hashlib.sha256).digest()
+        return base64.urlsafe_b64encode(body + signature).rstrip(b"=").decode("ascii")
+
+    def _decode_cursor(self, value: str, aggregate_sha256: str) -> int:
+        if not isinstance(value, str) or not value or len(value) > _CURSOR_MAX_LENGTH:
+            raise ConsoleOverviewError("OVERVIEW_CURSOR_INVALID")
+        try:
+            raw = base64.urlsafe_b64decode(value + "=" * (-len(value) % 4))
+        except (ValueError, UnicodeError):
+            raise ConsoleOverviewError("OVERVIEW_CURSOR_INVALID") from None
+        if len(raw) <= hashlib.sha256().digest_size:
+            raise ConsoleOverviewError("OVERVIEW_CURSOR_INVALID")
+        body, signature = raw[:-32], raw[-32:]
+        expected = hmac.new(self._cursor_secret, body, hashlib.sha256).digest()
+        if not hmac.compare_digest(expected, signature):
+            raise ConsoleOverviewError("OVERVIEW_CURSOR_INVALID")
+        try:
+            decoded: Any = json.loads(body.decode("utf-8"))
+        except (UnicodeDecodeError, json.JSONDecodeError):
+            raise ConsoleOverviewError("OVERVIEW_CURSOR_INVALID") from None
+        if (
+            not isinstance(decoded, dict)
+            or set(decoded) != {"schema_version", "offset", "aggregate_sha256"}
+            or decoded["schema_version"] != _PAGE_SCHEMA_VERSION
+            or type(decoded["offset"]) is not int
+            or decoded["offset"] < 0
+            or decoded["aggregate_sha256"] != aggregate_sha256
+        ):
+            raise ConsoleOverviewError("OVERVIEW_CURSOR_INVALID")
+        return decoded["offset"]

--- a/src/dyro/console/server.py
+++ b/src/dyro/console/server.py
@@ -12,6 +12,7 @@ from typing import Any
 from urllib.parse import urlsplit
 
 from .. import __version__
+from .overview import ConsoleOverviewError, ConsoleOverviewService
 from .session import ConsoleSessionStore, SessionRejected
 
 
@@ -53,10 +54,12 @@ class ConsoleHTTPServer(ThreadingHTTPServer):
         port: int,
         bootstrap_secret: str | None,
         session_store: ConsoleSessionStore | None,
+        overview_service: ConsoleOverviewService | None,
         max_concurrent_requests: int,
     ) -> None:
         self._request_slots = threading.BoundedSemaphore(max_concurrent_requests)
         self.sessions = session_store
+        self.overview_service = overview_service
         super().__init__((HOST, port), ConsoleRequestHandler)
         if self.sessions is None:
             self.sessions = ConsoleSessionStore(bootstrap_secret=bootstrap_secret)
@@ -252,7 +255,10 @@ class ConsoleRequestHandler(BaseHTTPRequestHandler):
         if not self._validate_request_envelope():
             return
         parsed = urlsplit(self.path)
-        if parsed.query or parsed.fragment or parsed.path != self.path:
+        if parsed.fragment or not parsed.path or parsed.path.startswith("//"):
+            self._error(400, "BAD_REQUEST")
+            return
+        if parsed.query and parsed.path != "/api/v1/overview":
             self._error(400, "BAD_REQUEST")
             return
         if self.command == "GET" and parsed.path == "/":
@@ -283,16 +289,75 @@ class ConsoleRequestHandler(BaseHTTPRequestHandler):
                     "schema_version": 1,
                     "data": {
                         "version": __version__,
-                        "capabilities": [],
+                        "capabilities": ["overview"] if self.console.overview_service else [],
                         "session_expires_at": session.expires_at.isoformat(),
                     },
                 },
             )
             return
+        if parsed.path == "/api/v1/overview":
+            if self.command != "GET":
+                self._method_not_allowed()
+                return
+            if self._has_body():
+                self._error(400, "BAD_REQUEST")
+                return
+            if self._authorized_session() is None:
+                return
+            self._overview(parsed.query)
+            return
         if parsed.path.startswith("/api/"):
             self._error(401, "UNAUTHORIZED")
             return
         self._error(404, "NOT_FOUND")
+
+    def _overview(self, query: str) -> None:
+        service = self.console.overview_service
+        if service is None:
+            self._error(404, "NOT_FOUND")
+            return
+        try:
+            cursor, limit = self._overview_parameters(query)
+            payload = service.page(cursor=cursor, limit=limit)
+        except ConsoleOverviewError as exc:
+            self._error(
+                400
+                if exc.code
+                in {
+                    "OVERVIEW_CURSOR_INVALID",
+                    "OVERVIEW_LIMIT_INVALID",
+                    "OVERVIEW_QUERY_INVALID",
+                }
+                else 503,
+                exc.code,
+            )
+            return
+        self._json(200, payload, etag=str(payload.get("snapshot_sha256", "")))
+
+    @staticmethod
+    def _overview_parameters(query: str) -> tuple[str | None, int]:
+        if not query:
+            return None, 20
+        values: dict[str, str] = {}
+        for segment in query.split("&"):
+            key, separator, value = segment.partition("=")
+            if (
+                not separator
+                or key not in {"cursor", "limit"}
+                or key in values
+                or not value
+            ):
+                raise ConsoleOverviewError("OVERVIEW_QUERY_INVALID")
+            values[key] = value
+        cursor = values.get("cursor")
+        if cursor is not None and (
+            len(cursor) > 512 or not re.fullmatch(r"[A-Za-z0-9_-]+", cursor)
+        ):
+            raise ConsoleOverviewError("OVERVIEW_QUERY_INVALID")
+        raw_limit = values.get("limit", "20")
+        if len(raw_limit) > 3 or not raw_limit.isdecimal():
+            raise ConsoleOverviewError("OVERVIEW_QUERY_INVALID")
+        return cursor, int(raw_limit)
 
     def _validate_request_envelope(self) -> bool:
         if len(self.raw_requestline) > REQUEST_LINE_LIMIT:
@@ -393,13 +458,29 @@ class ConsoleRequestHandler(BaseHTTPRequestHandler):
         if self._validate_request_envelope():
             self._method_not_allowed()
 
-    def _json(self, status: int, payload: object) -> None:
-        self._send(status, _json_bytes(payload), "application/json; charset=utf-8")
+    def _json(self, status: int, payload: object, *, etag: str = "") -> None:
+        if status == 200 and self._if_none_match(etag):
+            self._send(304, b"", "application/json; charset=utf-8", etag=etag)
+            return
+        self._send(
+            status,
+            _json_bytes(payload),
+            "application/json; charset=utf-8",
+            etag=etag,
+        )
 
     def _error(self, status: int, code: str) -> None:
         self._json(status, {"schema_version": 1, "error": {"code": code}})
 
-    def _send(self, status: int, body: bytes, content_type: str) -> None:
+    def _if_none_match(self, etag: str) -> bool:
+        if not re.fullmatch(r"[0-9a-f]{64}", etag):
+            return False
+        values = self.headers.get_all("If-None-Match") or []
+        return len(values) == 1 and values[0] == f'"{etag}"'
+
+    def _send(
+        self, status: int, body: bytes, content_type: str, *, etag: str = ""
+    ) -> None:
         # Every response terminates this HTTP/1.1 connection.  In particular,
         # rejected GET or unknown API requests must never leave an unread body
         # that a later handler iteration could interpret as a request line.
@@ -414,6 +495,8 @@ class ConsoleRequestHandler(BaseHTTPRequestHandler):
         self.send_header("X-Frame-Options", "DENY")
         self.send_header("Cross-Origin-Opener-Policy", "same-origin")
         self.send_header("Content-Security-Policy", _CSP)
+        if re.fullmatch(r"[0-9a-f]{64}", etag):
+            self.send_header("ETag", f'"{etag}"')
         self.end_headers()
         self.wfile.write(body)
 
@@ -423,6 +506,7 @@ def create_console_http_server(
     port: int = 0,
     bootstrap_secret: str | None = None,
     session_store: ConsoleSessionStore | None = None,
+    overview_service: ConsoleOverviewService | None = None,
     max_concurrent_requests: int = MAX_CONCURRENT_REQUESTS,
 ) -> ConsoleHTTPServer:
     """Bind a Console server to IPv4 loopback only; no host override exists."""
@@ -436,5 +520,6 @@ def create_console_http_server(
         port=port,
         bootstrap_secret=bootstrap_secret,
         session_store=session_store,
+        overview_service=overview_service,
         max_concurrent_requests=max_concurrent_requests,
     )

--- a/tests/test_console_overview.py
+++ b/tests/test_console_overview.py
@@ -1,0 +1,191 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from pathlib import Path
+from types import SimpleNamespace
+import unittest
+
+from dyro.console.overview import ConsoleOverviewError, ConsoleOverviewService
+from dyro.errors import ValidationError
+from dyro.hub import WorkspaceRecord, WorkspaceRegistry
+from dyro.observations import (
+    ObjectiveAttentionObservation,
+    WorkspaceLineObservation,
+    WorkspaceObjectiveObservation,
+    WorkspaceReadSnapshot,
+    WorkspaceTaskObservation,
+)
+
+
+def _snapshot(
+    *,
+    name: str,
+    task_status: str = "backlog",
+    attention_kind: str = "ready",
+    reason: str = "TASK_READY",
+    partial: bool = False,
+) -> WorkspaceReadSnapshot:
+    observed_at = datetime(2026, 8, 4, 12, 0, tzinfo=timezone.utc)
+    failures = ()
+    if partial:
+        from dyro.observations import ReadFailure
+
+        failures = (ReadFailure("objectives", "OBJECTIVES_UNAVAILABLE"),)
+    return WorkspaceReadSnapshot(
+        schema_version=1,
+        workspace_name=name,
+        observed_at=observed_at,
+        capture_id="capture-" + "a" * 24,
+        workspace_revision="a" * 64,
+        source_digests=(("tasks", "b" * 64),),
+        completeness="partial" if partial else "complete",
+        lines=(
+            WorkspaceLineObservation(
+                id="alpha",
+                kind="line",
+                branch="feat/alpha",
+                base="main",
+                repository_count=1,
+            ),
+        ),
+        tasks=(
+            WorkspaceTaskObservation(
+                id="TASK-A",
+                title="Safe task",
+                line="alpha",
+                status=task_status,
+                risk="write",
+                depends_on=(),
+                blocked_on=(),
+                conflict_group="",
+                executor="codex",
+                reviewer="codex",
+                integration_state="not_inspected",
+                external_claim_active=False,
+            ),
+        ),
+        objectives=(
+            WorkspaceObjectiveObservation(
+                id="release",
+                title="Safe release",
+                line="alpha",
+                revision=1,
+                operator_state="active",
+                derived_result="incomplete",
+                requested_mode="supervised",
+                operations=("execute",),
+                scope_count=1,
+                budget=(("max_actions", 2),),
+                selected_actions=(),
+                blocked_actions=(),
+                attention=(
+                    ObjectiveAttentionObservation(
+                        kind=attention_kind,
+                        subject_id="TASK-A",
+                        reason=reason,
+                    ),
+                ),
+                contract_sha256="c" * 64,
+                scope_sha256="d" * 64,
+                event_sha256="e" * 64,
+            ),
+        ),
+        failures=failures,
+    )
+
+
+class ConsoleOverviewServiceTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.alpha_root = Path("/private/alpha-workspace")
+        self.beta_root = Path("/private/beta-workspace")
+        self.broken_root = Path("/private/broken-workspace")
+        self.registry = WorkspaceRegistry(
+            default="alpha",
+            workspaces=(
+                WorkspaceRecord("alpha", self.alpha_root),
+                WorkspaceRecord("beta", self.beta_root),
+                WorkspaceRecord("broken", self.broken_root),
+            ),
+        )
+        configurations = {
+            self.alpha_root: SimpleNamespace(name="Alpha Project", repositories={"api": object()}),
+            self.beta_root: SimpleNamespace(name="Beta Project", repositories={"web": object()}),
+        }
+        snapshots = {
+            "Alpha Project": _snapshot(
+                name="Alpha Project",
+                attention_kind="needs_user",
+                reason="ANSWER_REQUIRED",
+            ),
+            "Beta Project": _snapshot(
+                name="Beta Project",
+                attention_kind="repair_required",
+                reason="ACTION_UNCERTAIN",
+                partial=True,
+            ),
+        }
+
+        def config_loader(root: Path) -> SimpleNamespace:
+            if root == self.broken_root:
+                raise ValidationError("/private/broken-workspace/dyro.toml is malformed")
+            return configurations[root]
+
+        self.service = ConsoleOverviewService(
+            registry_loader=lambda: self.registry,
+            config_loader=config_loader,
+            snapshot_loader=lambda config: snapshots[config.name],
+            clock=lambda: datetime(2026, 8, 4, 12, 5, tzinfo=timezone.utc),
+            cursor_secret=b"k" * 32,
+        )
+
+    def test_paginates_stably_prioritizes_attention_and_never_exposes_roots(self) -> None:
+        first = self.service.page(limit=1)
+
+        self.assertEqual(first["freshness"]["state"], "partial")
+        self.assertEqual(first["data"]["total_workspaces"], 3)
+        self.assertEqual(first["data"]["workspaces"][0]["alias"], "beta")
+        self.assertEqual(first["data"]["highest_priority"]["alias"], "beta")
+        self.assertEqual(first["data"]["highest_priority"]["kind"], "repair_required")
+        self.assertEqual(first["data"]["attention_counts"]["needs_user"], 1)
+        self.assertEqual(first["data"]["attention_counts"]["repair_required"], 1)
+        self.assertIn("WORKSPACE_UNAVAILABLE", first["freshness"]["warnings"][1]["code"])
+        self.assertNotIn("/private", repr(first))
+        self.assertNotIn("dyro.toml", repr(first))
+
+        second = self.service.page(cursor=first["data"]["next_cursor"], limit=1)
+        self.assertEqual(second["data"]["workspaces"][0]["alias"], "broken")
+        self.assertEqual(second["data"]["workspaces"][0]["availability"], "unavailable")
+        self.assertEqual(
+            second["data"]["workspaces"][0]["recommendation"]["command"],
+            "dyro --workspace broken doctor",
+        )
+        self.assertNotEqual(first["snapshot_sha256"], second["snapshot_sha256"])
+
+    def test_rejects_tampered_or_stale_cursor_without_falling_back_to_an_offset(self) -> None:
+        first = self.service.page(limit=1)
+        cursor = first["data"]["next_cursor"]
+        with self.assertRaisesRegex(ConsoleOverviewError, "OVERVIEW_CURSOR_INVALID"):
+            self.service.page(cursor=cursor[:-1] + "A", limit=1)
+
+        self.registry = WorkspaceRegistry(
+            default="alpha",
+            workspaces=(WorkspaceRecord("alpha", self.alpha_root),),
+        )
+        with self.assertRaisesRegex(ConsoleOverviewError, "OVERVIEW_CURSOR_INVALID"):
+            self.service.page(cursor=cursor, limit=1)
+
+    def test_registry_failure_is_stable_and_path_free(self) -> None:
+        service = ConsoleOverviewService(
+            registry_loader=lambda: (_ for _ in ()).throw(
+                ValidationError("/private/state/workspaces.json malformed")
+            ),
+            cursor_secret=b"z" * 32,
+        )
+
+        with self.assertRaisesRegex(ConsoleOverviewError, "REGISTRY_UNAVAILABLE") as raised:
+            service.page()
+        self.assertNotIn("/private", str(raised.exception))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_console_server.py
+++ b/tests/test_console_server.py
@@ -5,6 +5,7 @@ import json
 import socket
 from threading import Thread
 import unittest
+from unittest.mock import Mock
 
 from dyro.console.server import create_console_http_server
 
@@ -221,6 +222,79 @@ class ConsoleServerTests(unittest.TestCase):
         self.assertIn(b" 401 ", response)
         self.assertIn(b"Connection: close", response)
         self.assertNotIn(b"<h1>Dyro Console</h1>", response)
+
+
+class ConsoleOverviewServerTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.overview = Mock()
+        self.overview.page.return_value = {
+            "schema_version": 1,
+            "captured_at": "2026-08-04T12:00:00+00:00",
+            "snapshot_sha256": "f" * 64,
+            "freshness": {"state": "fresh", "partial": False, "warnings": []},
+            "data": {"workspaces": [], "next_cursor": None},
+        }
+        self.server = create_console_http_server(
+            port=0,
+            bootstrap_secret="a" * 43,
+            overview_service=self.overview,
+        )
+        self.thread = Thread(target=self.server.serve_forever, daemon=True)
+        self.thread.start()
+        self.port = self.server.server_port
+        self.origin = f"http://127.0.0.1:{self.port}"
+
+    def tearDown(self) -> None:
+        self.server.shutdown()
+        self.server.server_close()
+        self.thread.join(timeout=5)
+
+    def _request(
+        self, method: str, path: str, *, body: bytes | None = None, headers: dict[str, str] | None = None
+    ) -> tuple[int, dict[str, str], bytes]:
+        connection = HTTPConnection("127.0.0.1", self.port, timeout=5)
+        connection.request(method, path, body=body, headers=headers or {})
+        response = connection.getresponse()
+        result = response.status, dict(response.getheaders()), response.read()
+        connection.close()
+        return result
+
+    def _bearer(self) -> str:
+        status, _, body = self._request(
+            "POST",
+            "/api/v1/session",
+            body=json.dumps({"bootstrap": "a" * 43}).encode("utf-8"),
+            headers={"Content-Type": "application/json", "Origin": self.origin},
+        )
+        self.assertEqual(status, 201)
+        return json.loads(body)["bearer"]
+
+    def test_authenticated_overview_uses_strict_query_and_conditional_etag(self) -> None:
+        bearer = self._bearer()
+        headers = {"Authorization": f"Bearer {bearer}", "Origin": self.origin}
+
+        status, response_headers, body = self._request(
+            "GET", "/api/v1/overview?limit=1", headers=headers
+        )
+        self.assertEqual(status, 200)
+        self.assertEqual(response_headers["ETag"], '"' + "f" * 64 + '"')
+        self.assertEqual(json.loads(body)["data"]["workspaces"], [])
+        self.overview.page.assert_called_once_with(cursor=None, limit=1)
+
+        cached, cached_headers, cached_body = self._request(
+            "GET",
+            "/api/v1/overview?limit=1",
+            headers={**headers, "If-None-Match": response_headers["ETag"]},
+        )
+        self.assertEqual(cached, 304)
+        self.assertEqual(cached_headers["ETag"], response_headers["ETag"])
+        self.assertEqual(cached_body, b"")
+
+        invalid, _, body = self._request(
+            "GET", "/api/v1/overview?limit=1&limit=2", headers=headers
+        )
+        self.assertEqual(invalid, 400)
+        self.assertEqual(json.loads(body)["error"]["code"], "OVERVIEW_QUERY_INVALID")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## 摘要

- 新增多工作区只读 overview 投影：稳定 attention 排序、单工程失败隔离、安全恢复建议与摘要计数。
- 新增 bearer 保护的 GET /api/v1/overview，支持最多 100 条分页、带完整性校验的 opaque cursor 与 ETag/304。
- listener 继续不拥有 registry、Config、workspace 路径或调度判断；C04 将把读取迁移到可终止 worker。

## 验证

- uv run python -m unittest discover -s tests -t . -v
- uv run --with ruff ruff check src tests experiments
- uv run python -m compileall -q src tests experiments
- 安全复审：无 CRITICAL/HIGH；C04 前需完成慢读取 worker 隔离。