### PR TITLE
chore(发布): 准备 0.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,24 @@
 # Changelog
 
+## 0.6.0 - 2026-08-04
+
+- Add the native, local-first Continuation engine: versioned Objectives have
+  explicit ownership, deterministic planning, bounded scheduling waves,
+  budgets, triggers, attention projection, action journals, and supervised
+  execution. It remains opt-in and explicitly confirmed, uses the existing
+  Task execution and review APIs, and never bypasses the established review,
+  sign-off, merge, or push boundaries.
+- Add `dyro console`, a read-only local Web Console for registered workspaces.
+  It binds only to loopback, exchanges a one-time browser fragment secret for a
+  tab-scoped session, and shows health, attention, Task status, active
+  Objectives, and safe next CLI commands without browser-initiated Core or
+  project mutations and without external service access.
+- Package the Console's fixed static resources in both wheel and sdist,
+  validate their digest manifest before listening, and verify those resources
+  from clean installed artifacts in CI and the release workflow.
+- Harden execution identity, terminology policy scanning, signed evidence, and
+  control-state handling for the new supervised surfaces.
+
 ## 0.5.6 - 2026-08-03
 
 - Check the official PyPI endpoint at most once per local day on interactive

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "dyro"
-version = "0.5.6"
+version = "0.6.0"
 description = "DyroEngineeringFlow: local-first automation and delivery control for multi-repository teams"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/uv.lock
+++ b/uv.lock
@@ -282,7 +282,7 @@ wheels = [
 
 [[package]]
 name = "dyro"
-version = "0.5.6"
+version = "0.6.0"
 source = { editable = "." }
 dependencies = [
     { name = "cryptography" },


### PR DESCRIPTION
## 发布候选
- 版本：`0.6.0`；发布日期：2026-08-04。
- 覆盖已合入的 Native Continuation（明确确认、既有审查边界）与只读 loopback Web Console。
- `uv.lock` 仅同步项目自身版本，无依赖解析变更。

## 发布前验证
- PyPI `dyro 0.6.0` endpoint 返回 404，版本未被占用。
- `uv lock --check` 通过。
- `DYRO_RELEASE_TAG=v0.6.0 uv run python -m unittest discover -s tests -t . -q`：456 项通过。
- Ruff、compileall、`node --check` 与 `git diff --check` 通过。
- wheel/sdist 均通过 `twine check --strict`；从隔离环境安装后 `dyro --version` 为 `0.6.0`，并通过 Console 静态资源验证。

## 复核
- 发布元数据独立复核已通过；范围与控制权边界已校准。

合并后仍须单独执行 tag、GitHub Release、工作流和 PyPI 发布门禁。