### PR TITLE
feat(控制台): 隔离工作区概览读取

### DIFF
--- a/docs/designs/local-web-console.md
+++ b/docs/designs/local-web-console.md
@@ -219,6 +219,25 @@ C03 在 listener 外新增 `ConsoleOverviewService`，把既有 registry 与每�
 - overview 的 `snapshot_sha256` 可作为 ETag 使用；同一脱敏页面带精确 `If-None-Match` 时返回
   304。C03 仍没有 CLI、浏览器、静态资源或详情 API。
 
+### 4.4 C04 已落地的 inspection 与工作区摘要契约
+
+C04 将真实工作区读取移出 HTTP 请求线程，并补齐概览的单工作区下钻入口：
+
+- `create_console_http_server()` 默认装配 `IsolatedOverviewService` IPC client。它以固定 `python -m`
+  argv、最小环境和新 session 启动 inspection process；worker 不继承 bearer、bootstrap、编码工具
+  配置或其它宿主环境值，异常 stderr 不会进入 API；
+- inspection outer worker 对单次请求施加 5 秒硬 deadline。它在内部最多运行 4 个 daemon 子进程，
+  每个 workspace 750ms；超时或崩溃只返回该 workspace 的 `unavailable`/`WORKSPACE_TIMEOUT` 卡片，
+  并在父 deadline 后终止整个 process group；
+- 当前 process-tree 回收仅在 POSIX 平台启用；Windows 在具备经验证的 Job Object 回收实现前对
+  inspection fail closed，不会以“只终止 outer process”的方式留下读取子进程；
+- worker 到 listener 只返回有大小上限的规范 JSON。父进程重新校验 schema、digest、freshness 和
+  payload 形状；无效输出、超时或 worker 失败全部 fail closed 为稳定 code；
+- `GET /api/v1/workspaces/{alias}` 需要 bearer，只接收单段安全 alias，复用同一 summary DTO 与
+  ETag。未知 alias、编码 traversal 或双段路径不会落入 workspace 读取；
+- overview 和 workspace 的 ETag 覆盖 data 以及 `freshness.state`、`partial` 和 warnings，排除仅
+  表示采样时刻的 `captured_at`，因此 warning-only 变化也会使条件请求重新获得 200。
+
 ## 5. 模块设计
 
 建议模块边界：

--- a/src/dyro/console/__init__.py
+++ b/src/dyro/console/__init__.py
@@ -1,11 +1,18 @@
 """Local Console read-side and loopback presentation boundary.
 
-The package deliberately exposes no browser launcher, subprocess execution,
-workspace mutation, or Core scheduling authority.
+The package deliberately exposes no browser launcher, arbitrary subprocess
+execution, workspace mutation, or Core scheduling authority.  Its only child
+process boundary is the fixed, read-only inspection worker.
 """
 
+from .inspection import IsolatedOverviewService
 from .overview import ConsoleOverviewService
 from .read_model import workspace_envelope
 from .server import create_console_http_server
 
-__all__ = ["ConsoleOverviewService", "create_console_http_server", "workspace_envelope"]
+__all__ = [
+    "ConsoleOverviewService",
+    "IsolatedOverviewService",
+    "create_console_http_server",
+    "workspace_envelope",
+]

--- a/src/dyro/console/_inspect_worker.py
+++ b/src/dyro/console/_inspect_worker.py
@@ -1,0 +1,303 @@
+"""Exec-only Console inspection worker.
+
+This module is never reached from an HTTP request handler by import.  The
+parent starts it with a minimal environment and a fixed module argv, so a
+blocked workspace read can be terminated as a complete process group.
+"""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import json
+from multiprocessing import get_context
+import os
+import queue
+import sys
+import time
+from typing import Any
+
+from ..config import validate_id
+from ..hub import WorkspaceRecord, WorkspaceRegistry
+from .overview import ConsoleOverviewError, ConsoleOverviewService
+
+
+_CURSOR_SECRET_ENV = "DYRO_CONSOLE_CURSOR_SECRET"
+_MAX_WORKERS = 4
+_WORKSPACE_TIMEOUT_SECONDS = 0.75
+_OVERVIEW_TIMEOUT_SECONDS = 5.0
+_WORKER_RESPONSE_LIMIT = 2 * 1024 * 1024
+
+
+def _unavailable_summary(alias: str, code: str) -> dict[str, object]:
+    return {
+        "alias": alias,
+        "display_name": alias,
+        "is_default": False,
+        "availability": "unavailable",
+        "health": "unavailable",
+        "freshness": "partial",
+        "repository_count": 0,
+        "line_count": 0,
+        "objective_count": 0,
+        "active_objective_count": 0,
+        "task_count": 0,
+        "task_status_counts": {},
+        "attention_counts": {
+            "repair_required": 0,
+            "needs_user": 0,
+            "ready": 0,
+            "paused": 0,
+            "waiting": 0,
+        },
+        "recommendation": {
+            "reason": code,
+            "command": f"dyro --workspace {alias} doctor",
+        },
+        "snapshot_sha256": "",
+    }
+
+
+def _capture_workspace_summary(
+    result_queue: Any,
+    record: WorkspaceRecord,
+    is_default: bool,
+) -> None:
+    """Capture one workspace only, returning a JSON-safe value through IPC."""
+    try:
+        registry = WorkspaceRegistry(
+            default=record.name if is_default else "",
+            workspaces=(record,),
+        )
+        service = ConsoleOverviewService(registry_loader=lambda: registry)
+        payload = service.workspace(record.name)
+        summary = payload["data"]["workspace"]
+        warnings = [item["code"] for item in payload["freshness"]["warnings"]]
+        result_queue.put({"summary": summary, "warnings": warnings})
+    except Exception:
+        result_queue.put(
+            {
+                "summary": _unavailable_summary(record.name, "WORKSPACE_UNAVAILABLE"),
+                "warnings": ["WORKSPACE_UNAVAILABLE"],
+            }
+        )
+
+
+def _parse_child_result(
+    value: object, record: WorkspaceRecord, *, is_default: bool
+) -> tuple[dict[str, object], set[str]]:
+    if not isinstance(value, dict):
+        return _unavailable_summary(record.name, "WORKSPACE_UNAVAILABLE"), {
+            "WORKSPACE_UNAVAILABLE"
+        }
+    summary = value.get("summary")
+    warnings = value.get("warnings")
+    if (
+        not isinstance(summary, dict)
+        or not isinstance(warnings, list)
+        or not all(isinstance(item, str) for item in warnings)
+    ):
+        return _unavailable_summary(record.name, "WORKSPACE_UNAVAILABLE"), {
+            "WORKSPACE_UNAVAILABLE"
+        }
+    copied = dict(summary)
+    copied["alias"] = record.name
+    copied["is_default"] = is_default
+    return copied, set(warnings)
+
+
+def _isolated_summaries(
+    registry: WorkspaceRegistry,
+    *,
+    workspace_timeout: float = _WORKSPACE_TIMEOUT_SECONDS,
+    total_timeout: float = _OVERVIEW_TIMEOUT_SECONDS,
+) -> tuple[list[dict[str, object]], set[str]]:
+    """Sample at most four workspaces concurrently in killable child processes."""
+    context = get_context("spawn")
+    pending = list(registry.workspaces)
+    running: dict[str, tuple[Any, Any, float, WorkspaceRecord]] = {}
+    summaries: list[dict[str, object]] = []
+    warnings: set[str] = set()
+    deadline = time.monotonic() + total_timeout
+
+    def finish(record: WorkspaceRecord, value: object, *, default: bool) -> None:
+        summary, codes = _parse_child_result(value, record, is_default=default)
+        summaries.append(summary)
+        warnings.update(codes)
+
+    while pending or running:
+        now = time.monotonic()
+        if now >= deadline:
+            for _, process, _, record in running.values():
+                if process.is_alive():
+                    process.terminate()
+                process.join(timeout=0.1)
+                finish(
+                    record,
+                    {
+                        "summary": _unavailable_summary(record.name, "WORKSPACE_TIMEOUT"),
+                        "warnings": ["WORKSPACE_TIMEOUT"],
+                    },
+                    default=record.name == registry.default,
+                )
+            running.clear()
+            for record in pending:
+                finish(
+                    record,
+                    {
+                        "summary": _unavailable_summary(record.name, "WORKSPACE_TIMEOUT"),
+                        "warnings": ["WORKSPACE_TIMEOUT"],
+                    },
+                    default=record.name == registry.default,
+                )
+            pending.clear()
+            break
+        while pending and len(running) < _MAX_WORKERS:
+            record = pending.pop(0)
+            result_queue = context.Queue(maxsize=1)
+            process = context.Process(
+                target=_capture_workspace_summary,
+                args=(result_queue, record, record.name == registry.default),
+                daemon=True,
+            )
+            process.start()
+            running[record.name] = (result_queue, process, now, record)
+
+        made_progress = False
+        for name, (result_queue, process, started_at, record) in tuple(running.items()):
+            value: object | None = None
+            has_value = False
+            try:
+                value = result_queue.get_nowait()
+                has_value = True
+            except queue.Empty:
+                pass
+            timed_out = time.monotonic() - started_at >= workspace_timeout
+            if has_value or not process.is_alive() or timed_out:
+                if process.is_alive():
+                    process.terminate()
+                process.join(timeout=0.1)
+                if not has_value:
+                    try:
+                        value = result_queue.get(timeout=0.05)
+                        has_value = True
+                    except queue.Empty:
+                        pass
+                if has_value:
+                    finish(record, value, default=record.name == registry.default)
+                else:
+                    code = "WORKSPACE_TIMEOUT" if timed_out else "WORKSPACE_UNAVAILABLE"
+                    finish(
+                        record,
+                        {
+                            "summary": _unavailable_summary(record.name, code),
+                            "warnings": [code],
+                        },
+                        default=record.name == registry.default,
+                    )
+                result_queue.close()
+                running.pop(name)
+                made_progress = True
+        if not made_progress:
+            time.sleep(0.01)
+    return summaries, warnings
+
+
+def _isolated_workspace(
+    service: ConsoleOverviewService, alias: str
+) -> dict[str, object]:
+    try:
+        alias = validate_id(alias, "工作区别名")
+    except Exception:
+        raise ConsoleOverviewError("WORKSPACE_ALIAS_INVALID") from None
+    registry = service._load_registry()
+    try:
+        record = next(item for item in registry.workspaces if item.name == alias)
+    except StopIteration:
+        raise ConsoleOverviewError("WORKSPACE_NOT_FOUND") from None
+    isolated_registry = WorkspaceRegistry(
+        default=record.name if record.name == registry.default else "",
+        workspaces=(record,),
+    )
+    summaries, warnings = _isolated_summaries(
+        isolated_registry,
+        total_timeout=_WORKSPACE_TIMEOUT_SECONDS,
+    )
+    if not summaries:
+        raise ConsoleOverviewError("OVERVIEW_UNAVAILABLE")
+    return service._envelope({"workspace": summaries[0]}, warnings)
+
+
+def _secret_from_environment() -> bytes:
+    raw = os.environ.get(_CURSOR_SECRET_ENV)
+    if not isinstance(raw, str):
+        raise ConsoleOverviewError("OVERVIEW_UNAVAILABLE")
+    try:
+        decoded = base64.urlsafe_b64decode(raw + "=" * (-len(raw) % 4))
+    except (ValueError, UnicodeError):
+        raise ConsoleOverviewError("OVERVIEW_UNAVAILABLE") from None
+    if len(decoded) < 32:
+        raise ConsoleOverviewError("OVERVIEW_UNAVAILABLE")
+    return decoded
+
+
+def _decode_request(value: str) -> dict[str, object]:
+    if not isinstance(value, str) or not value or len(value) > 2048:
+        raise ConsoleOverviewError("OVERVIEW_UNAVAILABLE")
+    try:
+        raw = base64.urlsafe_b64decode(value + "=" * (-len(value) % 4))
+        decoded = json.loads(raw.decode("utf-8"))
+    except (ValueError, UnicodeError, json.JSONDecodeError):
+        raise ConsoleOverviewError("OVERVIEW_UNAVAILABLE") from None
+    if not isinstance(decoded, dict) or set(decoded) - {"op", "cursor", "limit", "alias"}:
+        raise ConsoleOverviewError("OVERVIEW_UNAVAILABLE")
+    return decoded
+
+
+def _response(payload: dict[str, object] | None = None, *, code: str = "") -> int:
+    body: dict[str, object] = {"ok": not code}
+    if code:
+        body["error"] = {"code": code}
+    else:
+        body["payload"] = payload
+    encoded = json.dumps(body, ensure_ascii=False, sort_keys=True, separators=(",", ":")).encode(
+        "utf-8"
+    )
+    if len(encoded) > _WORKER_RESPONSE_LIMIT:
+        encoded = b'{"error":{"code":"OVERVIEW_UNAVAILABLE"},"ok":false}'
+    sys.stdout.buffer.write(encoded)
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(add_help=False)
+    parser.add_argument("--request")
+    args = parser.parse_args(argv)
+    try:
+        request = _decode_request(args.request)
+        service = ConsoleOverviewService(
+            cursor_secret=_secret_from_environment(),
+            summary_loader=_isolated_summaries,
+        )
+        operation = request.get("op")
+        if operation == "overview":
+            payload = service.page(
+                cursor=request.get("cursor"),
+                limit=request.get("limit", 20),
+            )
+        elif operation == "workspace":
+            alias = request.get("alias")
+            if not isinstance(alias, str):
+                raise ConsoleOverviewError("WORKSPACE_ALIAS_INVALID")
+            payload = _isolated_workspace(service, alias)
+        else:
+            raise ConsoleOverviewError("OVERVIEW_UNAVAILABLE")
+        return _response(payload)
+    except ConsoleOverviewError as exc:
+        return _response(code=exc.code)
+    except Exception:
+        return _response(code="OVERVIEW_UNAVAILABLE")
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/dyro/console/inspection.py
+++ b/src/dyro/console/inspection.py
@@ -1,0 +1,376 @@
+"""Parent-side, bounded process boundary for Console inspection."""
+
+from __future__ import annotations
+
+import base64
+from collections.abc import Mapping
+from datetime import datetime
+import hashlib
+import hmac
+import json
+import os
+from pathlib import Path
+import re
+import signal
+import subprocess
+import sys
+import tempfile
+from typing import Any
+
+from ..canonical import canonical_json_bytes
+from ..hub import registry_home
+from .overview import ConsoleOverviewError
+from .redaction import REDACTED, safe_id, safe_sha256, safe_title
+
+
+_CURSOR_SECRET_ENV = "DYRO_CONSOLE_CURSOR_SECRET"
+_WORKER_OUTPUT_LIMIT = 2 * 1024 * 1024
+_SHA256 = re.compile(r"^[0-9a-f]{64}$")
+_CURSOR = re.compile(r"^[A-Za-z0-9_-]{1,512}$")
+_WARNING_CODE = re.compile(r"^[A-Z][A-Z0-9_]{2,79}$")
+_ATTENTION_KINDS = frozenset(
+    {"repair_required", "needs_user", "ready", "paused", "waiting"}
+)
+_SUMMARY_KEYS = frozenset(
+    {
+        "alias",
+        "display_name",
+        "is_default",
+        "availability",
+        "health",
+        "freshness",
+        "repository_count",
+        "line_count",
+        "objective_count",
+        "active_objective_count",
+        "task_count",
+        "task_status_counts",
+        "attention_counts",
+        "recommendation",
+        "snapshot_sha256",
+    }
+)
+
+
+class IsolatedOverviewService:
+    """Request a whitelisted overview from a hard-terminable worker process.
+
+    The listener only retains this IPC client.  It never receives a registry
+    record or Config object, and the child receives a minimal environment with
+    no launcher, provider, or session credentials.
+    """
+
+    def __init__(
+        self,
+        *,
+        registry_state_home: Path | None = None,
+        timeout_seconds: float = 5.0,
+        cursor_secret: bytes | None = None,
+        python_executable: str | None = None,
+    ) -> None:
+        if (
+            not isinstance(timeout_seconds, (int, float))
+            or isinstance(timeout_seconds, bool)
+            or not 0.1 <= float(timeout_seconds) <= 10.0
+        ):
+            raise ValueError("Console inspection timeout 必须为 0.1 到 10 秒")
+        if cursor_secret is not None and (
+            not isinstance(cursor_secret, bytes) or len(cursor_secret) < 32
+        ):
+            raise ValueError("Console inspection cursor secret 必须至少为 256 bit")
+        self._registry_state_home = (registry_state_home or registry_home()).absolute()
+        self._timeout_seconds = float(timeout_seconds)
+        self._cursor_secret = cursor_secret or os.urandom(32)
+        self._python_executable = python_executable or sys.executable
+
+    def page(self, *, cursor: str | None = None, limit: int = 20) -> dict[str, object]:
+        return self._request({"op": "overview", "cursor": cursor, "limit": limit})
+
+    def workspace(self, alias: str) -> dict[str, object]:
+        return self._request({"op": "workspace", "alias": alias})
+
+    def _request(self, request: Mapping[str, object]) -> dict[str, object]:
+        encoded_request = base64.urlsafe_b64encode(
+            json.dumps(dict(request), sort_keys=True, separators=(",", ":")).encode("utf-8")
+        ).rstrip(b"=").decode("ascii")
+        if len(encoded_request) > 2048:
+            raise ConsoleOverviewError("OVERVIEW_UNAVAILABLE")
+        output = self._run_worker(encoded_request)
+        operation = request.get("op")
+        return self._parse_worker_output(
+            output, expected_operation=operation if isinstance(operation, str) else None
+        )
+
+    def _run_worker(self, encoded_request: str) -> bytes:
+        # Console must not claim a bounded inspection lifetime on Windows until
+        # a tested Job Object implementation can terminate the entire worker
+        # tree.  Killing only the outer process may orphan a child reader.
+        if os.name == "nt":
+            raise ConsoleOverviewError("OVERVIEW_UNAVAILABLE")
+        environment = {
+            "PATH": os.defpath,
+            "PYTHONUTF8": "1",
+            "DYRO_HOME": str(self._registry_state_home),
+            _CURSOR_SECRET_ENV: base64.urlsafe_b64encode(self._cursor_secret)
+            .rstrip(b"=")
+            .decode("ascii"),
+        }
+        try:
+            process = subprocess.Popen(
+                (
+                    self._python_executable,
+                    "-m",
+                    "dyro.console._inspect_worker",
+                    "--request",
+                    encoded_request,
+                ),
+                stdin=subprocess.DEVNULL,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.DEVNULL,
+                cwd=tempfile.gettempdir(),
+                env=environment,
+                close_fds=True,
+                start_new_session=os.name != "nt",
+            )
+            output, _ = process.communicate(timeout=self._timeout_seconds)
+        except subprocess.TimeoutExpired as exc:
+            self._terminate(process)
+            try:
+                output, _ = process.communicate(timeout=1)
+            except (OSError, subprocess.TimeoutExpired):
+                output = b""
+            del exc
+            raise ConsoleOverviewError("OVERVIEW_TIMEOUT") from None
+        except (OSError, ValueError):
+            raise ConsoleOverviewError("OVERVIEW_UNAVAILABLE") from None
+        if process.returncode != 0 or len(output) > _WORKER_OUTPUT_LIMIT:
+            raise ConsoleOverviewError("OVERVIEW_UNAVAILABLE")
+        return output
+
+    @staticmethod
+    def _terminate(process: subprocess.Popen[bytes]) -> None:
+        if os.name != "nt" and process.pid is not None:
+            try:
+                os.killpg(process.pid, signal.SIGKILL)
+                return
+            except OSError:
+                pass
+        try:
+            process.kill()
+        except OSError:
+            pass
+
+    @classmethod
+    def _parse_worker_output(
+        cls, output: bytes, *, expected_operation: str | None = None
+    ) -> dict[str, object]:
+        try:
+            decoded: Any = json.loads(output.decode("utf-8"))
+        except (UnicodeDecodeError, json.JSONDecodeError):
+            raise ConsoleOverviewError("OVERVIEW_UNAVAILABLE") from None
+        if not isinstance(decoded, dict):
+            raise ConsoleOverviewError("OVERVIEW_UNAVAILABLE")
+        if decoded.get("ok") is False:
+            if set(decoded) != {"ok", "error"}:
+                raise ConsoleOverviewError("OVERVIEW_UNAVAILABLE")
+            error = decoded.get("error")
+            code = error.get("code") if isinstance(error, dict) else None
+            if isinstance(code, str) and re.fullmatch(r"[A-Z][A-Z0-9_]{2,79}", code):
+                raise ConsoleOverviewError(code)
+            raise ConsoleOverviewError("OVERVIEW_UNAVAILABLE")
+        if decoded.get("ok") is not True:
+            raise ConsoleOverviewError("OVERVIEW_UNAVAILABLE")
+        if set(decoded) != {"ok", "payload"}:
+            raise ConsoleOverviewError("OVERVIEW_UNAVAILABLE")
+        payload = decoded.get("payload")
+        if not isinstance(payload, dict) or set(payload) - {
+            "schema_version",
+            "captured_at",
+            "snapshot_sha256",
+            "freshness",
+            "data",
+        }:
+            raise ConsoleOverviewError("OVERVIEW_UNAVAILABLE")
+        if payload.get("schema_version") != 1 or not _SHA256.fullmatch(str(payload.get("snapshot_sha256", ""))):
+            raise ConsoleOverviewError("OVERVIEW_UNAVAILABLE")
+        captured_at = payload.get("captured_at")
+        if not isinstance(captured_at, str):
+            raise ConsoleOverviewError("OVERVIEW_UNAVAILABLE")
+        try:
+            parsed_time = datetime.fromisoformat(captured_at)
+        except ValueError:
+            raise ConsoleOverviewError("OVERVIEW_UNAVAILABLE") from None
+        if parsed_time.tzinfo is None:
+            raise ConsoleOverviewError("OVERVIEW_UNAVAILABLE")
+        freshness = payload.get("freshness")
+        if (
+            not isinstance(freshness, dict)
+            or set(freshness) != {"state", "partial", "warnings"}
+            or freshness.get("state") not in {"fresh", "partial"}
+            or type(freshness.get("partial")) is not bool
+            or not isinstance(freshness.get("warnings"), list)
+            or not isinstance(payload.get("data"), dict)
+        ):
+            raise ConsoleOverviewError("OVERVIEW_UNAVAILABLE")
+        state = freshness["state"]
+        partial = freshness["partial"]
+        warnings = freshness["warnings"]
+        if partial != (state == "partial"):
+            raise ConsoleOverviewError("OVERVIEW_UNAVAILABLE")
+        warning_codes = cls._warning_codes(warnings)
+        data = dict(payload["data"])
+        cls._validate_data(data, expected_operation=expected_operation)
+        expected = hashlib.sha256(
+            canonical_json_bytes(
+                {
+                    "schema_version": 1,
+                    "freshness": {
+                        "state": state,
+                        "partial": partial,
+                        "warnings": warning_codes,
+                    },
+                    "data": data,
+                }
+            )
+        ).hexdigest()
+        if not hmac.compare_digest(expected, payload["snapshot_sha256"]):
+            raise ConsoleOverviewError("OVERVIEW_UNAVAILABLE")
+        return dict(payload)
+
+    @staticmethod
+    def _warning_codes(value: list[object]) -> list[str]:
+        codes: list[str] = []
+        for item in value:
+            if not isinstance(item, dict) or set(item) != {"code"}:
+                raise ConsoleOverviewError("OVERVIEW_UNAVAILABLE")
+            code = item.get("code")
+            if not isinstance(code, str) or not _WARNING_CODE.fullmatch(code):
+                raise ConsoleOverviewError("OVERVIEW_UNAVAILABLE")
+            codes.append(code)
+        if codes != sorted(set(codes)):
+            raise ConsoleOverviewError("OVERVIEW_UNAVAILABLE")
+        return codes
+
+    @classmethod
+    def _validate_data(
+        cls, data: dict[str, object], *, expected_operation: str | None
+    ) -> None:
+        if set(data) == {"workspace"}:
+            if expected_operation == "overview":
+                raise ConsoleOverviewError("OVERVIEW_UNAVAILABLE")
+            cls._validate_summary(data["workspace"])
+            return
+        if expected_operation == "workspace":
+            raise ConsoleOverviewError("OVERVIEW_UNAVAILABLE")
+        expected = {
+            "default_workspace",
+            "total_workspaces",
+            "workspaces",
+            "next_cursor",
+            "attention_counts",
+            "highest_priority",
+        }
+        if set(data) != expected:
+            raise ConsoleOverviewError("OVERVIEW_UNAVAILABLE")
+        default_workspace = data["default_workspace"]
+        if default_workspace != "" and not cls._safe_alias(default_workspace):
+            raise ConsoleOverviewError("OVERVIEW_UNAVAILABLE")
+        if not cls._count(data["total_workspaces"]):
+            raise ConsoleOverviewError("OVERVIEW_UNAVAILABLE")
+        workspaces = data["workspaces"]
+        if not isinstance(workspaces, list) or len(workspaces) > 100:
+            raise ConsoleOverviewError("OVERVIEW_UNAVAILABLE")
+        for item in workspaces:
+            cls._validate_summary(item)
+        next_cursor = data["next_cursor"]
+        if next_cursor is not None and (
+            not isinstance(next_cursor, str) or not _CURSOR.fullmatch(next_cursor)
+        ):
+            raise ConsoleOverviewError("OVERVIEW_UNAVAILABLE")
+        cls._validate_attention_counts(data["attention_counts"])
+        highest = data["highest_priority"]
+        if highest is not None:
+            if not isinstance(highest, dict) or set(highest) != {"alias", "kind", "reason"}:
+                raise ConsoleOverviewError("OVERVIEW_UNAVAILABLE")
+            if (
+                not cls._safe_alias(highest.get("alias"))
+                or highest.get("kind") not in _ATTENTION_KINDS
+                or not cls._safe_code(highest.get("reason"))
+            ):
+                raise ConsoleOverviewError("OVERVIEW_UNAVAILABLE")
+
+    @classmethod
+    def _validate_summary(cls, value: object) -> None:
+        if not isinstance(value, dict) or set(value) != _SUMMARY_KEYS:
+            raise ConsoleOverviewError("OVERVIEW_UNAVAILABLE")
+        alias = value.get("alias")
+        if not cls._safe_alias(alias):
+            raise ConsoleOverviewError("OVERVIEW_UNAVAILABLE")
+        display_name = value.get("display_name")
+        if display_name != REDACTED and safe_title(display_name) != display_name:
+            raise ConsoleOverviewError("OVERVIEW_UNAVAILABLE")
+        if type(value.get("is_default")) is not bool:
+            raise ConsoleOverviewError("OVERVIEW_UNAVAILABLE")
+        if value.get("availability") not in {"available", "unavailable"}:
+            raise ConsoleOverviewError("OVERVIEW_UNAVAILABLE")
+        if value.get("health") not in {"healthy", "degraded", "unavailable"}:
+            raise ConsoleOverviewError("OVERVIEW_UNAVAILABLE")
+        if value.get("freshness") not in {"fresh", "partial"}:
+            raise ConsoleOverviewError("OVERVIEW_UNAVAILABLE")
+        for key in (
+            "repository_count",
+            "line_count",
+            "objective_count",
+            "active_objective_count",
+            "task_count",
+        ):
+            if not cls._count(value.get(key)):
+                raise ConsoleOverviewError("OVERVIEW_UNAVAILABLE")
+        statuses = value.get("task_status_counts")
+        if not isinstance(statuses, dict):
+            raise ConsoleOverviewError("OVERVIEW_UNAVAILABLE")
+        for status, count in statuses.items():
+            if not cls._safe_code(status) or not cls._count(count):
+                raise ConsoleOverviewError("OVERVIEW_UNAVAILABLE")
+        cls._validate_attention_counts(value.get("attention_counts"))
+        recommendation = value.get("recommendation")
+        if not isinstance(recommendation, dict) or set(recommendation) != {"reason", "command"}:
+            raise ConsoleOverviewError("OVERVIEW_UNAVAILABLE")
+        reason = recommendation.get("reason")
+        command = recommendation.get("command")
+        if not cls._safe_code(reason) or not cls._safe_command(command, alias):
+            raise ConsoleOverviewError("OVERVIEW_UNAVAILABLE")
+        digest = value.get("snapshot_sha256")
+        if digest != "" and safe_sha256(digest) != digest:
+            raise ConsoleOverviewError("OVERVIEW_UNAVAILABLE")
+
+    @staticmethod
+    def _count(value: object) -> bool:
+        return type(value) is int and 0 <= value <= 1_000_000
+
+    @staticmethod
+    def _safe_alias(value: object) -> bool:
+        return isinstance(value, str) and safe_id(value) == value and value != REDACTED
+
+    @staticmethod
+    def _safe_code(value: object) -> bool:
+        return isinstance(value, str) and safe_id(value) == value
+
+    @staticmethod
+    def _safe_command(command: object, alias: object) -> bool:
+        if not isinstance(command, str) or not isinstance(alias, str):
+            return False
+        escaped_alias = re.escape(alias)
+        return bool(
+            re.fullmatch(
+                rf"dyro --workspace {escaped_alias} (?:doctor|task next|objective explain [A-Za-z0-9][A-Za-z0-9._-]{{0,79}})",
+                command,
+            )
+        )
+
+    @staticmethod
+    def _validate_attention_counts(value: object) -> None:
+        if not isinstance(value, dict) or set(value) != _ATTENTION_KINDS:
+            raise ConsoleOverviewError("OVERVIEW_UNAVAILABLE")
+        if not all(IsolatedOverviewService._count(item) for item in value.values()):
+            raise ConsoleOverviewError("OVERVIEW_UNAVAILABLE")

--- a/src/dyro/console/overview.py
+++ b/src/dyro/console/overview.py
@@ -19,7 +19,7 @@ import secrets
 from typing import Any
 
 from ..canonical import canonical_json_bytes
-from ..config import Config, load
+from ..config import Config, load, validate_id
 from ..errors import DyroError, ValidationError
 from ..hub import WorkspaceRegistry, load_registry
 from ..observations import WorkspaceReadSnapshot, capture_workspace_read_snapshot
@@ -87,6 +87,10 @@ class ConsoleOverviewService:
         snapshot_loader: Callable[[Config], WorkspaceReadSnapshot] = capture_workspace_read_snapshot,
         clock: Callable[[], datetime] = _utc_now,
         cursor_secret: bytes | None = None,
+        summary_loader: Callable[
+            [WorkspaceRegistry], tuple[list[dict[str, object]], set[str]]
+        ]
+        | None = None,
     ) -> None:
         if cursor_secret is not None and (
             not isinstance(cursor_secret, bytes) or len(cursor_secret) < 32
@@ -97,6 +101,7 @@ class ConsoleOverviewService:
         self._snapshot_loader = snapshot_loader
         self._clock = clock
         self._cursor_secret = cursor_secret or secrets.token_bytes(32)
+        self._summary_loader = summary_loader
 
     def page(
         self,
@@ -113,11 +118,12 @@ class ConsoleOverviewService:
         if type(limit) is not int or not 1 <= limit <= _MAX_LIMIT:
             raise ConsoleOverviewError("OVERVIEW_LIMIT_INVALID")
         registry = self._load_registry()
-        summaries, warning_codes = self._summaries(registry)
+        summaries, warning_codes = self._load_summaries(registry)
         aggregate = {
             "schema_version": _PAGE_SCHEMA_VERSION,
             "default_workspace": _safe_code(registry.default) if registry.default else "",
             "workspaces": summaries,
+            "warnings": sorted(warning_codes),
         }
         aggregate_sha256 = _sha256(aggregate)
         offset = self._decode_cursor(cursor, aggregate_sha256) if cursor else 0
@@ -139,13 +145,50 @@ class ConsoleOverviewService:
             "attention_counts": attention_counts,
             "highest_priority": self._highest_priority(summaries),
         }
+        return self._envelope(data, warning_codes)
+
+    def workspace(self, alias: str) -> dict[str, object]:
+        """Return one registered workspace summary from the shared projection."""
+        try:
+            alias = validate_id(alias, "工作区别名")
+        except ValidationError:
+            raise ConsoleOverviewError("WORKSPACE_ALIAS_INVALID") from None
+        registry = self._load_registry()
+        try:
+            record = next(item for item in registry.workspaces if item.name == alias)
+        except StopIteration:
+            raise ConsoleOverviewError("WORKSPACE_NOT_FOUND") from None
+        summary, warning_codes = self._summary(
+            record.name, record.root, record.name == registry.default
+        )
+        return self._envelope({"workspace": summary}, warning_codes)
+
+    def _envelope(
+        self, data: dict[str, object], warning_codes: set[str]
+    ) -> dict[str, object]:
         partial = bool(warning_codes)
+        freshness_state = "partial" if partial else "fresh"
+        warnings = tuple(sorted(warning_codes))
+        # ``captured_at`` is intentionally excluded: re-sampling identical
+        # facts may update its wall-clock value, while a warning-only change
+        # must still invalidate the HTTP ETag.
+        digest = _sha256(
+            {
+                "schema_version": _PAGE_SCHEMA_VERSION,
+                "freshness": {
+                    "state": freshness_state,
+                    "partial": partial,
+                    "warnings": list(warnings),
+                },
+                "data": data,
+            }
+        )
         return ConsoleEnvelope(
             captured_at=self._capture_time(),
-            snapshot_sha256=_sha256(data),
-            freshness_state="partial" if partial else "fresh",
+            snapshot_sha256=digest,
+            freshness_state=freshness_state,
             partial=partial,
-            warnings=tuple(sorted(warning_codes)),
+            warnings=warnings,
             data=data,
         ).to_payload()
 
@@ -175,6 +218,20 @@ class ConsoleOverviewService:
             warnings.update(codes)
         summaries.sort(key=self._summary_sort_key)
         return summaries, warnings
+
+    def _load_summaries(
+        self, registry: WorkspaceRegistry
+    ) -> tuple[list[dict[str, object]], set[str]]:
+        if self._summary_loader is None:
+            return self._summaries(registry)
+        summaries, warnings = self._summary_loader(registry)
+        if not isinstance(summaries, list) or not isinstance(warnings, set):
+            raise ConsoleOverviewError("OVERVIEW_UNAVAILABLE")
+        copied = [dict(item) for item in summaries if isinstance(item, dict)]
+        if len(copied) != len(summaries) or not all(isinstance(item, str) for item in warnings):
+            raise ConsoleOverviewError("OVERVIEW_UNAVAILABLE")
+        copied.sort(key=self._summary_sort_key)
+        return copied, set(warnings)
 
     def _summary(
         self, alias: str, root: Path, is_default: bool

--- a/src/dyro/console/server.py
+++ b/src/dyro/console/server.py
@@ -12,7 +12,8 @@ from typing import Any
 from urllib.parse import urlsplit
 
 from .. import __version__
-from .overview import ConsoleOverviewError, ConsoleOverviewService
+from .inspection import IsolatedOverviewService
+from .overview import ConsoleOverviewError
 from .session import ConsoleSessionStore, SessionRejected
 
 
@@ -54,12 +55,12 @@ class ConsoleHTTPServer(ThreadingHTTPServer):
         port: int,
         bootstrap_secret: str | None,
         session_store: ConsoleSessionStore | None,
-        overview_service: ConsoleOverviewService | None,
+        overview_service: IsolatedOverviewService | None,
         max_concurrent_requests: int,
     ) -> None:
         self._request_slots = threading.BoundedSemaphore(max_concurrent_requests)
         self.sessions = session_store
-        self.overview_service = overview_service
+        self.overview_service = overview_service or IsolatedOverviewService()
         super().__init__((HOST, port), ConsoleRequestHandler)
         if self.sessions is None:
             self.sessions = ConsoleSessionStore(bootstrap_secret=bootstrap_secret)
@@ -306,6 +307,17 @@ class ConsoleRequestHandler(BaseHTTPRequestHandler):
                 return
             self._overview(parsed.query)
             return
+        if parsed.path.startswith("/api/v1/workspaces/"):
+            if self.command != "GET":
+                self._method_not_allowed()
+                return
+            if self._has_body():
+                self._error(400, "BAD_REQUEST")
+                return
+            if self._authorized_session() is None:
+                return
+            self._workspace_summary(parsed.path)
+            return
         if parsed.path.startswith("/api/"):
             self._error(401, "UNAUTHORIZED")
             return
@@ -320,19 +332,38 @@ class ConsoleRequestHandler(BaseHTTPRequestHandler):
             cursor, limit = self._overview_parameters(query)
             payload = service.page(cursor=cursor, limit=limit)
         except ConsoleOverviewError as exc:
-            self._error(
-                400
-                if exc.code
-                in {
-                    "OVERVIEW_CURSOR_INVALID",
-                    "OVERVIEW_LIMIT_INVALID",
-                    "OVERVIEW_QUERY_INVALID",
-                }
-                else 503,
-                exc.code,
-            )
+            self._error(self._overview_error_status(exc.code), exc.code)
             return
         self._json(200, payload, etag=str(payload.get("snapshot_sha256", "")))
+
+    def _workspace_summary(self, path: str) -> None:
+        service = self.console.overview_service
+        if service is None:
+            self._error(404, "NOT_FOUND")
+            return
+        alias = path.removeprefix("/api/v1/workspaces/")
+        if not re.fullmatch(r"[A-Za-z0-9][A-Za-z0-9._-]{0,79}", alias):
+            self._error(400, "WORKSPACE_ALIAS_INVALID")
+            return
+        try:
+            payload = service.workspace(alias)
+        except ConsoleOverviewError as exc:
+            self._error(self._overview_error_status(exc.code), exc.code)
+            return
+        self._json(200, payload, etag=str(payload.get("snapshot_sha256", "")))
+
+    @staticmethod
+    def _overview_error_status(code: str) -> int:
+        if code in {
+            "OVERVIEW_CURSOR_INVALID",
+            "OVERVIEW_LIMIT_INVALID",
+            "OVERVIEW_QUERY_INVALID",
+            "WORKSPACE_ALIAS_INVALID",
+        }:
+            return 400
+        if code == "WORKSPACE_NOT_FOUND":
+            return 404
+        return 503
 
     @staticmethod
     def _overview_parameters(query: str) -> tuple[str | None, int]:
@@ -506,7 +537,7 @@ def create_console_http_server(
     port: int = 0,
     bootstrap_secret: str | None = None,
     session_store: ConsoleSessionStore | None = None,
-    overview_service: ConsoleOverviewService | None = None,
+    overview_service: IsolatedOverviewService | None = None,
     max_concurrent_requests: int = MAX_CONCURRENT_REQUESTS,
 ) -> ConsoleHTTPServer:
     """Bind a Console server to IPv4 loopback only; no host override exists."""

--- a/tests/test_console_inspection.py
+++ b/tests/test_console_inspection.py
@@ -1,0 +1,103 @@
+from __future__ import annotations
+
+from copy import deepcopy
+import hashlib
+import json
+import os
+from pathlib import Path
+import subprocess
+import unittest
+from unittest.mock import Mock, patch
+
+from dyro.canonical import canonical_json_bytes
+from dyro.console.inspection import IsolatedOverviewService
+from dyro.console.overview import ConsoleOverviewError
+from dyro.hub import add_workspace
+
+from .support import WorkspaceCase
+
+
+class IsolatedOverviewServiceTests(WorkspaceCase):
+    def setUp(self) -> None:
+        super().setUp()
+        self.home = self.root / "console-state"
+        self.environment = patch.dict(os.environ, {"DYRO_HOME": str(self.home)})
+        self.environment.start()
+        add_workspace(self.root, name="demo", make_default=True)
+
+    def tearDown(self) -> None:
+        self.environment.stop()
+        super().tearDown()
+
+    def test_exec_worker_returns_overview_and_single_workspace_without_root_disclosure(self) -> None:
+        service = IsolatedOverviewService(
+            registry_state_home=self.home,
+            timeout_seconds=5,
+            cursor_secret=b"q" * 32,
+        )
+
+        overview = service.page(limit=1)
+        workspace = service.workspace("demo")
+
+        self.assertEqual(overview["data"]["workspaces"][0]["alias"], "demo")
+        self.assertEqual(workspace["data"]["workspace"]["alias"], "demo")
+        self.assertNotIn(str(self.root), repr(overview))
+        self.assertNotIn(str(self.root), repr(workspace))
+
+    def test_worker_timeout_kills_its_process_group_and_returns_a_stable_code(self) -> None:
+        process = Mock(spec=subprocess.Popen)
+        process.pid = 12345
+        process.communicate.side_effect = [
+            subprocess.TimeoutExpired(["worker"], 0.1),
+            (b"", b""),
+        ]
+        service = IsolatedOverviewService(registry_state_home=Path("/tmp"))
+
+        with (
+            patch("dyro.console.inspection.subprocess.Popen", return_value=process),
+            patch("dyro.console.inspection.os.killpg") as killpg,
+            self.assertRaisesRegex(ConsoleOverviewError, "OVERVIEW_TIMEOUT"),
+        ):
+            service.page()
+
+        killpg.assert_called_once()
+
+    def test_invalid_worker_output_fails_closed_without_echoing_it(self) -> None:
+        service = IsolatedOverviewService(registry_state_home=Path("/tmp"))
+        with self.assertRaisesRegex(ConsoleOverviewError, "OVERVIEW_UNAVAILABLE") as raised:
+            service._parse_worker_output(b'{"ok":false,"error":{"code":"/private/secret"}}')
+        self.assertNotIn("private", str(raised.exception))
+        with self.assertRaisesRegex(ConsoleOverviewError, "OVERVIEW_UNAVAILABLE"):
+            service._parse_worker_output(b'{"ok":1,"payload":{}}')
+
+    def test_parent_rejects_a_digest_consistent_but_unwhitelisted_ipc_payload(self) -> None:
+        service = IsolatedOverviewService(
+            registry_state_home=self.home,
+            cursor_secret=b"q" * 32,
+        )
+        valid = service.page(limit=1)
+        for mutation in (
+            lambda payload: payload["data"]["workspaces"][0].update(
+                {"alias": "../escaped"}
+            ),
+            lambda payload: payload["freshness"].update({"raw_path": "/private/secret"}),
+        ):
+            with self.subTest(mutation=mutation):
+                payload = deepcopy(valid)
+                mutation(payload)
+                payload["snapshot_sha256"] = hashlib.sha256(
+                    canonical_json_bytes(
+                        {
+                            "schema_version": 1,
+                            "freshness": payload["freshness"],
+                            "data": payload["data"],
+                        }
+                    )
+                ).hexdigest()
+                raw = json.dumps({"ok": True, "payload": payload}).encode("utf-8")
+                with self.assertRaisesRegex(ConsoleOverviewError, "OVERVIEW_UNAVAILABLE"):
+                    service._parse_worker_output(raw, expected_operation="overview")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_console_overview.py
+++ b/tests/test_console_overview.py
@@ -24,13 +24,14 @@ def _snapshot(
     attention_kind: str = "ready",
     reason: str = "TASK_READY",
     partial: bool = False,
+    failure_code: str = "OBJECTIVES_UNAVAILABLE",
 ) -> WorkspaceReadSnapshot:
     observed_at = datetime(2026, 8, 4, 12, 0, tzinfo=timezone.utc)
     failures = ()
     if partial:
         from dyro.observations import ReadFailure
 
-        failures = (ReadFailure("objectives", "OBJECTIVES_UNAVAILABLE"),)
+        failures = (ReadFailure("objectives", failure_code),)
     return WorkspaceReadSnapshot(
         schema_version=1,
         workspace_name=name,
@@ -111,7 +112,7 @@ class ConsoleOverviewServiceTests(unittest.TestCase):
             self.alpha_root: SimpleNamespace(name="Alpha Project", repositories={"api": object()}),
             self.beta_root: SimpleNamespace(name="Beta Project", repositories={"web": object()}),
         }
-        snapshots = {
+        self.snapshots = {
             "Alpha Project": _snapshot(
                 name="Alpha Project",
                 attention_kind="needs_user",
@@ -133,7 +134,7 @@ class ConsoleOverviewServiceTests(unittest.TestCase):
         self.service = ConsoleOverviewService(
             registry_loader=lambda: self.registry,
             config_loader=config_loader,
-            snapshot_loader=lambda config: snapshots[config.name],
+            snapshot_loader=lambda config: self.snapshots[config.name],
             clock=lambda: datetime(2026, 8, 4, 12, 5, tzinfo=timezone.utc),
             cursor_secret=b"k" * 32,
         )
@@ -185,6 +186,39 @@ class ConsoleOverviewServiceTests(unittest.TestCase):
         with self.assertRaisesRegex(ConsoleOverviewError, "REGISTRY_UNAVAILABLE") as raised:
             service.page()
         self.assertNotIn("/private", str(raised.exception))
+
+    def test_warning_only_change_invalidates_the_page_etag(self) -> None:
+        first = self.service.page(limit=1)
+        self.snapshots["Beta Project"] = _snapshot(
+            name="Beta Project",
+            attention_kind="repair_required",
+            reason="ACTION_UNCERTAIN",
+            partial=True,
+            failure_code="TASKS_UNAVAILABLE",
+        )
+
+        second = self.service.page(limit=1)
+
+        first_data = dict(first["data"])
+        second_data = dict(second["data"])
+        first_cursor = first_data.pop("next_cursor")
+        second_cursor = second_data.pop("next_cursor")
+        self.assertEqual(first_data, second_data)
+        self.assertNotEqual(first_cursor, second_cursor)
+        self.assertNotEqual(first["snapshot_sha256"], second["snapshot_sha256"])
+        self.assertNotEqual(first["freshness"]["warnings"], second["freshness"]["warnings"])
+        with self.assertRaisesRegex(ConsoleOverviewError, "OVERVIEW_CURSOR_INVALID"):
+            self.service.page(cursor=first["data"]["next_cursor"], limit=1)
+
+    def test_single_workspace_reuses_the_same_summary_and_rejects_unsafe_aliases(self) -> None:
+        payload = self.service.workspace("alpha")
+
+        self.assertEqual(payload["data"]["workspace"]["alias"], "alpha")
+        self.assertNotIn("/private", repr(payload))
+        with self.assertRaisesRegex(ConsoleOverviewError, "WORKSPACE_ALIAS_INVALID"):
+            self.service.workspace("%2fprivate")
+        with self.assertRaisesRegex(ConsoleOverviewError, "WORKSPACE_NOT_FOUND"):
+            self.service.workspace("missing")
 
 
 if __name__ == "__main__":

--- a/tests/test_console_server.py
+++ b/tests/test_console_server.py
@@ -7,6 +7,7 @@ from threading import Thread
 import unittest
 from unittest.mock import Mock
 
+from dyro.console.inspection import IsolatedOverviewService
 from dyro.console.server import create_console_http_server
 
 
@@ -111,7 +112,7 @@ class ConsoleServerTests(unittest.TestCase):
         self.assertEqual(headers["Content-Type"], "application/json; charset=utf-8")
         payload = json.loads(body)
         self.assertEqual(payload["schema_version"], 1)
-        self.assertEqual(payload["data"]["capabilities"], [])
+        self.assertEqual(payload["data"]["capabilities"], ["overview"])
         self.assertIn("session_expires_at", payload["data"])
 
     def test_api_refuses_cors_preflight_mutations_and_invalid_request_framing(self) -> None:
@@ -140,6 +141,7 @@ class ConsoleServerTests(unittest.TestCase):
 
     def test_server_uses_loopback_only_and_rejects_invalid_ports(self) -> None:
         self.assertEqual(self.server.server_address[0], "127.0.0.1")
+        self.assertIsInstance(self.server.overview_service, IsolatedOverviewService)
         with self.assertRaises(ValueError):
             create_console_http_server(port=-1)
         with self.assertRaises(ValueError):
@@ -234,6 +236,13 @@ class ConsoleOverviewServerTests(unittest.TestCase):
             "freshness": {"state": "fresh", "partial": False, "warnings": []},
             "data": {"workspaces": [], "next_cursor": None},
         }
+        self.overview.workspace.return_value = {
+            "schema_version": 1,
+            "captured_at": "2026-08-04T12:00:00+00:00",
+            "snapshot_sha256": "e" * 64,
+            "freshness": {"state": "partial", "partial": True, "warnings": []},
+            "data": {"workspace": {"alias": "alpha", "availability": "available"}},
+        }
         self.server = create_console_http_server(
             port=0,
             bootstrap_secret="a" * 43,
@@ -295,6 +304,26 @@ class ConsoleOverviewServerTests(unittest.TestCase):
         )
         self.assertEqual(invalid, 400)
         self.assertEqual(json.loads(body)["error"]["code"], "OVERVIEW_QUERY_INVALID")
+
+    def test_workspace_summary_is_authenticated_alias_only_and_cacheable(self) -> None:
+        bearer = self._bearer()
+        headers = {"Authorization": f"Bearer {bearer}", "Origin": self.origin}
+
+        status, response_headers, body = self._request(
+            "GET", "/api/v1/workspaces/alpha", headers=headers
+        )
+        self.assertEqual(status, 200)
+        self.assertEqual(response_headers["ETag"], '"' + "e" * 64 + '"')
+        self.assertEqual(json.loads(body)["data"]["workspace"]["alias"], "alpha")
+        self.overview.workspace.assert_called_once_with("alpha")
+
+        unsafe, _, unsafe_body = self._request(
+            "GET", "/api/v1/workspaces/%2fprivate", headers=headers
+        )
+        self.assertEqual(unsafe, 400)
+        self.assertEqual(
+            json.loads(unsafe_body)["error"]["code"], "WORKSPACE_ALIAS_INVALID"
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## 内容
- 将 HTTP Console 默认读取路径切换为受限的 inspection 子进程。
- 新增安全的单工作区概览 API，并让 warnings 纳入 cursor 与 ETag 连续性。
- 对 IPC 结果执行严格 schema、DTO、摘要和脱敏校验；POSIX 回收整个进程组，Windows 暂时 fail closed。

## 验证
- 445 项 unittest 通过
- Ruff、compileall、git diff --check 通过
- 在源码树外安装构建 wheel 后完成导入验证
- 两轮独立安全复审通过