### PR TITLE
feat(控制台): 添加本地启动入口

### DIFF
--- a/docs/designs/local-web-console.md
+++ b/docs/designs/local-web-console.md
@@ -238,6 +238,22 @@ C04 将真实工作区读取移出 HTTP 请求线程，并补齐概览的单工�
 - overview 和 workspace 的 ETag 覆盖 data 以及 `freshness.state`、`partial` 和 warnings，排除仅
   表示采样时刻的 `captured_at`，因此 warning-only 变化也会使条件请求重新获得 200。
 
+### 4.5 C05 已落地的 Console 启动与浏览器交接
+
+C05 提供前台入口 `dyro console [--no-open] [--port PORT]`，但不增加任何浏览器写能力：
+
+- listener 仍只能绑定 `127.0.0.1`，默认端口为 `0`，没有 `--host` 选项；启动器只会把固定的
+  Console server factory 与只读 `IsolatedOverviewService` 组合起来；
+- listener 就绪后，CLI 仅将一次性 bootstrap secret 放入浏览器 fragment。自动打开成功时，终端
+  只显示不含 secret 的 origin；`--no-open` 或浏览器打开失败才打印完整的、单次且 60 秒有效的
+  手工 URL；
+- `Ctrl-C` 或任意前台返回路径都会关闭 listener，并清空内存 session；`--dry-run` 仅输出
+  `127.0.0.1:<port>`、焦点和浏览器计划，绝不 bind、生成 secret、读写 recent state 或打开浏览器；
+- `--workspace` 只写入认证后可见的初始焦点，不减少或增加 registry 可读取的工作区；`--root`
+  先验证 Profile，再将该 root 作为临时的单 workspace 只读 inspection 目标，不登记到全局 registry；
+- bare `dyro` Home 新增“查看全部项目控制台”。它复用当前已登记工作区作为初始焦点，且 Home 的
+  dry-run 会保留零副作用；需要不登记某个 Profile 时，应显式使用 `dyro --root PATH console`。
+
 ## 5. 模块设计
 
 建议模块边界：

--- a/src/dyro/cli.py
+++ b/src/dyro/cli.py
@@ -22,6 +22,7 @@ from .blueprint import (
 )
 from .changesets import create_changeset, get_changeset, list_changesets, verify_changeset
 from .config import CONFIG_NAME, Config, load, validate_id
+from .console.launcher import launch_console, render_console_plan
 from .continuation.attention import (
     build_attention_projection,
     render_attention_json,
@@ -650,6 +651,33 @@ def cmd_home(args: argparse.Namespace) -> None:
         root=getattr(args, "root", None),
         workspace=getattr(args, "workspace_alias", None),
         dry_run=args.dry_run,
+    )
+
+
+def cmd_console(args: argparse.Namespace) -> None:
+    initial_workspace = getattr(args, "workspace_alias", None)
+    root_arg = getattr(args, "root", None)
+    target_root: Path | None = None
+    if args.dry_run:
+        target_root = Path(root_arg).expanduser().absolute() if root_arg else None
+        render_console_plan(
+            port=args.port,
+            no_open=args.no_open,
+            initial_workspace=initial_workspace,
+            target_root=target_root,
+        )
+        return
+    if root_arg:
+        config = load(Path(root_arg).expanduser())
+        target_root = config.root
+        initial_workspace = config.name
+    elif initial_workspace:
+        get_workspace(initial_workspace)
+    launch_console(
+        port=args.port,
+        no_open=args.no_open,
+        initial_workspace=initial_workspace,
+        target_root=target_root,
     )
 
 
@@ -2101,6 +2129,10 @@ def build_parser() -> argparse.ArgumentParser:
     setup.set_defaults(func=cmd_setup)
 
     sub.add_parser("home", help="打开当前或默认项目首页").set_defaults(func=cmd_home)
+    console = sub.add_parser("console", help="启动只读本地项目控制台")
+    console.add_argument("--no-open", action="store_true", help="不自动打开浏览器，打印一次性本地 URL")
+    console.add_argument("--port", type=int, default=0, help="loopback 端口；默认 0 由系统分配")
+    console.set_defaults(func=cmd_console)
     workspace = sub.add_parser("workspace", help="管理可从任意目录进入的全局工作区")
     workspace_sub = workspace.add_subparsers(dest="workspace_command", required=True)
     workspace_add = workspace_sub.add_parser("add", help="登记已有 Dyro 工作区")

--- a/src/dyro/console/__init__.py
+++ b/src/dyro/console/__init__.py
@@ -6,6 +6,7 @@ process boundary is the fixed, read-only inspection worker.
 """
 
 from .inspection import IsolatedOverviewService
+from .launcher import launch_console
 from .overview import ConsoleOverviewService
 from .read_model import workspace_envelope
 from .server import create_console_http_server
@@ -14,5 +15,6 @@ __all__ = [
     "ConsoleOverviewService",
     "IsolatedOverviewService",
     "create_console_http_server",
+    "launch_console",
     "workspace_envelope",
 ]

--- a/src/dyro/console/_inspect_worker.py
+++ b/src/dyro/console/_inspect_worker.py
@@ -12,12 +12,13 @@ import base64
 import json
 from multiprocessing import get_context
 import os
+from pathlib import Path
 import queue
 import sys
 import time
 from typing import Any
 
-from ..config import validate_id
+from ..config import load, validate_id
 from ..hub import WorkspaceRecord, WorkspaceRegistry
 from .overview import ConsoleOverviewError, ConsoleOverviewService
 
@@ -249,9 +250,34 @@ def _decode_request(value: str) -> dict[str, object]:
         decoded = json.loads(raw.decode("utf-8"))
     except (ValueError, UnicodeError, json.JSONDecodeError):
         raise ConsoleOverviewError("OVERVIEW_UNAVAILABLE") from None
-    if not isinstance(decoded, dict) or set(decoded) - {"op", "cursor", "limit", "alias"}:
+    if not isinstance(decoded, dict) or set(decoded) - {
+        "op",
+        "cursor",
+        "limit",
+        "alias",
+        "target_root",
+    }:
         raise ConsoleOverviewError("OVERVIEW_UNAVAILABLE")
     return decoded
+
+
+def _target_registry(request: dict[str, object]) -> WorkspaceRegistry | None:
+    raw_root = request.get("target_root")
+    if raw_root is None:
+        return None
+    if not isinstance(raw_root, str) or not raw_root or len(raw_root) > 4096:
+        raise ConsoleOverviewError("OVERVIEW_UNAVAILABLE")
+    root = Path(raw_root)
+    if not root.is_absolute():
+        raise ConsoleOverviewError("OVERVIEW_UNAVAILABLE")
+    try:
+        config = load(root)
+    except Exception:
+        raise ConsoleOverviewError("OVERVIEW_UNAVAILABLE") from None
+    return WorkspaceRegistry(
+        default=config.name,
+        workspaces=(WorkspaceRecord(name=config.name, root=config.root),),
+    )
 
 
 def _response(payload: dict[str, object] | None = None, *, code: str = "") -> int:
@@ -275,10 +301,14 @@ def main(argv: list[str] | None = None) -> int:
     args = parser.parse_args(argv)
     try:
         request = _decode_request(args.request)
-        service = ConsoleOverviewService(
-            cursor_secret=_secret_from_environment(),
-            summary_loader=_isolated_summaries,
-        )
+        target_registry = _target_registry(request)
+        service_arguments: dict[str, object] = {
+            "cursor_secret": _secret_from_environment(),
+            "summary_loader": _isolated_summaries,
+        }
+        if target_registry is not None:
+            service_arguments["registry_loader"] = lambda: target_registry
+        service = ConsoleOverviewService(**service_arguments)
         operation = request.get("op")
         if operation == "overview":
             payload = service.page(

--- a/src/dyro/console/inspection.py
+++ b/src/dyro/console/inspection.py
@@ -67,6 +67,7 @@ class IsolatedOverviewService:
         timeout_seconds: float = 5.0,
         cursor_secret: bytes | None = None,
         python_executable: str | None = None,
+        target_root: Path | None = None,
     ) -> None:
         if (
             not isinstance(timeout_seconds, (int, float))
@@ -82,6 +83,14 @@ class IsolatedOverviewService:
         self._timeout_seconds = float(timeout_seconds)
         self._cursor_secret = cursor_secret or os.urandom(32)
         self._python_executable = python_executable or sys.executable
+        if target_root is not None and not isinstance(target_root, Path):
+            raise ValueError("Console target_root 必须是 Path")
+        self._target_root = target_root.absolute() if target_root is not None else None
+
+    @property
+    def target_root(self) -> Path | None:
+        """The transient, read-only Profile root selected by ``--root``."""
+        return self._target_root
 
     def page(self, *, cursor: str | None = None, limit: int = 20) -> dict[str, object]:
         return self._request({"op": "overview", "cursor": cursor, "limit": limit})
@@ -90,8 +99,11 @@ class IsolatedOverviewService:
         return self._request({"op": "workspace", "alias": alias})
 
     def _request(self, request: Mapping[str, object]) -> dict[str, object]:
+        worker_request = dict(request)
+        if self._target_root is not None:
+            worker_request["target_root"] = str(self._target_root)
         encoded_request = base64.urlsafe_b64encode(
-            json.dumps(dict(request), sort_keys=True, separators=(",", ":")).encode("utf-8")
+            json.dumps(worker_request, sort_keys=True, separators=(",", ":")).encode("utf-8")
         ).rstrip(b"=").decode("ascii")
         if len(encoded_request) > 2048:
             raise ConsoleOverviewError("OVERVIEW_UNAVAILABLE")

--- a/src/dyro/console/launcher.py
+++ b/src/dyro/console/launcher.py
@@ -1,0 +1,126 @@
+"""Foreground lifecycle for the local, read-only Console."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from pathlib import Path
+import webbrowser
+
+from ..config import validate_id
+from ..errors import DyroError, ValidationError
+from .inspection import IsolatedOverviewService
+from .server import ConsoleHTTPServer, create_console_http_server
+
+
+BrowserOpen = Callable[[str], bool | None]
+ServerFactory = Callable[..., ConsoleHTTPServer]
+Serve = Callable[[ConsoleHTTPServer], None]
+
+
+def _validate_port(port: int) -> None:
+    if type(port) is not int or not 0 <= port <= 65535:
+        raise DyroError("Console port 必须是 0 到 65535 之间的整数")
+
+
+def _validate_workspace(alias: str | None) -> str | None:
+    if alias is None:
+        return None
+    try:
+        return validate_id(alias, "工作区别名")
+    except ValidationError:
+        raise DyroError("Console 工作区别名无效") from None
+
+
+def _bootstrap_url(server: ConsoleHTTPServer, initial_workspace: str | None) -> str:
+    # Both values are URL-safe tokens.  The secret remains in the fragment so
+    # it is never sent in an HTTP request, Referer header, or server log.
+    fragment = f"bootstrap={server.sessions.bootstrap_secret}"
+    if initial_workspace:
+        fragment += f"&workspace={initial_workspace}"
+    return f"{server.origin}/#{fragment}"
+
+
+def render_console_plan(
+    *,
+    port: int,
+    no_open: bool,
+    initial_workspace: str | None,
+    target_root: Path | None,
+) -> None:
+    """Print the all-read-only plan used by ``dyro --dry-run console``."""
+    _validate_port(port)
+    initial_workspace = _validate_workspace(initial_workspace)
+    print("DRY RUN: 将启动只读本地 Console；未 bind、未生成 secret、未打开浏览器。")
+    print(f"监听：127.0.0.1:{port}")
+    if target_root is not None:
+        print(f"临时只读工作区：{target_root.absolute()}")
+    elif initial_workspace:
+        print(f"初始焦点：{initial_workspace}")
+    else:
+        print("初始焦点：当前或默认工作区")
+    print("浏览器：不自动打开" if no_open else "浏览器：就绪后自动打开一次性 fragment URL")
+
+
+def _serve_forever(server: ConsoleHTTPServer) -> None:
+    server.serve_forever(poll_interval=0.2)
+
+
+def launch_console(
+    *,
+    port: int = 0,
+    no_open: bool = False,
+    initial_workspace: str | None = None,
+    target_root: Path | None = None,
+    browser_open: BrowserOpen = webbrowser.open,
+    server_factory: ServerFactory = create_console_http_server,
+    serve: Serve = _serve_forever,
+) -> None:
+    """Run the bounded Console server in the foreground until Ctrl-C.
+
+    This is deliberately the only Console component allowed to open a browser.
+    It passes a one-time bootstrap secret through a URL fragment, never through
+    a query string or terminal output after automatic opening succeeds.
+    """
+    _validate_port(port)
+    initial_workspace = _validate_workspace(initial_workspace)
+    if not isinstance(no_open, bool):
+        raise DyroError("Console --no-open 参数无效")
+    if target_root is not None and not isinstance(target_root, Path):
+        raise DyroError("Console 临时工作区路径无效")
+    service = (
+        IsolatedOverviewService(target_root=target_root.absolute())
+        if target_root is not None
+        else None
+    )
+    try:
+        server = server_factory(
+            port=port,
+            overview_service=service,
+            initial_workspace=initial_workspace,
+        )
+    except (OSError, ValueError):
+        raise DyroError("Console 无法启动本地 loopback listener") from None
+    try:
+        url = _bootstrap_url(server, initial_workspace)
+        if no_open:
+            print("Console 已就绪。以下 URL 单次可用，并在 60 秒后失效：")
+            print(url)
+        else:
+            try:
+                opened = browser_open(url)
+            except Exception:
+                opened = False
+            if opened is False:
+                print("无法自动打开浏览器。以下 URL 单次可用，并在 60 秒后失效：")
+                print(url)
+            else:
+                print(f"Console 已在 {server.origin} 打开；按 Ctrl-C 停止。")
+        try:
+            serve(server)
+        except KeyboardInterrupt:
+            print("Console 已停止。")
+    finally:
+        try:
+            server.shutdown()
+        finally:
+            server.server_close()

--- a/src/dyro/console/server.py
+++ b/src/dyro/console/server.py
@@ -56,11 +56,17 @@ class ConsoleHTTPServer(ThreadingHTTPServer):
         bootstrap_secret: str | None,
         session_store: ConsoleSessionStore | None,
         overview_service: IsolatedOverviewService | None,
+        initial_workspace: str | None,
         max_concurrent_requests: int,
     ) -> None:
         self._request_slots = threading.BoundedSemaphore(max_concurrent_requests)
         self.sessions = session_store
         self.overview_service = overview_service or IsolatedOverviewService()
+        if initial_workspace is not None and not re.fullmatch(
+            r"[A-Za-z0-9][A-Za-z0-9._-]{0,79}", initial_workspace
+        ):
+            raise ValueError("Console initial_workspace 无效")
+        self.initial_workspace = initial_workspace or ""
         super().__init__((HOST, port), ConsoleRequestHandler)
         if self.sessions is None:
             self.sessions = ConsoleSessionStore(bootstrap_secret=bootstrap_secret)
@@ -291,6 +297,7 @@ class ConsoleRequestHandler(BaseHTTPRequestHandler):
                     "data": {
                         "version": __version__,
                         "capabilities": ["overview"] if self.console.overview_service else [],
+                        "initial_workspace": self.console.initial_workspace,
                         "session_expires_at": session.expires_at.isoformat(),
                     },
                 },
@@ -538,6 +545,7 @@ def create_console_http_server(
     bootstrap_secret: str | None = None,
     session_store: ConsoleSessionStore | None = None,
     overview_service: IsolatedOverviewService | None = None,
+    initial_workspace: str | None = None,
     max_concurrent_requests: int = MAX_CONCURRENT_REQUESTS,
 ) -> ConsoleHTTPServer:
     """Bind a Console server to IPv4 loopback only; no host override exists."""
@@ -552,5 +560,6 @@ def create_console_http_server(
         bootstrap_secret=bootstrap_secret,
         session_store=session_store,
         overview_service=overview_service,
+        initial_workspace=initial_workspace,
         max_concurrent_requests=max_concurrent_requests,
     )

--- a/src/dyro/home.py
+++ b/src/dyro/home.py
@@ -664,7 +664,9 @@ def _choose_action(
         print(f"  {index}) {target.label}")
     status_index = len(targets) + 1
     print(f"  {status_index}) 查看当前项目状态")
-    switch_index = status_index + 1
+    console_index = status_index + 1
+    print(f"  {console_index}) 查看全部项目控制台")
+    switch_index = console_index + 1
     if can_switch:
         print(f"  {switch_index}) 切换项目")
     print("  q) 退出")
@@ -685,6 +687,8 @@ def _choose_action(
         return target.kind, target.id
     if selected == status_index:
         return "status", ""
+    if selected == console_index:
+        return "console", ""
     if can_switch and selected == switch_index:
         return "switch", ""
     raise DyroError("菜单编号超出范围")
@@ -877,6 +881,24 @@ def _run_config_home(
     kind, target_id = action
     if kind == "status":
         print_status(config)
+        return
+    if kind == "console":
+        from .console.launcher import launch_console, render_console_plan
+
+        initial_workspace = record.name if record else config.name
+        target_root = None if record else config.root
+        if dry_run:
+            render_console_plan(
+                port=0,
+                no_open=False,
+                initial_workspace=initial_workspace,
+                target_root=target_root,
+            )
+        else:
+            launch_console(
+                initial_workspace=initial_workspace,
+                target_root=target_root,
+            )
         return
     if kind == "switch":
         _switch_workspace(dry_run)

--- a/tests/test_console_inspection.py
+++ b/tests/test_console_inspection.py
@@ -44,6 +44,21 @@ class IsolatedOverviewServiceTests(WorkspaceCase):
         self.assertNotIn(str(self.root), repr(overview))
         self.assertNotIn(str(self.root), repr(workspace))
 
+    def test_temporary_root_is_read_without_registering_it_globally(self) -> None:
+        service = IsolatedOverviewService(
+            registry_state_home=self.root / "unrelated-state",
+            timeout_seconds=5,
+            cursor_secret=b"q" * 32,
+            target_root=self.root,
+        )
+
+        overview = service.page(limit=20)
+
+        self.assertEqual(overview["data"]["default_workspace"], "test-workspace")
+        self.assertEqual(overview["data"]["total_workspaces"], 1)
+        self.assertEqual(overview["data"]["workspaces"][0]["alias"], "test-workspace")
+        self.assertNotIn(str(self.root), repr(overview))
+
     def test_worker_timeout_kills_its_process_group_and_returns_a_stable_code(self) -> None:
         process = Mock(spec=subprocess.Popen)
         process.pid = 12345

--- a/tests/test_console_launcher.py
+++ b/tests/test_console_launcher.py
@@ -1,0 +1,115 @@
+from __future__ import annotations
+
+from contextlib import redirect_stdout
+from io import StringIO
+from pathlib import Path
+import unittest
+from unittest.mock import Mock, patch
+
+from dyro.cli import main
+from dyro.console.launcher import launch_console
+from dyro.errors import DyroError
+
+
+class _SessionStore:
+    bootstrap_secret = "a" * 43
+
+
+class _Server:
+    origin = "http://127.0.0.1:43123"
+
+    def __init__(self) -> None:
+        self.sessions = _SessionStore()
+        self.closed = False
+
+    def shutdown(self) -> None:
+        return
+
+    def server_close(self) -> None:
+        self.closed = True
+
+
+class ConsoleLauncherTests(unittest.TestCase):
+    def _launch(
+        self,
+        *,
+        no_open: bool = False,
+        browser_result: bool = True,
+        initial_workspace: str | None = None,
+        target_root: Path | None = None,
+    ) -> tuple[_Server, str, Mock, Mock]:
+        server = _Server()
+        factory = Mock(return_value=server)
+        browser = Mock(return_value=browser_result)
+        output = StringIO()
+        with redirect_stdout(output):
+            launch_console(
+                port=0,
+                no_open=no_open,
+                initial_workspace=initial_workspace,
+                target_root=target_root,
+                browser_open=browser,
+                server_factory=factory,
+                serve=lambda _: None,
+            )
+        return server, output.getvalue(), factory, browser
+
+    def test_auto_open_keeps_bootstrap_secret_out_of_terminal_output(self) -> None:
+        server, output, factory, browser = self._launch(initial_workspace="demo")
+
+        self.assertTrue(server.closed)
+        self.assertEqual(factory.call_args.kwargs["port"], 0)
+        self.assertEqual(factory.call_args.kwargs["initial_workspace"], "demo")
+        self.assertEqual(
+            browser.call_args.args[0],
+            "http://127.0.0.1:43123/#bootstrap=" + "a" * 43 + "&workspace=demo",
+        )
+        self.assertNotIn("a" * 43, output)
+        self.assertIn("127.0.0.1:43123", output)
+
+    def test_no_open_prints_the_one_time_fragment_url(self) -> None:
+        _, output, factory, browser = self._launch(no_open=True)
+
+        self.assertIn("#bootstrap=" + "a" * 43, output)
+        self.assertIn("单次", output)
+        self.assertFalse(factory.call_args is None)
+        browser.assert_not_called()
+
+    def test_failed_browser_open_prints_manual_recovery_url(self) -> None:
+        _, output, _, _ = self._launch(browser_result=False)
+
+        self.assertIn("无法自动打开浏览器", output)
+        self.assertIn("#bootstrap=" + "a" * 43, output)
+
+    def test_temporary_root_is_composed_into_the_read_only_service(self) -> None:
+        root = Path("/tmp/console-target")
+        _, _, factory, _ = self._launch(target_root=root)
+
+        service = factory.call_args.kwargs["overview_service"]
+        self.assertEqual(service.target_root, root.absolute())
+
+    def test_listener_start_failure_is_sanitized(self) -> None:
+        with self.assertRaisesRegex(DyroError, "无法启动本地 loopback listener") as raised:
+            launch_console(
+                server_factory=Mock(side_effect=OSError("/private/secret")),
+                serve=lambda _: None,
+            )
+        self.assertNotIn("private", str(raised.exception))
+
+    def test_dry_run_neither_binds_nor_opens_a_browser(self) -> None:
+        output = StringIO()
+        with (
+            patch("dyro.console.launcher.create_console_http_server") as server_factory,
+            patch("dyro.console.launcher.webbrowser.open") as browser_open,
+            redirect_stdout(output),
+        ):
+            main(["--dry-run", "console", "--no-open"])
+
+        self.assertIn("DRY RUN", output.getvalue())
+        self.assertIn("127.0.0.1:0", output.getvalue())
+        server_factory.assert_not_called()
+        browser_open.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_console_server.py
+++ b/tests/test_console_server.py
@@ -113,6 +113,7 @@ class ConsoleServerTests(unittest.TestCase):
         payload = json.loads(body)
         self.assertEqual(payload["schema_version"], 1)
         self.assertEqual(payload["data"]["capabilities"], ["overview"])
+        self.assertEqual(payload["data"]["initial_workspace"], "")
         self.assertIn("session_expires_at", payload["data"])
 
     def test_api_refuses_cors_preflight_mutations_and_invalid_request_framing(self) -> None:

--- a/tests/test_hub.py
+++ b/tests/test_hub.py
@@ -189,6 +189,21 @@ class HubCliTests(WorkspaceCase):
         self.assertIn("/usr/bin/true", rendered)
         self.assertEqual(load_registry().workspaces[0].last_target, "")
 
+    def test_home_console_choice_honors_dry_run(self) -> None:
+        self._create_line()
+        add_workspace(self.root, name="demo", make_default=True)
+        output = StringIO()
+        with (
+            patch("dyro.home.interactive_terminal", return_value=True),
+            patch("builtins.input", return_value="3"),
+            patch("dyro.console.launcher.create_console_http_server") as server_factory,
+            redirect_stdout(output),
+        ):
+            main(["--dry-run"])
+
+        self.assertIn("DRY RUN: 将启动只读本地 Console", output.getvalue())
+        server_factory.assert_not_called()
+
     def test_home_can_open_a_detected_tool_without_granting_adapter_capabilities(
         self,
     ) -> None:


### PR DESCRIPTION
## 内容
- 新增 dyro console 前台入口：固定 loopback、随机端口、一次性 fragment 会话交接与浏览器失败回退。
- 支持 --no-open、--port、--workspace 初始焦点，以及不登记全局状态的 --root 临时只读目标。
- Home 新增查看全部项目控制台，并保持 dry-run 零副作用。

## 验证
- 453 项 unittest 通过
- Ruff、compileall、git diff --check 与术语扫描通过
- 构建 wheel 后在源码树外安装并验证 dyro --dry-run console --no-open
- 独立安全复审通过