### PR TITLE
feat: 优化 Dyro 引导、编码工具与 Console 体验

### DIFF
--- a/README.md
+++ b/README.md
@@ -397,7 +397,8 @@ on the local machine are labeled `open workspace only` and receive no gate,
 review, merge, or push authority. Explicit commands such as
 `dyro open dev --agent codex` continue to launch directly for scripts.
 
-The picker detects Cursor Desktop separately from Cursor CLI, supports
+The picker detects Codex App and Claude Code Desktop separately from their
+CLI counterparts, detects Cursor Desktop separately from Cursor CLI, supports
 Antigravity CLI (`agy`) and Qoder CLI (`qodercli`) as launch-only terminal
 tools, opens ZCode as a launch-only desktop tool, and supports OpenClaw as a
 launch-only external runtime. It begins with at most three common choices;

--- a/README.md
+++ b/README.md
@@ -384,7 +384,7 @@ dyro bootstrap --yes
 dyro doctor
 ```
 
-After setup, run `dyro`. The first run inside a project registers it in a reversible global home. From then on, the same command can resume a recent development line, hotfix, or existing task worktree from any directory—without remembering `--root`:
+`dyro setup` registers the completed Profile in the reversible global home by default, so it is visible in Console immediately. The first registered workspace becomes the default; later setup runs keep the existing default unless you pass `--default`. Use `--no-register` for CI or temporary workspaces. From then on, bare `dyro` can resume a recent development line, hotfix, or existing task worktree from any directory—without remembering `--root`:
 
 ```bash
 dyro

--- a/README.md
+++ b/README.md
@@ -397,11 +397,15 @@ on the local machine are labeled `open workspace only` and receive no gate,
 review, merge, or push authority. Explicit commands such as
 `dyro open dev --agent codex` continue to launch directly for scripts.
 
-The picker detects Cursor Desktop separately from Cursor CLI and supports
-OpenClaw as a launch-only external runtime. Ready tools appear before tools that
-need setup or installation; the current workspace's last choice, project
-recommendation, personal default, and pinned order provide stable tie-breaking.
-Selecting a missing supported tool opens a confirmation-first guided installer:
+The picker detects Cursor Desktop separately from Cursor CLI, supports
+Antigravity CLI (`agy`) and Qoder CLI (`qodercli`) as launch-only terminal
+tools, opens ZCode as a launch-only desktop tool, and supports OpenClaw as a
+launch-only external runtime. It begins with at most three common choices;
+type `m` for the full catalog or enter a tool ID, label, or command directly.
+Ready tools appear before tools that need setup or installation; the current
+workspace's last choice, project recommendation, personal default, and pinned
+order provide stable tie-breaking. Selecting a missing supported tool opens a
+confirmation-first guided installer:
 
 ```bash
 dyro tool list

--- a/docs/tool-catalog.md
+++ b/docs/tool-catalog.md
@@ -75,10 +75,21 @@ user can inspect and choose the platform-specific installer. This applies to
 Cursor CLI and Hermes; Cursor Desktop likewise opens the official download
 page.
 
-Current catalog entries include Codex, Claude Code, Cursor Desktop, Cursor CLI,
-Grok, OpenCode, OpenClaw, Hermes, Kimi Code, and Shell. An entry can be known
+Current catalog entries include Antigravity CLI, Codex, Claude Code, Cursor
+Desktop, Cursor CLI, Grok, OpenCode, OpenClaw, Hermes, Kimi Code, Qoder CLI,
+ZCode, and Shell. Antigravity uses the official `agy` command; Qoder uses
+`qodercli`; ZCode is opened as a desktop workspace tool. An entry can be known
 without having an audited installation recipe; such entries fail closed with
 an actionable message.
+
+## Compact Home picker
+
+Home starts by showing at most three common choices: the most recent or
+default tool, project recommendation, user pins, and available Dyro adapters.
+This keeps everyday startup short while retaining the full catalog. Enter a
+tool ID, label, or command directly, or type `m` to expand the full list,
+including guided-install choices. The shorter display does not change launch
+authority: launch-only tools still only open the selected workspace.
 
 ## Cursor Desktop and OpenClaw
 

--- a/docs/tool-catalog.md
+++ b/docs/tool-catalog.md
@@ -75,12 +75,12 @@ user can inspect and choose the platform-specific installer. This applies to
 Cursor CLI and Hermes; Cursor Desktop likewise opens the official download
 page.
 
-Current catalog entries include Antigravity CLI, Codex, Claude Code, Cursor
-Desktop, Cursor CLI, Grok, OpenCode, OpenClaw, Hermes, Kimi Code, Qoder CLI,
-ZCode, and Shell. Antigravity uses the official `agy` command; Qoder uses
-`qodercli`; ZCode is opened as a desktop workspace tool. An entry can be known
-without having an audited installation recipe; such entries fail closed with
-an actionable message.
+Current catalog entries include Antigravity CLI, Codex CLI, Codex App, Claude
+Code CLI, Claude Code Desktop, Cursor Desktop, Cursor CLI, Grok, OpenCode,
+OpenClaw, Hermes, Kimi Code, Qoder CLI, ZCode, and Shell. Antigravity uses the
+official `agy` command; Qoder uses `qodercli`; ZCode is opened as a desktop
+workspace tool. An entry can be known without having an audited installation
+recipe; such entries fail closed with an actionable message.
 
 ## Compact Home picker
 
@@ -91,12 +91,20 @@ tool ID, label, or command directly, or type `m` to expand the full list,
 including guided-install choices. The shorter display does not change launch
 authority: launch-only tools still only open the selected workspace.
 
-## Cursor Desktop and OpenClaw
+## Desktop apps and OpenClaw
 
 Cursor Desktop is distinct from Cursor CLI. Dyro detects the `cursor` command,
 the standard macOS application bundle, or the standard per-user Windows
 application path, then opens the selected workspace as a launch-only desktop
 tool.
+
+Codex App and Claude Code Desktop are likewise separate from their terminal
+tools. On macOS, Dyro detects their application bundles before offering them,
+including the ChatGPT app's Codex entry and Claude Code's URL-handler bundle.
+Codex uses `codex app <workspace>` when the CLI is available. Claude uses its
+official Code deep link with the selected folder; Claude Desktop still asks the
+user to confirm that folder before it is adopted. Neither desktop launch path
+turns into a Dyro adapter.
 
 OpenClaw is treated as an external runtime, not a Dyro adapter. A configured
 installation receives the selected path through `OPENCLAW_WORKSPACE_DIR`. A

--- a/src/dyro/cli.py
+++ b/src/dyro/cli.py
@@ -365,7 +365,17 @@ def _setup_provider_preset() -> str | None:
 
     discovered = [
         command
-        for command in ("codex", "claude", "cursor-agent", "grok", "opencode", "hermes", "kimi")
+        for command in (
+            "agy",
+            "codex",
+            "claude",
+            "cursor-agent",
+            "grok",
+            "opencode",
+            "hermes",
+            "kimi",
+            "qodercli",
+        )
         if shutil.which(command)
     ]
     if not discovered:

--- a/src/dyro/cli.py
+++ b/src/dyro/cli.py
@@ -20,7 +20,12 @@ from .blueprint import (
     preflight_join_plan,
     render_join_plan,
 )
-from .changesets import create_changeset, get_changeset, list_changesets, verify_changeset
+from .changesets import (
+    create_changeset,
+    get_changeset,
+    list_changesets,
+    verify_changeset,
+)
 from .config import CONFIG_NAME, Config, load, validate_id
 from .console.launcher import launch_console, render_console_plan
 from .continuation.attention import (
@@ -64,7 +69,12 @@ from .continuation.supervision import (
     supervised_outcomes_payload,
     supervised_wave_payload,
 )
-from .continuation.triggers import TriggerConfig, TriggerKind, TriggerProbeInput, probe_builtin
+from .continuation.triggers import (
+    TriggerConfig,
+    TriggerKind,
+    TriggerProbeInput,
+    probe_builtin,
+)
 from .evidence import build_execution_bundle, unpack_execution_bundle
 from .errors import DyroError, ValidationError
 from .home import (
@@ -103,8 +113,16 @@ from .onboarding import (
     repository_input_from_path,
     sibling_workspace_for,
 )
-from .profile import append_adapter, command_adapter, config_value, preset_adapter, set_config_value, test_adapter
+from .profile import (
+    append_adapter,
+    command_adapter,
+    config_value,
+    preset_adapter,
+    set_config_value,
+    test_adapter,
+)
 from .state import atomic_write_text, exclusive_lock
+from .terminal import danger, muted, success, title, value as terminal_value, warning
 from .graph import (
     build_task_graph,
     explain_task,
@@ -163,7 +181,7 @@ from .updates import (
 from .workspace import create_line, doctor, get_line, list_lines, status_rows
 
 
-CONFIG_TEMPLATE = '''schema_version = 1
+CONFIG_TEMPLATE = """schema_version = 1
 
 [workspace]
 name = "{name}"
@@ -199,7 +217,7 @@ verify = [["python3", "-m", "pytest", "-q"]]
 path = "repositories/clients/web"
 mount = "clients/web"
 verify = [["npm", "test", "--", "--runInBand"]]
-'''
+"""
 
 
 def _config(args: argparse.Namespace) -> Config:
@@ -214,7 +232,9 @@ def _config(args: argparse.Namespace) -> Config:
         return resolve_workspace(
             start=Path.cwd(),
             interactive=interactive,
-            chooser=(lambda label, values: _choose(label, list(values))) if interactive else None,
+            chooser=(lambda label, values: _choose(label, list(values)))
+            if interactive
+            else None,
         )
     return load(root)
 
@@ -245,12 +265,16 @@ def _repository_assignments(values: list[str] | None, label: str) -> dict[str, s
 
 def _require_yes(args: argparse.Namespace, label: str) -> None:
     if not args.yes and not args.dry_run:
-        raise DyroError(f"{label} 会创建或修改 Git worktree；请先使用 --dry-run 检查，再加 --yes 执行")
+        raise DyroError(
+            f"{label} 会创建或修改 Git worktree；请先使用 --dry-run 检查，再加 --yes 执行"
+        )
 
 
 def _require_objective_yes(args: argparse.Namespace, label: str) -> None:
     if not args.yes and not args.dry_run:
-        raise DyroError(f"{label} 会修改 Objective 状态；请先使用 --dry-run 检查，再加 --yes 执行")
+        raise DyroError(
+            f"{label} 会修改 Objective 状态；请先使用 --dry-run 检查，再加 --yes 执行"
+        )
 
 
 def _objective_contract_from_args(args: argparse.Namespace, config: Config) -> str:
@@ -262,23 +286,36 @@ def _objective_contract_from_args(args: argparse.Namespace, config: Config) -> s
     if not args.id or not args.title:
         raise DyroError("非文件模式必须提供 --id 与 --title")
     interactive = sys.stdin.isatty() and sys.stdout.isatty()
-    selected_line = args.line or resolve_line(
-        config,
-        interactive=interactive,
-        chooser=(lambda label, values: _choose(label, list(values))) if interactive else None,
-    ).id
-    targets = tuple(item.strip() for item in (args.targets or "").split(",") if item.strip())
+    selected_line = (
+        args.line
+        or resolve_line(
+            config,
+            interactive=interactive,
+            chooser=(lambda label, values: _choose(label, list(values)))
+            if interactive
+            else None,
+        ).id
+    )
+    targets = tuple(
+        item.strip() for item in (args.targets or "").split(",") if item.strip()
+    )
     if not targets:
-        raise DyroError("非文件模式必须提供 --targets TASK_ID[,TASK_ID...]；交互选择将在后续版本提供")
+        raise DyroError(
+            "非文件模式必须提供 --targets TASK_ID[,TASK_ID...]；交互选择将在后续版本提供"
+        )
     mode = args.mode or RequestedMode.SUPERVISED.value
-    operations = tuple(args.operation or (Operation.EXECUTE.value, Operation.REVIEW.value))
+    operations = tuple(
+        args.operation or (Operation.EXECUTE.value, Operation.REVIEW.value)
+    )
     return "\n".join(
         (
             "schema_version = 1",
             f"id = {json.dumps(args.id, ensure_ascii=False)}",
             f"title = {json.dumps(args.title, ensure_ascii=False)}",
             f"line = {json.dumps(selected_line, ensure_ascii=False)}",
-            "targets = [" + ", ".join(json.dumps(item, ensure_ascii=False) for item in targets) + "]",
+            "targets = ["
+            + ", ".join(json.dumps(item, ensure_ascii=False) for item in targets)
+            + "]",
             "",
             "[continuation]",
             f"requested_mode = {json.dumps(mode)}",
@@ -315,7 +352,9 @@ def cmd_init(args: argparse.Namespace) -> None:
     elif args.discover:
         repositories = discover_repositories(root)
         if not repositories:
-            raise DyroError("未发现 Git 仓库；可先 clone 仓库，或使用 dyro init --wizard")
+            raise DyroError(
+                "未发现 Git 仓库；可先 clone 仓库，或使用 dyro init --wizard"
+            )
         content = render_config(args.name, repositories, args.base)
     else:
         content = CONFIG_TEMPLATE.format(name=args.name)
@@ -324,13 +363,18 @@ def cmd_init(args: argparse.Namespace) -> None:
         (root / relative).mkdir(parents=True, exist_ok=True)
     print(f"已初始化 {root}")
     if args.discover:
-        print(f"已自动登记 {len(repositories)} 个本地 Git 仓库；下一步：运行 dyro doctor")
+        print(
+            f"已自动登记 {len(repositories)} 个本地 Git 仓库；下一步：运行 dyro doctor"
+        )
     else:
         print("下一步：登记 repositories，随后运行 dyro doctor")
 
 
 def _default_workspace_name(root: Path) -> str:
-    candidate = "".join(character if character.isascii() and character.isalnum() else "-" for character in root.name).strip("-._")
+    candidate = "".join(
+        character if character.isascii() and character.isalnum() else "-"
+        for character in root.name
+    ).strip("-._")
     candidate = candidate or "my-workspace"
     if not candidate[0].isalnum():
         candidate = "workspace-" + candidate
@@ -408,13 +452,17 @@ def _render_setup_registration_plan(
     registration: WorkspaceRegistrationPlan | None,
 ) -> None:
     if registration is None:
-        print("  - Console：不登记全局入口（--no-register）")
+        print("  - Console：" + muted("不登记全局入口（--no-register）"))
         return
     name = registration.name
     root = registration.root
-    action = "已登记，保持现有入口" if registration.already_registered else "将登记全局入口"
+    action = (
+        "已登记，保持现有入口" if registration.already_registered else "将登记全局入口"
+    )
     default = "；设为默认项目" if registration.becomes_default else "；不改变默认项目"
-    print(f"  - Console：{action} {name} → {root}{default}")
+    print(
+        f"  - Console：{action} {terminal_value(name)} → {terminal_value(root)}{default}"
+    )
 
 
 def _register_setup_workspace(
@@ -422,36 +470,48 @@ def _register_setup_workspace(
 ) -> WorkspaceRecord | None:
     if not register:
         return None
-    record = add_workspace(
-        config.root, name=config.name, make_default=make_default
-    )
+    record = add_workspace(config.root, name=config.name, make_default=make_default)
     default = "（默认项目）" if load_registry().default == record.name else ""
-    print(f"已登记全局入口：{record.name}{default}")
+    print(success(f"已登记全局入口：{record.name}{default}"))
     return record
 
 
 def _print_setup_completion(
     config: Config, registration: WorkspaceRecord | None
 ) -> None:
-    print("\n设置完成：")
-    print(f"  - Profile：{config.name}")
+    print("\n" + success("━━ 设置完成 ━━"))
+    print(f"  - Profile：{terminal_value(config.name)}")
     if registration is None:
-        print("  - Console：未登记（--no-register）")
+        print("  - Console：" + muted("未登记（--no-register）"))
     else:
-        print(f"  - Console：{registration.name} 已可在 dyro console 中查看")
-    print("下一步：dyro start")
+        print(
+            f"  - Console：{terminal_value(registration.name)} 已可在 dyro console 中查看"
+        )
+    print("下一步：" + terminal_value("dyro start"))
 
 
 def _render_interactive_setup_plan(
     plan: SetupPlan, registration: WorkspaceRegistrationPlan | None
 ) -> None:
-    print("\n设置计划（尚未修改任何文件）：")
+    print("\n" + title("━━ 设置计划 ━━"))
+    print(muted("尚未修改任何文件。"))
     for item in render_setup_plan(plan):
         print("  - " + item)
     _render_setup_registration_plan(registration)
     if plan.needs_bootstrap:
-        print("  - 将仅 clone 缺失且已明确提供 remote 的仓库")
-    print("  - 不会移动、覆盖或清理现有 Git 仓库")
+        print("  - " + muted("将仅 clone 缺失且已明确提供 remote 的仓库"))
+    print("  - " + muted("不会移动、覆盖或清理现有 Git 仓库"))
+
+
+def _print_doctor_finding(finding: str) -> None:
+    if finding.startswith("PASS"):
+        print(success(finding))
+    elif finding.startswith("WARN"):
+        print(warning(finding))
+    elif finding.startswith("FAIL"):
+        print(danger(finding))
+    else:
+        print(finding)
 
 
 def _apply_setup_plan(
@@ -494,10 +554,14 @@ def _apply_setup_plan(
             base=plan.default_base,
             kind="line",
         )
-        print(f"已创建开发线 {line.id}（{line.branch}）")
+        print(
+            success("已创建开发线 ")
+            + terminal_value(line.id)
+            + f"（{terminal_value(line.branch)}）"
+        )
     findings = doctor(config)
     for finding in findings:
-        print(finding)
+        _print_doctor_finding(finding)
     if any(finding.startswith("FAIL") for finding in findings):
         raise DyroError("设置已保存，但 doctor 发现问题；请修复后运行 dyro next")
     _print_setup_completion(config, registration)
@@ -507,18 +571,23 @@ def _interactive_setup(args: argparse.Namespace) -> None:
     root = Path(args.path).expanduser().resolve()
     config_file = root / CONFIG_NAME
     suggested_base = args.base or "main"
-    print("Dyro 首次设置。先检查环境，确认前不会修改文件。")
+    print("\n" + title("━━ Dyro 首次设置 ━━"))
+    print(muted("先检查环境，确认前不会修改文件。"))
     if config_file.exists():
         config = load(root)
         registration = _setup_registration_plan(config.root, config.name, args)
-        print(f"已发现 Profile：{config_file}（{len(config.repositories)} 个仓库）")
+        print(
+            f"已发现 Profile：{terminal_value(config_file)}（{len(config.repositories)} 个仓库）"
+        )
         _render_setup_registration_plan(registration)
         for finding in doctor(config):
-            print(finding)
+            _print_doctor_finding(finding)
         if args.dry_run or registration is None:
-            print("下一步：dyro next")
+            print("下一步：" + terminal_value("dyro next"))
             return
-        if not args.yes and not _ask_yes_no("将此 Profile 登记到全局 Console", default=False):
+        if not args.yes and not _ask_yes_no(
+            "将此 Profile 登记到全局 Console", default=False
+        ):
             print("已取消；没有修改全局入口。")
             return
         record = _register_setup_workspace(
@@ -527,24 +596,38 @@ def _interactive_setup(args: argparse.Namespace) -> None:
         _print_setup_completion(config, record)
         return
 
-    repositories = discover_repositories(root) if root.exists() and not is_git_repository(root) else []
+    repositories = (
+        discover_repositories(root)
+        if root.exists() and not is_git_repository(root)
+        else []
+    )
     if is_git_repository(root):
         remote = origin_url(root)
         if not remote:
-            print("当前目录是 Git 仓库，但没有 origin。Dyro 不会把控制状态写进该仓库。")
-            print("请先为它配置 origin，或在包含多个仓库的独立目录中运行 dyro setup。")
+            print(
+                warning(
+                    "当前目录是 Git 仓库，但没有 origin。Dyro 不会把控制状态写进该仓库。"
+                )
+            )
+            print(
+                muted(
+                    "请先为它配置 origin，或在包含多个仓库的独立目录中运行 dyro setup。"
+                )
+            )
             return
         source_branch = current_branch(root)
         if source_branch and not args.base:
             suggested_base = source_branch
         suggested_root = sibling_workspace_for(root)
-        raw_root = _ask_value("为这个项目创建独立 Dyro 工作区", default=str(suggested_root))
+        raw_root = _ask_value(
+            "为这个项目创建独立 Dyro 工作区", default=str(suggested_root)
+        )
         root = Path(raw_root).expanduser().resolve()
         if root.exists() and any(root.iterdir()):
             raise DyroError(f"建议工作区必须为空或不存在：{root}")
         repository = repository_from_remote(remote)
         repositories = [repository]
-        print("将从当前仓库的 origin clone 新 anchor；当前仓库保持不变。")
+        print(muted("将从当前仓库的 origin clone 新 anchor；当前仓库保持不变。"))
     elif not repositories:
         remote = _ask_value("未发现本地 Git 仓库。输入一个 Git remote（留空退出）")
         if not remote:
@@ -592,10 +675,11 @@ def _interactive_setup(args: argparse.Namespace) -> None:
 def _setup_quick(args: argparse.Namespace) -> None:
     root = Path(args.path).expanduser().resolve()
     config = load(root)
-    print(f"检查现有 Profile：{config.root}")
+    print("\n" + title("━━ 快速检查 ━━"))
+    print(f"检查现有 Profile：{terminal_value(config.root)}")
     for finding in doctor(config):
-        print(finding)
-    print("下一步：dyro next")
+        _print_doctor_finding(finding)
+    print("下一步：" + terminal_value("dyro next"))
 
 
 def _non_interactive_setup(args: argparse.Namespace) -> None:
@@ -605,26 +689,34 @@ def _non_interactive_setup(args: argparse.Namespace) -> None:
     created = False
     if config_file.exists():
         config = load(root)
-        print(f"复用已有 Profile：{config_file}")
+        print(f"复用已有 Profile：{terminal_value(config_file)}")
         registration = _setup_registration_plan(config.root, config.name, args)
     else:
         repositories = discover_repositories(root)
         if not repositories:
-            raise DyroError("未发现 Git 仓库；请先 clone 仓库到工作区，或使用 dyro init --wizard")
+            raise DyroError(
+                "未发现 Git 仓库；请先 clone 仓库到工作区，或使用 dyro init --wizard"
+            )
         name = args.name or _default_workspace_name(root)
         validate_id(name, "workspace 名称")
         registration = _setup_registration_plan(root, name, args)
         if args.dry_run:
-            print(f"DRY RUN: 将创建 {config_file}，自动登记 {len(repositories)} 个 Git 仓库")
+            print(
+                f"DRY RUN: 将创建 {config_file}，自动登记 {len(repositories)} 个 Git 仓库"
+            )
             _render_setup_registration_plan(registration)
             if not args.no_line:
-                print(f"DRY RUN: 将创建开发线 {args.line}（分支 {args.branch or f'feat/{args.line}'}）")
+                print(
+                    f"DRY RUN: 将创建开发线 {args.line}（分支 {args.branch or f'feat/{args.line}'}）"
+                )
             return
         root.mkdir(parents=True, exist_ok=True)
-        atomic_write_text(config_file, render_config(name, repositories, args.base or "main"))
+        atomic_write_text(
+            config_file, render_config(name, repositories, args.base or "main")
+        )
         config = load(root)
         created = True
-        print(f"已创建 Profile，并自动登记 {len(repositories)} 个 Git 仓库")
+        print(success(f"已创建 Profile，并自动登记 {len(repositories)} 个 Git 仓库"))
     if config_file.exists() or not args.dry_run:
         _render_setup_registration_plan(registration)
     if not args.dry_run:
@@ -650,12 +742,18 @@ def _non_interactive_setup(args: argparse.Namespace) -> None:
                 kind="line",
                 dry_run=args.dry_run,
             )
-            print(f"{'DRY RUN: ' if args.dry_run else ''}已创建开发线 {line.id}（{line.branch}）")
+            prefix = "DRY RUN: " if args.dry_run else ""
+            print(
+                prefix
+                + success("已创建开发线 ")
+                + terminal_value(line.id)
+                + f"（{terminal_value(line.branch)}）"
+            )
         else:
             print(f"开发线已存在：{existing.id}（{existing.branch}）")
     findings = doctor(config)
     for finding in findings:
-        print(finding)
+        _print_doctor_finding(finding)
     if any(finding.startswith("FAIL") for finding in findings):
         raise DyroError("setup 已完成基础配置，但 doctor 仍发现结构错误")
     if created or registered is not None:
@@ -692,9 +790,15 @@ def cmd_setup(args: argparse.Namespace) -> None:
 
 def cmd_repo_list(args: argparse.Namespace) -> None:
     config = _config(args)
-    print(f"{'ID':18} {'ANCHOR':36} {'MOUNT':28} REMOTE")
+    print("\n" + title("━━ 已登记仓库 ━━"))
+    print(muted(f"Profile：{config.name} · {len(config.repositories)} 个仓库"))
+    print(muted(f"{'ID':18} {'ANCHOR':36} {'MOUNT':28} REMOTE"))
     for repository_id, repository in sorted(config.repositories.items()):
-        print(f"{repository_id:18} {repository.path:36} {repository.mount:28} {'configured' if repository.remote else '-'}")
+        remote = success("configured") if repository.remote else muted("-")
+        print(
+            f"{terminal_value(f'{repository_id:18}')} "
+            f"{repository.path:36} {repository.mount:28} {remote}"
+        )
 
 
 def cmd_repo_add(args: argparse.Namespace) -> None:
@@ -721,23 +825,34 @@ def cmd_repo_add(args: argparse.Namespace) -> None:
 def cmd_bootstrap(args: argparse.Namespace) -> None:
     _require_yes(args, "bootstrap")
     config = _config(args)
+    print("\n" + title("━━ 初始化仓库 ━━"))
+    print(muted("只处理当前 Profile 中缺失的 anchor 仓库。"))
     for message in bootstrap(config, dry_run=args.dry_run):
         print(message)
     if not args.dry_run:
+        print("\n" + title("━━ 初始化后检查 ━━"))
         for finding in doctor(config):
-            print(finding)
+            _print_doctor_finding(finding)
 
 
 def cmd_doctor(args: argparse.Namespace) -> None:
-    findings = doctor(_config(args))
+    config = _config(args)
+    print("\n" + title("━━ Dyro 健康检查 ━━"))
+    print(muted(f"Profile：{config.name} · 检查仓库、基线与隔离工作区。"))
+    findings = doctor(config)
     for finding in findings:
-        print(finding)
+        _print_doctor_finding(finding)
     if any(item.startswith("FAIL") for item in findings):
         raise DyroError("doctor 发现结构错误")
+    print("\n" + success("检查通过。") + " 下一步：" + terminal_value("dyro"))
 
 
 def cmd_terminology_check(args: argparse.Namespace) -> None:
-    root = _config(args).root if args.workspace_alias else Path(args.root or ".").expanduser().resolve()
+    root = (
+        _config(args).root
+        if args.workspace_alias
+        else Path(args.root or ".").expanduser().resolve()
+    )
     policy = load_terminology_policy(
         root,
         policy_file=Path(args.policy_file) if args.policy_file else None,
@@ -801,7 +916,12 @@ def cmd_workspace_add(args: argparse.Namespace) -> None:
         name=args.name,
         make_default=args.default,
     )
-    print(f"已登记工作区：{record.name} -> {record.root}")
+    print(
+        success("已登记工作区：")
+        + terminal_value(record.name)
+        + " → "
+        + terminal_value(record.root)
+    )
 
 
 def cmd_workspace_list(args: argparse.Namespace) -> None:
@@ -809,16 +929,25 @@ def cmd_workspace_list(args: argparse.Namespace) -> None:
     if not registry.workspaces:
         print("还没有登记全局工作区。下一步：dyro workspace add <路径>")
         return
-    print(f"{'默认':4} {'名称':20} {'状态':8} 路径")
+    print("\n" + title("━━ 全局工作区 ━━"))
+    print(muted("这里只管理首页入口，不会移动或删除项目文件。"))
+    print(muted(f"{'默认':4} {'名称':20} {'状态':8} 路径"))
     for record in registry.workspaces:
-        marker = "*" if record.name == registry.default else "-"
+        marker = (
+            success(f"{'●':4}")
+            if record.name == registry.default
+            else muted(f"{'·':4}")
+        )
         try:
             load(record.root)
         except (DyroError, ValidationError):
-            state = "不可用"
+            state = danger(f"{'不可用':8}")
         else:
-            state = "可用"
-        print(f"{marker:4} {record.name:20} {state:8} {record.root}")
+            state = success(f"{'可用':8}")
+        print(
+            f"{marker}{terminal_value(f'{record.name:20}')} {state} "
+            f"{terminal_value(record.root)}"
+        )
 
 
 def cmd_workspace_default(args: argparse.Namespace) -> None:
@@ -833,9 +962,7 @@ def cmd_workspace_default(args: argparse.Namespace) -> None:
 def cmd_workspace_remove(args: argparse.Namespace) -> None:
     get_workspace(args.name)
     if not args.yes and not args.dry_run:
-        raise DyroError(
-            "移除只会删除全局首页入口，不会删除项目文件；确认后请加 --yes"
-        )
+        raise DyroError("移除只会删除全局首页入口，不会删除项目文件；确认后请加 --yes")
     if args.dry_run:
         print(f"DRY RUN: 将移除工作区入口 {args.name}；不会删除项目文件")
         return
@@ -902,7 +1029,9 @@ def cmd_join(args: argparse.Namespace) -> None:
         return
     if not args.yes:
         if not sys.stdin.isatty():
-            raise DyroError("join 会创建工作区和 Git worktree；请先使用 --dry-run，再加 --yes 执行")
+            raise DyroError(
+                "join 会创建工作区和 Git worktree；请先使用 --dry-run，再加 --yes 执行"
+            )
         if not _ask_yes_no("应用此加入计划", default=False):
             print("已取消；没有修改任何文件。")
             return
@@ -924,9 +1053,7 @@ def cmd_join(args: argparse.Namespace) -> None:
     for scope, repository_id, _branch, _head, _upstream, dirty in status_rows(config):
         if scope in selected_scopes and dirty == 0:
             clean_scopes[repository_id].add(scope)
-    clean_count = sum(
-        scopes == selected_scopes for scopes in clean_scopes.values()
-    )
+    clean_count = sum(scopes == selected_scopes for scopes in clean_scopes.values())
     print(f"仓库：{clean_count}/{len(config.repositories)} clean")
     print("下一步：dyro")
 
@@ -940,8 +1067,12 @@ def cmd_status(args: argparse.Namespace) -> None:
 
 def cmd_agent_list(args: argparse.Namespace) -> None:
     config = _config(args)
+    print("\n" + title("━━ 已登记 Agent ━━"))
     for adapter_id, adapter in sorted(config.adapters.items()):
-        print(f"{adapter_id:16} launch={shlex.join(adapter.launch)}")
+        print(
+            f"{terminal_value(f'{adapter_id:16}')} "
+            f"{muted('launch=')}{shlex.join(adapter.launch)}"
+        )
 
 
 def cmd_agent_add(args: argparse.Namespace) -> None:
@@ -955,14 +1086,17 @@ def cmd_agent_add(args: argparse.Namespace) -> None:
             raise DyroError(f"Agent command 解析失败：{exc}") from exc
         adapter = command_adapter(args.id, command)
     append_adapter(config, adapter, dry_run=args.dry_run)
-    print(f"{'DRY RUN: 将添加' if args.dry_run else '已添加'} Agent adapter：{adapter.id}")
+    print(
+        f"{'DRY RUN: 将添加' if args.dry_run else '已添加'} Agent adapter：{adapter.id}"
+    )
 
 
 def cmd_agent_test(args: argparse.Namespace) -> None:
     checks = test_adapter(_config(args), args.id)
     failures = []
     for mode, available, executable in checks:
-        print(f"{'PASS' if available else 'FAIL'} {args.id}.{mode}: {executable}")
+        rendered = f"{'PASS' if available else 'FAIL'} {args.id}.{mode}: {executable}"
+        print(success(rendered) if available else danger(rendered))
         if not available:
             failures.append(mode)
     if failures:
@@ -995,7 +1129,15 @@ def cmd_tool_list(args: argparse.Namespace) -> None:
         ToolState.INSTALLABLE: "可引导安装",
         ToolState.UNAVAILABLE: "不可用",
     }
-    print(f"{'ID':20} {'状态':12} {'类型':10} 名称")
+    print("\n" + title("━━ 编码工具 ━━"))
+    print(muted("顺序已综合上次使用、项目推荐与个人偏好。"))
+    print(muted(f"{'ID':20} {'状态':12} {'类型':10} 名称"))
+    state_styles = {
+        ToolState.READY: success,
+        ToolState.NEEDS_SETUP: warning,
+        ToolState.INSTALLABLE: warning,
+        ToolState.UNAVAILABLE: danger,
+    }
     for tool in tools:
         markers: list[str] = []
         if record and tool.id == record.last_agent:
@@ -1006,8 +1148,9 @@ def cmd_tool_list(args: argparse.Namespace) -> None:
             markers.append("个人默认")
         suffix = f" [{' / '.join(markers)}]" if markers else ""
         print(
-            f"{tool.id:20} {labels[tool.state]:12} {tool.kind:10} "
-            f"{tool.label}{suffix}"
+            f"{terminal_value(f'{tool.id:20}')} "
+            f"{state_styles[tool.state](f'{labels[tool.state]:12}')} "
+            f"{muted(f'{tool.kind:10}')} {terminal_value(tool.label)}{muted(suffix)}"
         )
 
 
@@ -1051,9 +1194,7 @@ def cmd_tool_pin(args: argparse.Namespace) -> None:
         return
     set_pinned_tools(tool_ids)
     print(
-        "已清除工具置顶顺序"
-        if not tool_ids
-        else "工具置顶顺序：" + ", ".join(tool_ids)
+        "已清除工具置顶顺序" if not tool_ids else "工具置顶顺序：" + ", ".join(tool_ids)
     )
 
 
@@ -1143,7 +1284,9 @@ def cmd_config_set(args: argparse.Namespace) -> None:
     value = set_config_value(config, args.key, args.value, dry_run=args.dry_run)
     if not args.dry_run:
         load(config.root)
-    print(f"{'DRY RUN: 将设置' if args.dry_run else '已设置'} {args.key} = {json.dumps(value, ensure_ascii=False)}")
+    print(
+        f"{'DRY RUN: 将设置' if args.dry_run else '已设置'} {args.key} = {json.dumps(value, ensure_ascii=False)}"
+    )
 
 
 def cmd_open(args: argparse.Namespace) -> None:
@@ -1178,13 +1321,22 @@ def cmd_start(args: argparse.Namespace) -> None:
     failures = [finding for finding in findings if finding.startswith("FAIL")]
     if failures:
         print("\n".join(failures))
-        raise DyroError("工作区尚未就绪；先修复 doctor 失败项，或运行 dyro bootstrap --yes")
+        raise DyroError(
+            "工作区尚未就绪；先修复 doctor 失败项，或运行 dyro bootstrap --yes"
+        )
     if not config.adapters:
         raise DyroError("尚未配置可启动的 Agent；先运行 dyro next 查看安全的下一步")
     line_id = args.line or _choose("开发线", [line.id for line in list_lines(config)])
     line = get_line(config, line_id, args.kind)
     agent = args.agent or _choose("Agent", sorted(config.adapters))
-    open_args = argparse.Namespace(root=str(config.root), line=line.id, kind=line.kind, agent=agent, prompt=args.prompt or "", dry_run=args.dry_run)
+    open_args = argparse.Namespace(
+        root=str(config.root),
+        line=line.id,
+        kind=line.kind,
+        agent=agent,
+        prompt=args.prompt or "",
+        dry_run=args.dry_run,
+    )
     cmd_open(open_args)
 
 
@@ -1204,7 +1356,9 @@ def cmd_next(args: argparse.Namespace) -> None:
         print("工作区还不能开始任务：")
         for finding in failures:
             print("  " + finding)
-        print("下一步：dyro doctor；若仓库缺失且已配置 remote，则运行 dyro bootstrap --yes")
+        print(
+            "下一步：dyro doctor；若仓库缺失且已配置 remote，则运行 dyro bootstrap --yes"
+        )
         return
     lines = list_lines(config)
     if not lines:
@@ -1212,12 +1366,18 @@ def cmd_next(args: argparse.Namespace) -> None:
         return
     if not config.adapters:
         if shutil.which("codex"):
-            print("工作区已就绪，检测到 Codex 尚未加入 Profile。下一步：dyro agent add codex --preset codex")
+            print(
+                "工作区已就绪，检测到 Codex 尚未加入 Profile。下一步：dyro agent add codex --preset codex"
+            )
         else:
-            print("工作区已就绪，但尚未配置可启动的 Agent。下一步：dyro agent add <id> --command '…'")
+            print(
+                "工作区已就绪，但尚未配置可启动的 Agent。下一步：dyro agent add <id> --command '…'"
+            )
         return
     if len(lines) == 1 and len(config.adapters) == 1:
-        print(f"工作区已就绪。下一步：dyro start --line {lines[0].id} --agent {next(iter(config.adapters))}")
+        print(
+            f"工作区已就绪。下一步：dyro start --line {lines[0].id} --agent {next(iter(config.adapters))}"
+        )
         return
     print("工作区已就绪。下一步：dyro start")
 
@@ -1231,17 +1391,24 @@ def cmd_line_list(args: argparse.Namespace) -> None:
     print(f"{'KIND':8} {'ID':28} {'BRANCH':30} {'BASE':24} REPOSITORIES")
     for line in lines:
         repositories = ", ".join(
-            f"{repo_id}@{line.base_for(repo_id)}[{line.storage_for(repo_id)}]" for repo_id in line.repositories
+            f"{repo_id}@{line.base_for(repo_id)}[{line.storage_for(repo_id)}]"
+            for repo_id in line.repositories
         )
-        print(f"{line.kind:8} {line.id:28} {line.branch:30} {line.base:24} {repositories}")
+        print(
+            f"{line.kind:8} {line.id:28} {line.branch:30} {line.base:24} {repositories}"
+        )
 
 
 def _create_line(args: argparse.Namespace, kind: str) -> None:
     config = _config(args)
     _require_yes(args, "创建开发线")
-    branch = args.branch or (f"hotfix/{args.id}" if kind == "hotfix" else f"feat/{args.id}")
+    branch = args.branch or (
+        f"hotfix/{args.id}" if kind == "hotfix" else f"feat/{args.id}"
+    )
     if kind == "hotfix" and not args.base:
-        raise DyroError("Hotfix 必须显式提供 --base（已核实的 release/tag/deployed SHA）")
+        raise DyroError(
+            "Hotfix 必须显式提供 --base（已核实的 release/tag/deployed SHA）"
+        )
     base = args.base or config.policy.default_base
     repository_bases = _repository_assignments(args.repo_base, "--repo-base")
     storage_modes = _repository_assignments(args.storage, "--storage")
@@ -1256,8 +1423,12 @@ def _create_line(args: argparse.Namespace, kind: str) -> None:
         kind=kind,
         dry_run=args.dry_run,
     )
-    bases = ", ".join(f"{repo_id}={line.base_for(repo_id)}" for repo_id in line.repositories)
-    print(f"{'DRY RUN: ' if args.dry_run else ''}已创建 {line.kind} {line.id}，分支 {line.branch}，仓库基线：{bases}")
+    bases = ", ".join(
+        f"{repo_id}={line.base_for(repo_id)}" for repo_id in line.repositories
+    )
+    print(
+        f"{'DRY RUN: ' if args.dry_run else ''}已创建 {line.kind} {line.id}，分支 {line.branch}，仓库基线：{bases}"
+    )
 
 
 def cmd_line_create(args: argparse.Namespace) -> None:
@@ -1277,8 +1448,13 @@ def cmd_changeset_create(args: argparse.Namespace) -> None:
         repositories=_repositories(args.repos),
         dry_run=args.dry_run,
     )
-    heads = ", ".join(f"{repository}={changeset.heads[repository][:12]}" for repository in changeset.repositories)
-    print(f"{'DRY RUN: ' if args.dry_run else ''}已创建 Change Set {changeset.id}：{heads}")
+    heads = ", ".join(
+        f"{repository}={changeset.heads[repository][:12]}"
+        for repository in changeset.repositories
+    )
+    print(
+        f"{'DRY RUN: ' if args.dry_run else ''}已创建 Change Set {changeset.id}：{heads}"
+    )
 
 
 def cmd_changeset_list(args: argparse.Namespace) -> None:
@@ -1288,7 +1464,9 @@ def cmd_changeset_list(args: argparse.Namespace) -> None:
         return
     print(f"{'ID':28} {'LINE':24} {'BRANCH':28} REPOSITORIES")
     for changeset in changesets:
-        print(f"{changeset.id:28} {changeset.line:24} {changeset.branch:28} {', '.join(changeset.repositories)}")
+        print(
+            f"{changeset.id:28} {changeset.line:24} {changeset.branch:28} {', '.join(changeset.repositories)}"
+        )
 
 
 def cmd_changeset_verify(args: argparse.Namespace) -> None:
@@ -1315,8 +1493,13 @@ def cmd_task_create(args: argparse.Namespace) -> None:
             raise DyroError(f"任务目录已存在：{path}")
         path.mkdir(parents=True)
         mount = config.repositories[args.repository].mount
-        atomic_write_text(path / "task.toml", task_template(args.id, args.title, args.line, args.repository, mount))
-        atomic_write_text(path / "handoff.md", f"# {args.title}\n\n- 目标：\n- 范围：\n- 验收：\n")
+        atomic_write_text(
+            path / "task.toml",
+            task_template(args.id, args.title, args.line, args.repository, mount),
+        )
+        atomic_write_text(
+            path / "handoff.md", f"# {args.title}\n\n- 目标：\n- 范围：\n- 验收：\n"
+        )
     print(f"已创建任务：{path}")
 
 
@@ -1356,7 +1539,9 @@ def cmd_task_binding(args: argparse.Namespace) -> None:
 def cmd_task_list(args: argparse.Namespace) -> None:
     config = _config(args)
     for task in list_tasks(config):
-        print(f"{task.id:30} {task_status(config, task):16} {task.line:20} {task.title}")
+        print(
+            f"{task.id:30} {task_status(config, task):16} {task.line:20} {task.title}"
+        )
 
 
 def cmd_task_board(args: argparse.Namespace) -> None:
@@ -1393,15 +1578,11 @@ def cmd_task_open(args: argparse.Namespace) -> None:
 def cmd_task_claim(args: argparse.Namespace) -> None:
     config = _config(args)
     task = load_task(config, args.id)
-    requested_output = (
-        Path(args.output).expanduser() if args.output else None
-    )
+    requested_output = Path(args.output).expanduser() if args.output else None
     if requested_output is not None and (
         requested_output.exists() or requested_output.is_symlink()
     ):
-        raise DyroError(
-            f"拒绝覆盖已有 claim 导出文件：{requested_output}"
-        )
+        raise DyroError(f"拒绝覆盖已有 claim 导出文件：{requested_output}")
     output = (
         requested_output.parent.resolve() / requested_output.name
         if requested_output is not None
@@ -1412,9 +1593,7 @@ def cmd_task_claim(args: argparse.Namespace) -> None:
         try:
             output.parent.mkdir(parents=True, exist_ok=True)
         except OSError as exc:
-            raise DyroError(
-                f"无法创建 claim 导出目录：{output.parent}"
-            ) from exc
+            raise DyroError(f"无法创建 claim 导出目录：{output.parent}") from exc
         flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL
         flags |= getattr(os, "O_CLOEXEC", 0)
         flags |= getattr(os, "O_NOFOLLOW", 0)
@@ -1422,9 +1601,7 @@ def cmd_task_claim(args: argparse.Namespace) -> None:
         try:
             descriptor = os.open(output, flags, initial_mode)
         except FileExistsError as exc:
-            raise DyroError(
-                f"拒绝覆盖已有 claim 导出文件：{output}"
-            ) from exc
+            raise DyroError(f"拒绝覆盖已有 claim 导出文件：{output}") from exc
         except OSError as exc:
             raise DyroError(f"无法创建 claim 导出文件：{output}") from exc
     try:
@@ -1487,7 +1664,9 @@ def cmd_task_claim_release(args: argparse.Namespace) -> None:
 
     config = _config(args)
     task = load_task(config, args.id)
-    print(f"{task.id} -> {release_task_claim(config, task, runner=args.by, dry_run=args.dry_run)}")
+    print(
+        f"{task.id} -> {release_task_claim(config, task, runner=args.by, dry_run=args.dry_run)}"
+    )
 
 
 def cmd_task_next(args: argparse.Namespace) -> None:
@@ -1500,7 +1679,10 @@ def cmd_task_next(args: argparse.Namespace) -> None:
     if not args.run:
         for task in candidates:
             print(f"{task.id:30} {task.line:20} {task.title}")
-        print("运行：dyro task next --run --yes" + (" --id <任务ID>" if len(candidates) > 1 else ""))
+        print(
+            "运行：dyro task next --run --yes"
+            + (" --id <任务ID>" if len(candidates) > 1 else "")
+        )
         return
     _require_yes(args, "启动下一个任务")
     if len(candidates) > 1:
@@ -1565,7 +1747,9 @@ def cmd_task_evidence_execution(args: argparse.Namespace) -> None:
                 receipt=evidence["receipt"],
                 gates=evidence["gates"] if evidence["gates"].is_file() else None,
                 heads=evidence["heads"] if evidence["heads"].is_file() else None,
-                provenance=evidence["provenance"] if evidence["provenance"].is_file() else None,
+                provenance=evidence["provenance"]
+                if evidence["provenance"].is_file()
+                else None,
                 allow_legacy_provenance=args.allow_legacy,
                 dry_run=args.dry_run,
             )
@@ -1715,20 +1899,28 @@ def cmd_witness_serve(args: argparse.Namespace) -> None:
         raise ValidationError(
             f"环境变量 {args.auth_token_env} 未设置；本地测试才可使用 --allow-unauthenticated"
         )
-    if args.allow_unauthenticated and args.host not in {"127.0.0.1", "::1", "localhost"}:
+    if args.allow_unauthenticated and args.host not in {
+        "127.0.0.1",
+        "::1",
+        "localhost",
+    }:
         raise ValidationError("--allow-unauthenticated 只能绑定 loopback host")
     if (args.tls_cert is None) != (args.tls_key is None):
         raise ValidationError("Witness TLS cert 与 key 必须同时设置")
     if args.tls_cert is None:
         if not args.allow_http:
-            raise ValidationError("Witness 必须设置 TLS，或显式使用仅本地的 --allow-http")
+            raise ValidationError(
+                "Witness 必须设置 TLS，或显式使用仅本地的 --allow-http"
+            )
         if args.host not in {"127.0.0.1", "::1", "localhost"}:
             raise ValidationError("--allow-http 只能绑定 loopback host")
     bindings: dict[str, str] = {}
     for value in args.client_workspace_binding:
         key_id, separator, workspace_id = value.partition("=")
         if not separator or not key_id or not workspace_id:
-            raise ValidationError("--client-workspace-binding 必须为 KEY_ID=WORKSPACE_ID")
+            raise ValidationError(
+                "--client-workspace-binding 必须为 KEY_ID=WORKSPACE_ID"
+            )
         if key_id in bindings:
             raise ValidationError(f"--client-workspace-binding 重复：{key_id}")
         bindings[key_id] = workspace_id
@@ -1772,7 +1964,9 @@ def cmd_witness_serve(args: argparse.Namespace) -> None:
 def cmd_task_evidence_review(args: argparse.Namespace) -> None:
     config = _config(args)
     task = load_task(config, args.id)
-    print(f"{task.id} -> {import_review_evidence(config, task, review=Path(args.file), dry_run=args.dry_run)}")
+    print(
+        f"{task.id} -> {import_review_evidence(config, task, review=Path(args.file), dry_run=args.dry_run)}"
+    )
 
 
 def cmd_task_evidence_review_build(args: argparse.Namespace) -> None:
@@ -1797,7 +1991,8 @@ def cmd_task_evidence_review_build(args: argparse.Namespace) -> None:
         return
     atomic_write_bytes(
         output,
-        json.dumps(record, ensure_ascii=False, sort_keys=True, indent=2).encode("utf-8") + b"\n",
+        json.dumps(record, ensure_ascii=False, sort_keys=True, indent=2).encode("utf-8")
+        + b"\n",
     )
     print(f"{task.id} -> signed review: {output}")
 
@@ -1819,7 +2014,13 @@ def cmd_task_evidence_generations(args: argparse.Namespace) -> None:
     )
     target_ids = {record.generation_id for record in targets}
     for record in records:
-        state = "current" if record.current else "temporary" if record.temporary else "history"
+        state = (
+            "current"
+            if record.current
+            else "temporary"
+            if record.temporary
+            else "history"
+        )
         action = "prune" if record.generation_id in target_ids else "keep"
         print(
             f"{record.generation_id}\t{state}\t{record.modified_at.isoformat()}\t"
@@ -1835,7 +2036,10 @@ def cmd_task_merge(args: argparse.Namespace) -> None:
     config = _config(args)
     task = load_task(config, args.id)
     merge_task(config, task, push=args.push, dry_run=args.dry_run)
-    print(f"{'DRY RUN: ' if args.dry_run else ''}已合并 {task.id}" + (" 并推送" if args.push else ""))
+    print(
+        f"{'DRY RUN: ' if args.dry_run else ''}已合并 {task.id}"
+        + (" 并推送" if args.push else "")
+    )
 
 
 def cmd_task_decisions(args: argparse.Namespace) -> None:
@@ -1854,7 +2058,9 @@ def cmd_task_stats(args: argparse.Namespace) -> None:
         return
     print(f"{'AGENT':18} {'EXEC':>5} {'EXEC OK':>8} {'REVIEW':>7} {'REVIEW OK':>10}")
     for agent, counters in sorted(report.items()):
-        print(f"{agent:18} {counters['executor']:>5} {counters['executor_ok']:>8} {counters['review']:>7} {counters['review_ok']:>10}")
+        print(
+            f"{agent:18} {counters['executor']:>5} {counters['executor_ok']:>8} {counters['review']:>7} {counters['review_ok']:>10}"
+        )
 
 
 def cmd_task_loop(args: argparse.Namespace) -> None:
@@ -1879,7 +2085,9 @@ def cmd_objective_list(args: argparse.Namespace) -> None:
     config = _config(args)
     records = list_objectives(config)
     if not records:
-        print("暂无 Objective。下一步：dyro objective start --file <objective.toml> --yes")
+        print(
+            "暂无 Objective。下一步：dyro objective start --file <objective.toml> --yes"
+        )
         return
     print(f"{'OBJECTIVE':28} {'STATE':8} {'RESULT':16} {'REV':4} {'LINE':20} TARGETS")
     for record in records:
@@ -1909,7 +2117,14 @@ def _read_objective_plan(config: Config, objective_id: str):
 def cmd_objective_plan(args: argparse.Namespace) -> None:
     _, plan = _read_objective_plan(_config(args), args.id)
     if args.format == "json":
-        print(json.dumps(continuation_plan_payload(plan), ensure_ascii=False, sort_keys=True, indent=2))
+        print(
+            json.dumps(
+                continuation_plan_payload(plan),
+                ensure_ascii=False,
+                sort_keys=True,
+                indent=2,
+            )
+        )
         return
     print(render_plan_text(plan))
 
@@ -1917,7 +2132,14 @@ def cmd_objective_plan(args: argparse.Namespace) -> None:
 def cmd_objective_explain(args: argparse.Namespace) -> None:
     _, plan = _read_objective_plan(_config(args), args.id)
     if args.format == "json":
-        print(json.dumps(continuation_plan_payload(plan), ensure_ascii=False, sort_keys=True, indent=2))
+        print(
+            json.dumps(
+                continuation_plan_payload(plan),
+                ensure_ascii=False,
+                sort_keys=True,
+                indent=2,
+            )
+        )
         return
     print(render_plan_text(plan))
 
@@ -1937,7 +2159,9 @@ def cmd_objective_tick(args: argparse.Namespace) -> None:
     record = get_objective(config, args.id, recover=False)
     snapshot = build_scheduler_snapshot(config, objective=record)
     plan = build_continuation_plan(snapshot)
-    tick = build_scheduler_tick(snapshot, plan, max_parallel=record.objective.budget.max_parallel)
+    tick = build_scheduler_tick(
+        snapshot, plan, max_parallel=record.objective.budget.max_parallel
+    )
     if args.format == "json":
         print(render_scheduler_tick_json(tick))
         return
@@ -1971,15 +2195,28 @@ def cmd_objective_apply(args: argparse.Namespace) -> None:
         print(render_supervised_wave_text(wave))
     if args.dry_run:
         if args.format == "json":
-            print(json.dumps({"wave": supervised_wave_payload(wave), "dry_run": True}, ensure_ascii=False, sort_keys=True, indent=2))
+            print(
+                json.dumps(
+                    {"wave": supervised_wave_payload(wave), "dry_run": True},
+                    ensure_ascii=False,
+                    sort_keys=True,
+                    indent=2,
+                )
+            )
         else:
-            print("DRY RUN: 未创建 owner lease、Action intent、Action-start 或 Task 执行。")
+            print(
+                "DRY RUN: 未创建 owner lease、Action intent、Action-start 或 Task 执行。"
+            )
         return
     if args.yes and args.confirm_sha != wave.confirmation_sha256:
-        raise DyroError("--yes 必须同时提供当前 Confirmation SHA-256；请先运行 objective apply --dry-run 后复制摘要")
+        raise DyroError(
+            "--yes 必须同时提供当前 Confirmation SHA-256；请先运行 objective apply --dry-run 后复制摘要"
+        )
     if not args.yes:
         if not (sys.stdin.isatty() and sys.stdout.isatty()):
-            raise DyroError("非交互执行必须提供 --yes 与 --confirm-sha；先使用 --dry-run 查看精确 wave")
+            raise DyroError(
+                "非交互执行必须提供 --yes 与 --confirm-sha；先使用 --dry-run 查看精确 wave"
+            )
         if not _ask_yes_no("确认按上述顺序执行该受监督 Action wave", default=False):
             print("已取消；未写入 Objective 或 Task 状态。")
             return
@@ -1987,7 +2224,11 @@ def cmd_objective_apply(args: argparse.Namespace) -> None:
     if args.format == "json":
         print(
             json.dumps(
-                {"wave": supervised_wave_payload(wave), "dry_run": False, "outcomes": supervised_outcomes_payload(outcomes)},
+                {
+                    "wave": supervised_wave_payload(wave),
+                    "dry_run": False,
+                    "outcomes": supervised_outcomes_payload(outcomes),
+                },
                 ensure_ascii=False,
                 sort_keys=True,
                 indent=2,
@@ -2009,7 +2250,9 @@ def _trigger_cli_time(value: str | None, label: str) -> datetime | None:
     return parsed.astimezone(timezone.utc)
 
 
-def _trigger_cli_facts(values: list[str] | None, label: str) -> tuple[tuple[str, str], ...]:
+def _trigger_cli_facts(
+    values: list[str] | None, label: str
+) -> tuple[tuple[str, str], ...]:
     facts: list[tuple[str, str]] = []
     seen: set[str] = set()
     for value in values or []:
@@ -2030,15 +2273,21 @@ def _trigger_payload(observation, *, delivery: str | None = None) -> dict[str, o
         "state": observation.state.value,
         "summary": observation.summary,
         "evidence_ref": observation.evidence_ref,
-        "observed_at": observation.observed_at.isoformat() if observation.observed_at else None,
-        "next_probe_at": observation.next_probe_at.isoformat() if observation.next_probe_at else None,
+        "observed_at": observation.observed_at.isoformat()
+        if observation.observed_at
+        else None,
+        "next_probe_at": observation.next_probe_at.isoformat()
+        if observation.next_probe_at
+        else None,
     }
     if delivery is not None:
         payload["delivery"] = delivery
     return payload
 
 
-def _print_trigger_observation(args: argparse.Namespace, observation, *, delivery: str | None = None) -> None:
+def _print_trigger_observation(
+    args: argparse.Namespace, observation, *, delivery: str | None = None
+) -> None:
     payload = _trigger_payload(observation, delivery=delivery)
     if args.format == "json":
         print(json.dumps(payload, ensure_ascii=False, sort_keys=True))
@@ -2055,7 +2304,9 @@ def cmd_trigger_list(args: argparse.Namespace) -> None:
     rows = [
         {
             "kind": kind.value,
-            "execution": "bounded_adapter_required" if kind is TriggerKind.PROVIDER else "builtin_read_only",
+            "execution": "bounded_adapter_required"
+            if kind is TriggerKind.PROVIDER
+            else "builtin_read_only",
         }
         for kind in TriggerKind
     ]
@@ -2069,7 +2320,9 @@ def cmd_trigger_list(args: argparse.Namespace) -> None:
 def cmd_trigger_probe(args: argparse.Namespace) -> None:
     kind = TriggerKind(args.kind)
     if kind is TriggerKind.PROVIDER:
-        raise DyroError("provider Trigger 只能由已登记的有界 adapter 调用；CLI 不接受命令、URL 或脚本")
+        raise DyroError(
+            "provider Trigger 只能由已登记的有界 adapter 调用；CLI 不接受命令、URL 或脚本"
+        )
     now = _trigger_cli_time(args.at, "--at") or datetime.now(timezone.utc)
     not_before = _trigger_cli_time(args.not_before, "--not-before")
     if args.signal and kind is not TriggerKind.MANUAL_SIGNAL:
@@ -2108,7 +2361,9 @@ def _cmd_objective_transition(args: argparse.Namespace, action: str) -> None:
         "reconcile": reconcile_objective,
     }
     record = handlers[action](config, args.id, dry_run=args.dry_run)
-    print(f"{'DRY RUN: ' if args.dry_run else ''}{record.objective.id} -> {record.operator_state} r{record.revision}")
+    print(
+        f"{'DRY RUN: ' if args.dry_run else ''}{record.objective.id} -> {record.operator_state} r{record.revision}"
+    )
 
 
 def cmd_objective_pause(args: argparse.Namespace) -> None:
@@ -2131,14 +2386,18 @@ def cmd_objective_scope_add(args: argparse.Namespace) -> None:
     config = _config(args)
     _require_objective_yes(args, "扩展 Objective scope")
     record = add_objective_target(config, args.id, args.task, dry_run=args.dry_run)
-    print(f"{'DRY RUN: ' if args.dry_run else ''}{record.objective.id} r{record.revision} targets={', '.join(record.objective.targets)}")
+    print(
+        f"{'DRY RUN: ' if args.dry_run else ''}{record.objective.id} r{record.revision} targets={', '.join(record.objective.targets)}"
+    )
 
 
 def cmd_objective_scope_remove(args: argparse.Namespace) -> None:
     config = _config(args)
     _require_objective_yes(args, "缩减 Objective scope")
     record = remove_objective_target(config, args.id, args.task, dry_run=args.dry_run)
-    print(f"{'DRY RUN: ' if args.dry_run else ''}{record.objective.id} r{record.revision} targets={', '.join(record.objective.targets)}")
+    print(
+        f"{'DRY RUN: ' if args.dry_run else ''}{record.objective.id} r{record.revision} targets={', '.join(record.objective.targets)}"
+    )
 
 
 def _daemon_select_runnable(config: Config, tasks: list, *, limit: int) -> list:
@@ -2156,9 +2415,17 @@ def cmd_task_daemon(args: argparse.Namespace) -> None:
         assert_legacy_scheduler_allowed(config, (task.id for task in tasks))
         queued = _daemon_select_runnable(config, tasks, limit=max(1, args.parallel))
         if queued:
-            with ThreadPoolExecutor(max_workers=max(1, args.parallel), thread_name_prefix="dyro-dispatch") as pool:
+            with ThreadPoolExecutor(
+                max_workers=max(1, args.parallel), thread_name_prefix="dyro-dispatch"
+            ) as pool:
                 futures = {
-                    pool.submit(run_task, config, task, dry_run=args.dry_run, legacy_scheduler=True): task
+                    pool.submit(
+                        run_task,
+                        config,
+                        task,
+                        dry_run=args.dry_run,
+                        legacy_scheduler=True,
+                    ): task
                     for task in queued
                 }
                 for future in as_completed(futures):
@@ -2169,8 +2436,13 @@ def cmd_task_daemon(args: argparse.Namespace) -> None:
                         print(f"skip {task.id}: {exc}")
         review_queue = list(plan_tasks(config).review)
         if review_queue:
-            with ThreadPoolExecutor(max_workers=max(1, args.parallel), thread_name_prefix="dyro-review") as pool:
-                futures = {pool.submit(review_task, config, task, dry_run=args.dry_run): task for task in review_queue}
+            with ThreadPoolExecutor(
+                max_workers=max(1, args.parallel), thread_name_prefix="dyro-review"
+            ) as pool:
+                futures = {
+                    pool.submit(review_task, config, task, dry_run=args.dry_run): task
+                    for task in review_queue
+                }
                 for future in as_completed(futures):
                     task = futures[future]
                     try:
@@ -2184,17 +2456,26 @@ def cmd_task_daemon(args: argparse.Namespace) -> None:
 
 def _add_common(parser: argparse.ArgumentParser) -> None:
     location = parser.add_mutually_exclusive_group()
-    location.add_argument("--root", help="工作区根目录；默认从当前目录向上查找 dyro.toml")
+    location.add_argument(
+        "--root", help="工作区根目录；默认从当前目录向上查找 dyro.toml"
+    )
     location.add_argument(
         "--workspace",
         dest="workspace_alias",
         help="全局登记的工作区别名；可从任意目录使用",
     )
-    parser.add_argument("--dry-run", action="store_true", help="仅输出计划，不写文件、不调用 Agent 或 Git 写操作")
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="仅输出计划，不写文件、不调用 Agent 或 Git 写操作",
+    )
 
 
 def build_parser() -> argparse.ArgumentParser:
-    parser = argparse.ArgumentParser(prog="dyro", description="DyroEngineeringFlow：本地优先的多仓工程自动化与交付控制平台")
+    parser = argparse.ArgumentParser(
+        prog="dyro",
+        description="DyroEngineeringFlow：本地优先的多仓工程自动化与交付控制平台",
+    )
     parser.add_argument("--version", action="version", version=f"dyro {__version__}")
     _add_common(parser)
     sub = parser.add_subparsers(dest="command")
@@ -2210,17 +2491,29 @@ def build_parser() -> argparse.ArgumentParser:
     init.add_argument("--name", default="my-workspace")
     init.add_argument("--base", default="main", help="--discover 时写入的默认基线分支")
     init_mode = init.add_mutually_exclusive_group()
-    init_mode.add_argument("--wizard", action="store_true", help="交互式登记真实仓库与可选 remote")
-    init_mode.add_argument("--discover", action="store_true", help="自动发现当前目录下的 Git 仓库并登记 origin")
+    init_mode.add_argument(
+        "--wizard", action="store_true", help="交互式登记真实仓库与可选 remote"
+    )
+    init_mode.add_argument(
+        "--discover",
+        action="store_true",
+        help="自动发现当前目录下的 Git 仓库并登记 origin",
+    )
     init.set_defaults(func=cmd_init)
 
-    setup = sub.add_parser("setup", help="首次引导：预览并安全创建 Profile、仓库与首条开发线")
+    setup = sub.add_parser(
+        "setup", help="首次引导：预览并安全创建 Profile、仓库与首条开发线"
+    )
     setup.add_argument("path", nargs="?", default=".")
     setup.add_argument("--name", help="新 Profile 的工作区名称；默认由目录名推断")
     setup.add_argument("--base", help="首条开发线与新 Profile 的默认基线；默认 main")
     setup.add_argument("--line", default="dev", help="首条功能开发线 ID；默认 dev")
     setup.add_argument("--branch", help="首条开发线分支；默认 feat/<line>")
-    setup.add_argument("--no-line", action="store_true", help="仅建立 Profile，不创建 Git worktree 开发线")
+    setup.add_argument(
+        "--no-line",
+        action="store_true",
+        help="仅建立 Profile，不创建 Git worktree 开发线",
+    )
     setup.add_argument(
         "--yes",
         action="store_true",
@@ -2239,9 +2532,15 @@ def build_parser() -> argparse.ArgumentParser:
         help="登记后设为裸 dyro 的默认项目",
     )
     setup_mode = setup.add_mutually_exclusive_group()
-    setup_mode.add_argument("--interactive", action="store_true", help="强制运行交互式首次设置")
-    setup_mode.add_argument("--non-interactive", action="store_true", help="禁用交互提示；适合脚本与 CI")
-    setup.add_argument("--quick", action="store_true", help="只检查现有 Profile 并给出下一步")
+    setup_mode.add_argument(
+        "--interactive", action="store_true", help="强制运行交互式首次设置"
+    )
+    setup_mode.add_argument(
+        "--non-interactive", action="store_true", help="禁用交互提示；适合脚本与 CI"
+    )
+    setup.add_argument(
+        "--quick", action="store_true", help="只检查现有 Profile 并给出下一步"
+    )
     setup.add_argument(
         "--dry-run",
         dest="dry_run",
@@ -2253,32 +2552,50 @@ def build_parser() -> argparse.ArgumentParser:
 
     sub.add_parser("home", help="打开当前或默认项目首页").set_defaults(func=cmd_home)
     console = sub.add_parser("console", help="启动只读本地项目控制台")
-    console.add_argument("--no-open", action="store_true", help="不自动打开浏览器，打印一次性本地 URL")
-    console.add_argument("--port", type=int, default=0, help="loopback 端口；默认 0 由系统分配")
+    console.add_argument(
+        "--no-open", action="store_true", help="不自动打开浏览器，打印一次性本地 URL"
+    )
+    console.add_argument(
+        "--port", type=int, default=0, help="loopback 端口；默认 0 由系统分配"
+    )
     console.set_defaults(func=cmd_console)
     workspace = sub.add_parser("workspace", help="管理可从任意目录进入的全局工作区")
     workspace_sub = workspace.add_subparsers(dest="workspace_command", required=True)
     workspace_add = workspace_sub.add_parser("add", help="登记已有 Dyro 工作区")
     workspace_add.add_argument("path", nargs="?", default=".")
-    workspace_add.add_argument("--name", help="便于记忆的工作区别名；默认读取 Profile 名称")
-    workspace_add.add_argument("--default", action="store_true", help="设为裸 dyro 的默认项目")
+    workspace_add.add_argument(
+        "--name", help="便于记忆的工作区别名；默认读取 Profile 名称"
+    )
+    workspace_add.add_argument(
+        "--default", action="store_true", help="设为裸 dyro 的默认项目"
+    )
     workspace_add.set_defaults(func=cmd_workspace_add)
     workspace_sub.add_parser("list", help="显示已登记工作区及可用状态").set_defaults(
         func=cmd_workspace_list
     )
-    workspace_default = workspace_sub.add_parser("default", help="设置裸 dyro 的默认项目")
+    workspace_default = workspace_sub.add_parser(
+        "default", help="设置裸 dyro 的默认项目"
+    )
     workspace_default.add_argument("name")
     workspace_default.set_defaults(func=cmd_workspace_default)
-    workspace_remove = workspace_sub.add_parser("remove", help="移除全局入口，不删除项目文件")
+    workspace_remove = workspace_sub.add_parser(
+        "remove", help="移除全局入口，不删除项目文件"
+    )
     workspace_remove.add_argument("name")
     workspace_remove.add_argument("--yes", action="store_true")
     workspace_remove.set_defaults(func=cmd_workspace_remove)
 
     blueprint = sub.add_parser("blueprint", help="验证可复用的团队工作区蓝图")
     blueprint_sub = blueprint.add_subparsers(dest="blueprint_command", required=True)
-    blueprint_validate = blueprint_sub.add_parser("validate", help="只读验证蓝图结构与固定基线")
-    blueprint_validate.add_argument("source", help="本地 TOML/目录、HTTPS 文件或 Git 仓库")
-    blueprint_validate.add_argument("--ref", dest="blueprint_ref", help="Git 蓝图仓库的分支或 tag")
+    blueprint_validate = blueprint_sub.add_parser(
+        "validate", help="只读验证蓝图结构与固定基线"
+    )
+    blueprint_validate.add_argument(
+        "source", help="本地 TOML/目录、HTTPS 文件或 Git 仓库"
+    )
+    blueprint_validate.add_argument(
+        "--ref", dest="blueprint_ref", help="Git 蓝图仓库的分支或 tag"
+    )
     blueprint_validate.add_argument(
         "--file",
         dest="blueprint_file",
@@ -2289,7 +2606,9 @@ def build_parser() -> argparse.ArgumentParser:
 
     join = sub.add_parser("join", help="从团队蓝图安全创建独立的多仓工作区")
     join.add_argument("source", help="本地 TOML/目录、HTTPS 文件或 Git 仓库")
-    join.add_argument("--path", help="目标目录；默认 ~/DyroProjects/<suggested_directory>")
+    join.add_argument(
+        "--path", help="目标目录；默认 ~/DyroProjects/<suggested_directory>"
+    )
     join.add_argument("--line", help="要创建的开发线；默认交互选择或使用蓝图默认值")
     join.add_argument("--ref", dest="blueprint_ref", help="Git 蓝图仓库的分支或 tag")
     join.add_argument(
@@ -2300,7 +2619,9 @@ def build_parser() -> argparse.ArgumentParser:
     )
     join.add_argument("--yes", action="store_true", help="确认执行已展示的加入计划")
     registration = join.add_mutually_exclusive_group()
-    registration.add_argument("--no-register", action="store_true", help="不登记到裸 dyro 的全局首页")
+    registration.add_argument(
+        "--no-register", action="store_true", help="不登记到裸 dyro 的全局首页"
+    )
     registration.add_argument(
         "--default",
         dest="make_default",
@@ -2318,7 +2639,9 @@ def build_parser() -> argparse.ArgumentParser:
 
     sub.add_parser("doctor", help="验证动态工作区结构").set_defaults(func=cmd_doctor)
     terminology = sub.add_parser("terminology", help="使用仓库外策略扫描候选术语")
-    terminology_sub = terminology.add_subparsers(dest="terminology_command", required=True)
+    terminology_sub = terminology.add_subparsers(
+        dest="terminology_command", required=True
+    )
     terminology_check = terminology_sub.add_parser(
         "check",
         help="扫描工作区、分支、diff 与提交候选；策略不写入仓库",
@@ -2340,9 +2663,13 @@ def build_parser() -> argparse.ArgumentParser:
     )
     terminology_check.set_defaults(func=cmd_terminology_check)
     status_parser = sub.add_parser("status", help="显示 anchors 与开发线 Git 状态")
-    status_parser.add_argument("--all", action="store_true", help="汇总所有全局登记工作区")
+    status_parser.add_argument(
+        "--all", action="store_true", help="汇总所有全局登记工作区"
+    )
     status_parser.set_defaults(func=cmd_status)
-    bootstrap_parser = sub.add_parser("bootstrap", help="clone 配置了 remote 的缺失仓库 anchor")
+    bootstrap_parser = sub.add_parser(
+        "bootstrap", help="clone 配置了 remote 的缺失仓库 anchor"
+    )
     bootstrap_parser.add_argument("--yes", action="store_true")
     bootstrap_parser.set_defaults(func=cmd_bootstrap)
     repo = sub.add_parser("repo", help="免手改 TOML 的仓库配置管理")
@@ -2352,21 +2679,31 @@ def build_parser() -> argparse.ArgumentParser:
     repo_add.add_argument("path", help="工作区内的仓库路径")
     repo_add.add_argument("--id", help="仓库标识；默认使用目录名")
     repo_add.add_argument("--mount", help="开发线内挂载路径；默认智能推断")
-    repo_add.add_argument("--remote", help="缺失路径的 clone remote，或覆盖自动发现的 origin")
+    repo_add.add_argument(
+        "--remote", help="缺失路径的 clone remote，或覆盖自动发现的 origin"
+    )
     repo_add.set_defaults(func=cmd_repo_add)
     agent = sub.add_parser("agent", help="Agent adapters")
     agent_sub = agent.add_subparsers(dest="agent_command", required=True)
-    agent_sub.add_parser("list", help="显示已登记的 Agent adapter").set_defaults(func=cmd_agent_list)
-    agent_sub.add_parser("discover", help="检测本机 Agent，并区分已配置与尚未集成").set_defaults(
-        func=cmd_agent_discover
+    agent_sub.add_parser("list", help="显示已登记的 Agent adapter").set_defaults(
+        func=cmd_agent_list
     )
-    agent_add = agent_sub.add_parser("add", help="通过预设或命令登记 Agent，无需编辑 TOML")
+    agent_sub.add_parser(
+        "discover", help="检测本机 Agent，并区分已配置与尚未集成"
+    ).set_defaults(func=cmd_agent_discover)
+    agent_add = agent_sub.add_parser(
+        "add", help="通过预设或命令登记 Agent，无需编辑 TOML"
+    )
     agent_add.add_argument("id")
     agent_source = agent_add.add_mutually_exclusive_group(required=True)
     agent_source.add_argument("--preset", choices=("codex", "noop"))
-    agent_source.add_argument("--command", help="作为 launch/read/write 的 argv 命令行；不会经 shell 执行")
+    agent_source.add_argument(
+        "--command", help="作为 launch/read/write 的 argv 命令行；不会经 shell 执行"
+    )
     agent_add.set_defaults(func=cmd_agent_add)
-    agent_test = agent_sub.add_parser("test", help="仅检查 adapter 可执行文件是否可用，不启动 Agent")
+    agent_test = agent_sub.add_parser(
+        "test", help="仅检查 adapter 可执行文件是否可用，不启动 Agent"
+    )
     agent_test.add_argument("id")
     agent_test.set_defaults(func=cmd_agent_test)
     tool = sub.add_parser("tool", help="发现、排序和安全安装本地编码工具")
@@ -2376,7 +2713,9 @@ def build_parser() -> argparse.ArgumentParser:
     )
     tool_install = tool_sub.add_parser("install", help="显示并执行内置的官方安装方案")
     tool_install.add_argument("id")
-    tool_install.add_argument("--yes", action="store_true", help="确认执行已展示的安装命令或打开官方页面")
+    tool_install.add_argument(
+        "--yes", action="store_true", help="确认执行已展示的安装命令或打开官方页面"
+    )
     tool_install.set_defaults(func=cmd_tool_install)
     tool_default = tool_sub.add_parser("default", help="设置个人默认工具")
     tool_default.add_argument("id", nargs="?")
@@ -2388,14 +2727,18 @@ def build_parser() -> argparse.ArgumentParser:
     tool_pin.set_defaults(func=cmd_tool_pin)
     update = sub.add_parser("update", help="检测并安全更新 Dyro")
     update_sub = update.add_subparsers(dest="update_command", required=True)
-    update_sub.add_parser("check", help="立即检查官方 PyPI 的最新稳定版本").set_defaults(
-        func=cmd_update_check
-    )
+    update_sub.add_parser(
+        "check", help="立即检查官方 PyPI 的最新稳定版本"
+    ).set_defaults(func=cmd_update_check)
     update_now = update_sub.add_parser("now", help="显示计划并更新到最新稳定版本")
-    update_now.add_argument("--yes", action="store_true", help="确认执行已展示的更新命令")
+    update_now.add_argument(
+        "--yes", action="store_true", help="确认执行已展示的更新命令"
+    )
     update_now.set_defaults(func=cmd_update_now)
     update_auto = update_sub.add_parser("auto", help="管理补丁版本自动更新")
-    update_auto.add_argument("mode", choices=("on", "off", "status"), nargs="?", default="status")
+    update_auto.add_argument(
+        "mode", choices=("on", "off", "status"), nargs="?", default="status"
+    )
     update_auto.set_defaults(func=cmd_update_auto)
     update_sub.add_parser("enable", help="开启每日首次交互运行更新检测").set_defaults(
         func=cmd_update_enabled
@@ -2414,12 +2757,16 @@ def build_parser() -> argparse.ArgumentParser:
     config_set.set_defaults(func=cmd_config_set)
     key = sub.add_parser("key", help="Ed25519 签名密钥与工作区信任根")
     key_sub = key.add_subparsers(dest="key_command", required=True)
-    key_generate = key_sub.add_parser("generate", help="生成 runner 或 approver Ed25519 密钥对")
+    key_generate = key_sub.add_parser(
+        "generate", help="生成 runner 或 approver Ed25519 密钥对"
+    )
     key_generate.add_argument("id")
     key_generate.add_argument("--private-key", required=True)
     key_generate.add_argument("--public-key", required=True)
     key_generate.set_defaults(func=cmd_key_generate)
-    key_trust = key_sub.add_parser("trust", help="将公钥安装到用途隔离的工作区 trust store")
+    key_trust = key_sub.add_parser(
+        "trust", help="将公钥安装到用途隔离的工作区 trust store"
+    )
     key_trust.add_argument("id")
     key_trust.add_argument(
         "--purpose",
@@ -2431,7 +2778,9 @@ def build_parser() -> argparse.ArgumentParser:
     key_trust.add_argument("--not-before", help="ISO-8601 生效时间；必须包含时区")
     key_trust.add_argument("--not-after", help="ISO-8601 失效时间；必须包含时区")
     key_trust.set_defaults(func=cmd_key_trust)
-    key_revoke = key_sub.add_parser("revoke", help="撤销指定用途的 trusted key ID；保留公钥与审计记录")
+    key_revoke = key_sub.add_parser(
+        "revoke", help="撤销指定用途的 trusted key ID；保留公钥与审计记录"
+    )
     key_revoke.add_argument("id")
     key_revoke.add_argument(
         "--purpose",
@@ -2446,9 +2795,15 @@ def build_parser() -> argparse.ArgumentParser:
         choices=TRUST_PURPOSES,
         required=True,
     )
-    key_list.add_argument("--show-status", action="store_true", help="同时显示 pending、expired 与 revoked key")
+    key_list.add_argument(
+        "--show-status",
+        action="store_true",
+        help="同时显示 pending、expired 与 revoked key",
+    )
     key_list.set_defaults(func=cmd_key_list)
-    key_sub.add_parser("audit", help="输出 trust/revoke JSONL 审计记录").set_defaults(func=cmd_key_audit)
+    key_sub.add_parser("audit", help="输出 trust/revoke JSONL 审计记录").set_defaults(
+        func=cmd_key_audit
+    )
     key_audit_sync = key_sub.add_parser(
         "audit-sync",
         help="将本地 trust 审计链同步到远程 Witness",
@@ -2470,7 +2825,9 @@ def build_parser() -> argparse.ArgumentParser:
     key_audit_sync.set_defaults(func=cmd_key_audit_sync)
     witness = sub.add_parser("witness", help="运行独立的远程 audit Witness 服务")
     witness_sub = witness.add_subparsers(dest="witness_command", required=True)
-    witness_serve = witness_sub.add_parser("serve", help="验证批次、签发回执并持久化 Witness ledger")
+    witness_serve = witness_sub.add_parser(
+        "serve", help="验证批次、签发回执并持久化 Witness ledger"
+    )
     witness_serve.add_argument("--storage-root", required=True)
     witness_serve.add_argument("--client-trust-root", required=True)
     witness_serve.add_argument("--witness-id", required=True)
@@ -2514,7 +2871,9 @@ def build_parser() -> argparse.ArgumentParser:
     start.add_argument("--agent")
     start.add_argument("--prompt", default="")
     start.set_defaults(func=cmd_start)
-    sub.add_parser("next", help="根据当前状态给出新手的唯一安全下一步").set_defaults(func=cmd_next)
+    sub.add_parser("next", help="根据当前状态给出新手的唯一安全下一步").set_defaults(
+        func=cmd_next
+    )
 
     line = sub.add_parser("line", help="功能开发线")
     line_sub = line.add_subparsers(dest="line_command", required=True)
@@ -2525,9 +2884,21 @@ def build_parser() -> argparse.ArgumentParser:
     line_create.add_argument("id")
     line_create.add_argument("--branch")
     line_create.add_argument("--base")
-    line_create.add_argument("--repos", help="逗号分隔；默认全部 configured repositories")
-    line_create.add_argument("--repo-base", action="append", metavar="REPOSITORY=REF", help="为一个仓库覆盖默认基线；可重复")
-    line_create.add_argument("--storage", action="append", metavar="REPOSITORY=MODE", help="仓库存储方式：linked-worktree 或 anchor-reference；可重复")
+    line_create.add_argument(
+        "--repos", help="逗号分隔；默认全部 configured repositories"
+    )
+    line_create.add_argument(
+        "--repo-base",
+        action="append",
+        metavar="REPOSITORY=REF",
+        help="为一个仓库覆盖默认基线；可重复",
+    )
+    line_create.add_argument(
+        "--storage",
+        action="append",
+        metavar="REPOSITORY=MODE",
+        help="仓库存储方式：linked-worktree 或 anchor-reference；可重复",
+    )
     line_create.add_argument("--yes", action="store_true")
     line_create.set_defaults(func=cmd_line_create)
 
@@ -2538,8 +2909,18 @@ def build_parser() -> argparse.ArgumentParser:
     hotfix_create.add_argument("--branch")
     hotfix_create.add_argument("--base", required=True)
     hotfix_create.add_argument("--repos")
-    hotfix_create.add_argument("--repo-base", action="append", metavar="REPOSITORY=REF", help="为一个仓库覆盖 --base；可重复")
-    hotfix_create.add_argument("--storage", action="append", metavar="REPOSITORY=MODE", help="仓库存储方式：linked-worktree 或 anchor-reference；可重复")
+    hotfix_create.add_argument(
+        "--repo-base",
+        action="append",
+        metavar="REPOSITORY=REF",
+        help="为一个仓库覆盖 --base；可重复",
+    )
+    hotfix_create.add_argument(
+        "--storage",
+        action="append",
+        metavar="REPOSITORY=MODE",
+        help="仓库存储方式：linked-worktree 或 anchor-reference；可重复",
+    )
     hotfix_create.add_argument("--yes", action="store_true")
     hotfix_create.set_defaults(func=cmd_hotfix_create)
 
@@ -2555,33 +2936,53 @@ def build_parser() -> argparse.ArgumentParser:
     changeset_verify.add_argument("id")
     changeset_verify.set_defaults(func=cmd_changeset_verify)
 
-    objective = sub.add_parser("objective", help="持久化并观察一个跨任务 Objective；此阶段不执行 Task")
+    objective = sub.add_parser(
+        "objective", help="持久化并观察一个跨任务 Objective；此阶段不执行 Task"
+    )
     objective_sub = objective.add_subparsers(dest="objective_command", required=True)
-    objective_start = objective_sub.add_parser("start", help="固定 Objective 合约、目标和依赖闭包")
+    objective_start = objective_sub.add_parser(
+        "start", help="固定 Objective 合约、目标和依赖闭包"
+    )
     objective_start.add_argument("--file", help="完整 Objective v1 TOML 合约")
     objective_start.add_argument("--id")
     objective_start.add_argument("--title")
     objective_start.add_argument("--line")
     objective_start.add_argument("--targets", help="逗号分隔的 Task ID；非文件模式必填")
-    objective_start.add_argument("--mode", choices=tuple(item.value for item in RequestedMode))
-    objective_start.add_argument("--operation", action="append", choices=tuple(item.value for item in Operation))
+    objective_start.add_argument(
+        "--mode", choices=tuple(item.value for item in RequestedMode)
+    )
+    objective_start.add_argument(
+        "--operation", action="append", choices=tuple(item.value for item in Operation)
+    )
     objective_start.add_argument("--yes", action="store_true")
     objective_start.set_defaults(func=cmd_objective_start)
-    objective_sub.add_parser("list", help="列出已接受的 Objective").set_defaults(func=cmd_objective_list)
-    objective_status = objective_sub.add_parser("status", help="显示 Objective 状态和派生结果")
+    objective_sub.add_parser("list", help="列出已接受的 Objective").set_defaults(
+        func=cmd_objective_list
+    )
+    objective_status = objective_sub.add_parser(
+        "status", help="显示 Objective 状态和派生结果"
+    )
     objective_status.add_argument("id")
     objective_status.set_defaults(func=cmd_objective_status)
-    objective_plan = objective_sub.add_parser("plan", help="只读生成确定性 Objective action plan，不执行任务")
+    objective_plan = objective_sub.add_parser(
+        "plan", help="只读生成确定性 Objective action plan，不执行任务"
+    )
     objective_plan.add_argument("id")
     objective_plan.add_argument("--format", choices=("text", "json"), default="text")
     objective_plan.set_defaults(func=cmd_objective_plan)
-    objective_explain = objective_sub.add_parser("explain", help="解释 Objective 当前的可推进项与阻塞原因")
+    objective_explain = objective_sub.add_parser(
+        "explain", help="解释 Objective 当前的可推进项与阻塞原因"
+    )
     objective_explain.add_argument("id")
     objective_explain.add_argument("--format", choices=("text", "json"), default="text")
     objective_explain.set_defaults(func=cmd_objective_explain)
-    objective_graph = objective_sub.add_parser("graph", help="渲染 Objective、Task、Decision 与 Action 的只读组合图")
+    objective_graph = objective_sub.add_parser(
+        "graph", help="渲染 Objective、Task、Decision 与 Action 的只读组合图"
+    )
     objective_graph.add_argument("id")
-    objective_graph.add_argument("--format", choices=("mermaid", "json"), default="mermaid")
+    objective_graph.add_argument(
+        "--format", choices=("mermaid", "json"), default="mermaid"
+    )
     objective_graph.set_defaults(func=cmd_objective_graph)
     objective_tick = objective_sub.add_parser(
         "tick", help="预览下一组有界 Objective Action；不创建 intent 或执行任务"
@@ -2593,29 +2994,43 @@ def build_parser() -> argparse.ArgumentParser:
         "attention", help="显示安全且只读的 Objective Attention 投影"
     )
     objective_attention.add_argument("id")
-    objective_attention.add_argument("--format", choices=("text", "json"), default="text")
+    objective_attention.add_argument(
+        "--format", choices=("text", "json"), default="text"
+    )
     objective_attention.set_defaults(func=cmd_objective_attention)
     objective_apply = objective_sub.add_parser(
         "apply",
         help="显示精确 Action wave；确认后仅受监督地执行 execute/review，不 merge 或 push",
     )
     objective_apply.add_argument("id")
-    objective_apply.add_argument("--confirm-sha", help="非交互 --yes 必填；必须等于当前 Confirmation SHA-256")
-    objective_apply.add_argument("--yes", action="store_true", help="确认当前显示的精确 wave 后执行")
+    objective_apply.add_argument(
+        "--confirm-sha", help="非交互 --yes 必填；必须等于当前 Confirmation SHA-256"
+    )
+    objective_apply.add_argument(
+        "--yes", action="store_true", help="确认当前显示的精确 wave 后执行"
+    )
     objective_apply.add_argument("--format", choices=("text", "json"), default="text")
     objective_apply.set_defaults(func=cmd_objective_apply)
     for command, function, help_text in (
         ("pause", cmd_objective_pause, "暂停后续推进，不写完成状态"),
         ("resume", cmd_objective_resume, "恢复 paused Objective 的 ownership"),
         ("stop", cmd_objective_stop, "终止 Objective；不能再恢复"),
-        ("reconcile", cmd_objective_reconcile, "重新固定 TaskGraph scope 与 contract 哈希"),
+        (
+            "reconcile",
+            cmd_objective_reconcile,
+            "重新固定 TaskGraph scope 与 contract 哈希",
+        ),
     ):
         parser_item = objective_sub.add_parser(command, help=help_text)
         parser_item.add_argument("id")
         parser_item.add_argument("--yes", action="store_true")
         parser_item.set_defaults(func=function)
-    objective_scope = objective_sub.add_parser("scope", help="显式调整 Objective targets 并建立新 revision")
-    objective_scope_sub = objective_scope.add_subparsers(dest="objective_scope_command", required=True)
+    objective_scope = objective_sub.add_parser(
+        "scope", help="显式调整 Objective targets 并建立新 revision"
+    )
+    objective_scope_sub = objective_scope.add_subparsers(
+        dest="objective_scope_command", required=True
+    )
     for command, function, help_text in (
         ("add", cmd_objective_scope_add, "将同一开发线的 Task 加入 targets"),
         ("remove", cmd_objective_scope_remove, "从 targets 移除一个 Task"),
@@ -2626,42 +3041,70 @@ def build_parser() -> argparse.ArgumentParser:
         parser_item.add_argument("--yes", action="store_true")
         parser_item.set_defaults(func=function)
 
-    trigger = sub.add_parser("trigger", help="只读 Trigger 观测与有界 provider 协议入口")
+    trigger = sub.add_parser(
+        "trigger", help="只读 Trigger 观测与有界 provider 协议入口"
+    )
     trigger_sub = trigger.add_subparsers(dest="trigger_command", required=True)
-    trigger_list = trigger_sub.add_parser("list", help="列出内置 Trigger 类型与 provider 边界")
+    trigger_list = trigger_sub.add_parser(
+        "list", help="列出内置 Trigger 类型与 provider 边界"
+    )
     trigger_list.add_argument("--format", choices=("text", "json"), default="text")
     trigger_list.set_defaults(func=cmd_trigger_list)
-    trigger_probe = trigger_sub.add_parser("probe", help="用显式事实执行一次只读内置 Trigger 观测")
-    trigger_probe.add_argument("kind", choices=tuple(item.value for item in TriggerKind))
+    trigger_probe = trigger_sub.add_parser(
+        "probe", help="用显式事实执行一次只读内置 Trigger 观测"
+    )
+    trigger_probe.add_argument(
+        "kind", choices=tuple(item.value for item in TriggerKind)
+    )
     trigger_probe.add_argument("--id", default="manual-probe")
-    trigger_probe.add_argument("--at", help="观测时间（带时区 ISO-8601）；默认当前 UTC 时间")
-    trigger_probe.add_argument("--not-before", help="time_due 的最早触发时间（带时区 ISO-8601）")
-    trigger_probe.add_argument("--current", action="append", metavar="KEY=VALUE", help="当前事实；可重复指定")
-    trigger_probe.add_argument("--previous", action="append", metavar="KEY=VALUE", help="上次事实；可重复指定")
+    trigger_probe.add_argument(
+        "--at", help="观测时间（带时区 ISO-8601）；默认当前 UTC 时间"
+    )
+    trigger_probe.add_argument(
+        "--not-before", help="time_due 的最早触发时间（带时区 ISO-8601）"
+    )
+    trigger_probe.add_argument(
+        "--current", action="append", metavar="KEY=VALUE", help="当前事实；可重复指定"
+    )
+    trigger_probe.add_argument(
+        "--previous", action="append", metavar="KEY=VALUE", help="上次事实；可重复指定"
+    )
     trigger_probe.add_argument("--signal", help="manual_signal 的非空人工信号")
     trigger_probe.add_argument("--format", choices=("text", "json"), default="text")
     trigger_probe.set_defaults(func=cmd_trigger_probe)
-    trigger_signal = trigger_sub.add_parser("signal", help="输出一次临时人工信号观测，不写入任务或控制面")
+    trigger_signal = trigger_sub.add_parser(
+        "signal", help="输出一次临时人工信号观测，不写入任务或控制面"
+    )
     trigger_signal.add_argument("signal")
     trigger_signal.add_argument("--id", default="manual-signal")
-    trigger_signal.add_argument("--at", help="观测时间（带时区 ISO-8601）；默认当前 UTC 时间")
+    trigger_signal.add_argument(
+        "--at", help="观测时间（带时区 ISO-8601）；默认当前 UTC 时间"
+    )
     trigger_signal.add_argument("--format", choices=("text", "json"), default="text")
     trigger_signal.set_defaults(func=cmd_trigger_signal)
 
     task = sub.add_parser("task", help="任务编排")
     task_sub = task.add_subparsers(dest="task_command", required=True)
     task_graph = task_sub.add_parser("graph", help="编译、校验或渲染任务图")
-    task_graph.add_argument("action", nargs="?", choices=("show", "check"), default="show")
+    task_graph.add_argument(
+        "action", nargs="?", choices=("show", "check"), default="show"
+    )
     task_graph.add_argument("--line", help="只显示或校验指定开发线")
     task_graph.add_argument("--format", choices=("mermaid", "json"), default="mermaid")
     task_graph.set_defaults(func=cmd_task_graph)
-    task_explain = task_sub.add_parser("explain", help="解释任务当前为什么可调度或被阻塞")
+    task_explain = task_sub.add_parser(
+        "explain", help="解释任务当前为什么可调度或被阻塞"
+    )
     task_explain.add_argument("id")
     task_explain.set_defaults(func=cmd_task_explain)
-    task_attempts = task_sub.add_parser("attempts", help="显示任务的本地执行 provenance")
+    task_attempts = task_sub.add_parser(
+        "attempts", help="显示任务的本地执行 provenance"
+    )
     task_attempts.add_argument("id")
     task_attempts.set_defaults(func=cmd_task_attempts)
-    task_binding = task_sub.add_parser("binding", help="输出 review 所需的完整 attempt 与 plan binding")
+    task_binding = task_sub.add_parser(
+        "binding", help="输出 review 所需的完整 attempt 与 plan binding"
+    )
     task_binding.add_argument("id")
     task_binding.set_defaults(func=cmd_task_binding)
     task_create = task_sub.add_parser("create")
@@ -2680,7 +3123,9 @@ def build_parser() -> argparse.ArgumentParser:
     task_run = task_sub.add_parser("run")
     task_run.add_argument("id")
     task_run.set_defaults(func=cmd_task_run)
-    task_open = task_sub.add_parser("open", help="进入已存在的任务工作树，不改变任务状态")
+    task_open = task_sub.add_parser(
+        "open", help="进入已存在的任务工作树，不改变任务状态"
+    )
     task_open.add_argument("id")
     task_open.add_argument("--agent", default="codex")
     task_open.add_argument("--prompt", default="")
@@ -2689,20 +3134,32 @@ def build_parser() -> argparse.ArgumentParser:
     task_claim.add_argument("id")
     task_claim.add_argument("--by", required=True, help="执行器实例或受信任身份")
     task_claim.add_argument("--key-id", help="与 claim 绑定的 trusted execution key ID")
-    task_claim.add_argument("--lease-seconds", type=int, default=3600, help="claim 租约秒数；默认 3600")
+    task_claim.add_argument(
+        "--lease-seconds", type=int, default=3600, help="claim 租约秒数；默认 3600"
+    )
     task_claim.add_argument(
         "--output",
         help="把新 claim 以 0600 权限导出到 runner 交接路径；拒绝覆盖",
     )
     task_claim.set_defaults(func=cmd_task_claim)
-    task_claim_renew = task_sub.add_parser("claim-renew", help="由当前 runner 续租未过期 claim")
+    task_claim_renew = task_sub.add_parser(
+        "claim-renew", help="由当前 runner 续租未过期 claim"
+    )
     task_claim_renew.add_argument("id")
-    task_claim_renew.add_argument("--by", required=True, help="当前执行器实例或受信任身份")
-    task_claim_renew.add_argument("--lease-seconds", type=int, default=3600, help="续租秒数；默认 3600")
+    task_claim_renew.add_argument(
+        "--by", required=True, help="当前执行器实例或受信任身份"
+    )
+    task_claim_renew.add_argument(
+        "--lease-seconds", type=int, default=3600, help="续租秒数；默认 3600"
+    )
     task_claim_renew.set_defaults(func=cmd_task_claim_renew)
-    task_claim_release = task_sub.add_parser("claim-release", help="释放当前 runner 的 claim")
+    task_claim_release = task_sub.add_parser(
+        "claim-release", help="释放当前 runner 的 claim"
+    )
     task_claim_release.add_argument("id")
-    task_claim_release.add_argument("--by", required=True, help="当前执行器实例或受信任身份")
+    task_claim_release.add_argument(
+        "--by", required=True, help="当前执行器实例或受信任身份"
+    )
     task_claim_release.set_defaults(func=cmd_task_claim_release)
     task_next = task_sub.add_parser("next", help="显示或启动下一个满足依赖的任务")
     task_next.add_argument("--id")
@@ -2729,32 +3186,64 @@ def build_parser() -> argparse.ArgumentParser:
     task_signoff.set_defaults(func=cmd_task_signoff)
     evidence = task_sub.add_parser("evidence", help="构建或导入隔离执行器证据")
     evidence_sub = evidence.add_subparsers(dest="evidence_command", required=True)
-    evidence_execution = evidence_sub.add_parser("execution", help="导入执行回执与门禁结果")
+    evidence_execution = evidence_sub.add_parser(
+        "execution", help="导入执行回执与门禁结果"
+    )
     evidence_execution.add_argument("id")
     evidence_input = evidence_execution.add_mutually_exclusive_group(required=True)
     evidence_input.add_argument("--receipt")
-    evidence_input.add_argument("--bundle", help="由 task evidence build 生成的可移植 ZIP 证据包")
-    evidence_execution.add_argument("--gates", help="外部门禁 JSON；任务含 gates 时必填")
-    evidence_execution.add_argument("--heads", help="执行后逐仓 Git HEAD JSON；DONE 回执时必填")
-    evidence_execution.add_argument("--provenance", help="可选的外部 execution provenance JSON")
-    evidence_execution.add_argument("--allow-legacy", action="store_true", help="显式允许导入缺少 provenance 的旧证据")
+    evidence_input.add_argument(
+        "--bundle", help="由 task evidence build 生成的可移植 ZIP 证据包"
+    )
+    evidence_execution.add_argument(
+        "--gates", help="外部门禁 JSON；任务含 gates 时必填"
+    )
+    evidence_execution.add_argument(
+        "--heads", help="执行后逐仓 Git HEAD JSON；DONE 回执时必填"
+    )
+    evidence_execution.add_argument(
+        "--provenance", help="可选的外部 execution provenance JSON"
+    )
+    evidence_execution.add_argument(
+        "--allow-legacy",
+        action="store_true",
+        help="显式允许导入缺少 provenance 的旧证据",
+    )
     evidence_execution.set_defaults(func=cmd_task_evidence_execution)
-    evidence_build = evidence_sub.add_parser("build", help="在隔离 runner 中运行门禁并构建可导入 ZIP 证据包")
+    evidence_build = evidence_sub.add_parser(
+        "build", help="在隔离 runner 中运行门禁并构建可导入 ZIP 证据包"
+    )
     evidence_build.add_argument("id")
-    evidence_build.add_argument("--workspace", required=True, help="隔离 runner 中任务分支的多仓工作区")
-    evidence_build.add_argument("--receipt", required=True, help="执行器写出的 receipt.md")
-    evidence_build.add_argument("--output", required=True, help="新 ZIP 证据包的输出路径；拒绝覆盖已有文件")
+    evidence_build.add_argument(
+        "--workspace", required=True, help="隔离 runner 中任务分支的多仓工作区"
+    )
+    evidence_build.add_argument(
+        "--receipt", required=True, help="执行器写出的 receipt.md"
+    )
+    evidence_build.add_argument(
+        "--output", required=True, help="新 ZIP 证据包的输出路径；拒绝覆盖已有文件"
+    )
     evidence_build.add_argument("--signing-key", help="Ed25519 runner 私钥 PEM")
-    evidence_build.add_argument("--key-id", help="已安装到 execution trust store 的 key ID")
-    evidence_build.add_argument("--claim", help="控制面导出的 claim.json；默认读取任务目录")
+    evidence_build.add_argument(
+        "--key-id", help="已安装到 execution trust store 的 key ID"
+    )
+    evidence_build.add_argument(
+        "--claim", help="控制面导出的 claim.json；默认读取任务目录"
+    )
     evidence_build.set_defaults(func=cmd_task_evidence_build)
-    evidence_review = evidence_sub.add_parser("review", help="导入 receipt-bound 复核结果")
+    evidence_review = evidence_sub.add_parser(
+        "review", help="导入 receipt-bound 复核结果"
+    )
     evidence_review.add_argument("id")
     evidence_review.add_argument("--file", required=True)
     evidence_review.set_defaults(func=cmd_task_evidence_review)
-    evidence_review_build = evidence_sub.add_parser("review-build", help="构建独立 reviewer 签名的 review JSON")
+    evidence_review_build = evidence_sub.add_parser(
+        "review-build", help="构建独立 reviewer 签名的 review JSON"
+    )
     evidence_review_build.add_argument("id")
-    evidence_review_build.add_argument("--file", required=True, help="包含 verdict 与绑定字段的 review.md")
+    evidence_review_build.add_argument(
+        "--file", required=True, help="包含 verdict 与绑定字段的 review.md"
+    )
     evidence_review_build.add_argument("--reviewer", required=True)
     evidence_review_build.add_argument("--output", required=True)
     evidence_review_build.add_argument("--signing-key", required=True)
@@ -2765,7 +3254,9 @@ def build_parser() -> argparse.ArgumentParser:
         help="列出证据世代，或按年龄与保留数量安全清理非当前世代",
     )
     evidence_generations.add_argument("id")
-    evidence_generations.add_argument("--prune", action="store_true", help="执行或预演清理计划")
+    evidence_generations.add_argument(
+        "--prune", action="store_true", help="执行或预演清理计划"
+    )
     evidence_generations.add_argument("--older-than-days", type=int, default=30)
     evidence_generations.add_argument("--keep", type=int, default=10)
     evidence_generations.add_argument("--yes", action="store_true")
@@ -2816,9 +3307,7 @@ def _route_experiment_surface(raw: list[str]) -> tuple[str, list[str]] | None:
         dispatch_common.add_argument("--home")
         dispatch_common.add_argument("--dry-run", action="store_true")
         _, dispatch_remaining = dispatch_common.parse_known_args(forwarded)
-        dispatch_command = (
-            dispatch_remaining[0] if dispatch_remaining else ""
-        )
+        dispatch_command = dispatch_remaining[0] if dispatch_remaining else ""
         selected_root = global_args.root
         if global_args.workspace_alias:
             selected_root = str(get_workspace(global_args.workspace_alias).root)
@@ -2859,9 +3348,7 @@ def _maybe_run_daily_update(*, install=perform_update) -> None:
         state = load_update_state()
     except (DyroError, OSError):
         return
-    print(
-        f"\n发现 Dyro {result.latest_version}（当前 {result.current_version}）。"
-    )
+    print(f"\n发现 Dyro {result.latest_version}（当前 {result.current_version}）。")
     if state.auto_patch and result.kind == UpdateKind.PATCH:
         print("已开启补丁版本自动更新，正在安全更新……")
         try:
@@ -2900,7 +3387,16 @@ def main(argv: list[str] | None = None) -> None:
         else:
             cmd_home(args)
     except DyroError as exc:
-        parser.exit(2, f"错误：{exc}\n")
+        parser.exit(2, danger(f"错误：{exc}\n", stream=sys.stderr))
+    except (KeyboardInterrupt, EOFError):
+        parser.exit(
+            130,
+            muted(
+                "\n已停止当前操作；未完成的步骤不会继续。"
+                "若刚开始执行写入、clone 或创建 worktree，请运行 dyro doctor 确认状态。\n",
+                stream=sys.stderr,
+            ),
+        )
 
 
 if __name__ == "__main__":

--- a/src/dyro/cli.py
+++ b/src/dyro/cli.py
@@ -79,9 +79,12 @@ from .home import (
     sort_home_tools,
 )
 from .hub import (
+    WorkspaceRecord,
+    WorkspaceRegistrationPlan,
     add_workspace,
     get_workspace,
     load_registry,
+    preview_workspace_registration,
     remove_workspace,
     set_default_workspace,
 )
@@ -381,16 +384,73 @@ def _setup_provider_preset() -> str | None:
     return None
 
 
-def _render_interactive_setup_plan(plan: SetupPlan) -> None:
+def _setup_registration_plan(
+    root: Path, name: str, args: argparse.Namespace
+) -> WorkspaceRegistrationPlan | None:
+    if args.no_register:
+        return None
+    return preview_workspace_registration(
+        root, name=name, make_default=args.make_default
+    )
+
+
+def _render_setup_registration_plan(
+    registration: WorkspaceRegistrationPlan | None,
+) -> None:
+    if registration is None:
+        print("  - Console：不登记全局入口（--no-register）")
+        return
+    name = registration.name
+    root = registration.root
+    action = "已登记，保持现有入口" if registration.already_registered else "将登记全局入口"
+    default = "；设为默认项目" if registration.becomes_default else "；不改变默认项目"
+    print(f"  - Console：{action} {name} → {root}{default}")
+
+
+def _register_setup_workspace(
+    config: Config, *, register: bool, make_default: bool
+) -> WorkspaceRecord | None:
+    if not register:
+        return None
+    record = add_workspace(
+        config.root, name=config.name, make_default=make_default
+    )
+    default = "（默认项目）" if load_registry().default == record.name else ""
+    print(f"已登记全局入口：{record.name}{default}")
+    return record
+
+
+def _print_setup_completion(
+    config: Config, registration: WorkspaceRecord | None
+) -> None:
+    print("\n设置完成：")
+    print(f"  - Profile：{config.name}")
+    if registration is None:
+        print("  - Console：未登记（--no-register）")
+    else:
+        print(f"  - Console：{registration.name} 已可在 dyro console 中查看")
+    print("下一步：dyro start")
+
+
+def _render_interactive_setup_plan(
+    plan: SetupPlan, registration: WorkspaceRegistrationPlan | None
+) -> None:
     print("\n设置计划（尚未修改任何文件）：")
     for item in render_setup_plan(plan):
         print("  - " + item)
+    _render_setup_registration_plan(registration)
     if plan.needs_bootstrap:
         print("  - 将仅 clone 缺失且已明确提供 remote 的仓库")
     print("  - 不会移动、覆盖或清理现有 Git 仓库")
 
 
-def _apply_setup_plan(plan: SetupPlan, *, dry_run: bool) -> None:
+def _apply_setup_plan(
+    plan: SetupPlan,
+    *,
+    dry_run: bool,
+    register: bool,
+    make_default: bool,
+) -> None:
     if dry_run:
         print("DRY RUN: 上述计划不会写入文件、执行 clone 或创建 Git worktree")
         return
@@ -410,6 +470,9 @@ def _apply_setup_plan(plan: SetupPlan, *, dry_run: bool) -> None:
     )
     config = load(plan.root)
     _ensure_state_directories(config.root)
+    registration = _register_setup_workspace(
+        config, register=register, make_default=make_default
+    )
     if plan.needs_bootstrap:
         for message in bootstrap(config, branch=plan.default_base):
             print(message)
@@ -427,7 +490,7 @@ def _apply_setup_plan(plan: SetupPlan, *, dry_run: bool) -> None:
         print(finding)
     if any(finding.startswith("FAIL") for finding in findings):
         raise DyroError("设置已保存，但 doctor 发现问题；请修复后运行 dyro next")
-    print("\n设置完成。下一步：dyro next")
+    _print_setup_completion(config, registration)
 
 
 def _interactive_setup(args: argparse.Namespace) -> None:
@@ -437,10 +500,21 @@ def _interactive_setup(args: argparse.Namespace) -> None:
     print("Dyro 首次设置。先检查环境，确认前不会修改文件。")
     if config_file.exists():
         config = load(root)
+        registration = _setup_registration_plan(config.root, config.name, args)
         print(f"已发现 Profile：{config_file}（{len(config.repositories)} 个仓库）")
+        _render_setup_registration_plan(registration)
         for finding in doctor(config):
             print(finding)
-        print("下一步：dyro next")
+        if args.dry_run or registration is None:
+            print("下一步：dyro next")
+            return
+        if not args.yes and not _ask_yes_no("将此 Profile 登记到全局 Console", default=False):
+            print("已取消；没有修改全局入口。")
+            return
+        record = _register_setup_workspace(
+            config, register=True, make_default=args.make_default
+        )
+        _print_setup_completion(config, record)
         return
 
     repositories = discover_repositories(root) if root.exists() and not is_git_repository(root) else []
@@ -484,14 +558,25 @@ def _interactive_setup(args: argparse.Namespace) -> None:
         branch=f"feat/{line_id}" if line_id else None,
         provider_preset=provider,
     )
-    _render_interactive_setup_plan(plan)
+    registration = _setup_registration_plan(plan.root, plan.name, args)
+    _render_interactive_setup_plan(plan, registration)
     if args.dry_run:
-        _apply_setup_plan(plan, dry_run=True)
+        _apply_setup_plan(
+            plan,
+            dry_run=True,
+            register=not args.no_register,
+            make_default=args.make_default,
+        )
         return
     if not args.yes and not _ask_yes_no("应用此设置计划", default=False):
         print("已取消；没有修改任何文件。")
         return
-    _apply_setup_plan(plan, dry_run=False)
+    _apply_setup_plan(
+        plan,
+        dry_run=False,
+        register=not args.no_register,
+        make_default=args.make_default,
+    )
 
 
 def _setup_quick(args: argparse.Namespace) -> None:
@@ -511,14 +596,17 @@ def _non_interactive_setup(args: argparse.Namespace) -> None:
     if config_file.exists():
         config = load(root)
         print(f"复用已有 Profile：{config_file}")
+        registration = _setup_registration_plan(config.root, config.name, args)
     else:
         repositories = discover_repositories(root)
         if not repositories:
             raise DyroError("未发现 Git 仓库；请先 clone 仓库到工作区，或使用 dyro init --wizard")
         name = args.name or _default_workspace_name(root)
         validate_id(name, "workspace 名称")
+        registration = _setup_registration_plan(root, name, args)
         if args.dry_run:
             print(f"DRY RUN: 将创建 {config_file}，自动登记 {len(repositories)} 个 Git 仓库")
+            _render_setup_registration_plan(registration)
             if not args.no_line:
                 print(f"DRY RUN: 将创建开发线 {args.line}（分支 {args.branch or f'feat/{args.line}'}）")
             return
@@ -527,8 +615,17 @@ def _non_interactive_setup(args: argparse.Namespace) -> None:
         config = load(root)
         created = True
         print(f"已创建 Profile，并自动登记 {len(repositories)} 个 Git 仓库")
+    if config_file.exists() or not args.dry_run:
+        _render_setup_registration_plan(registration)
     if not args.dry_run:
         _ensure_state_directories(config.root)
+        registered = _register_setup_workspace(
+            config,
+            register=not args.no_register,
+            make_default=args.make_default,
+        )
+    else:
+        registered = None
     if not args.no_line:
         _require_yes(args, "setup 创建开发线")
         try:
@@ -551,8 +648,8 @@ def _non_interactive_setup(args: argparse.Namespace) -> None:
         print(finding)
     if any(finding.startswith("FAIL") for finding in findings):
         raise DyroError("setup 已完成基础配置，但 doctor 仍发现结构错误")
-    if created:
-        print("下一步：dyro next")
+    if created or registered is not None:
+        _print_setup_completion(config, registered)
 
 
 def _uses_interactive_setup(args: argparse.Namespace) -> bool:
@@ -2114,7 +2211,23 @@ def build_parser() -> argparse.ArgumentParser:
     setup.add_argument("--line", default="dev", help="首条功能开发线 ID；默认 dev")
     setup.add_argument("--branch", help="首条开发线分支；默认 feat/<line>")
     setup.add_argument("--no-line", action="store_true", help="仅建立 Profile，不创建 Git worktree 开发线")
-    setup.add_argument("--yes", action="store_true", help="确认创建首条 Git worktree 开发线")
+    setup.add_argument(
+        "--yes",
+        action="store_true",
+        help="确认需要确认的 setup 计划步骤，包括首条 Git worktree 与全局入口登记",
+    )
+    setup_registration = setup.add_mutually_exclusive_group()
+    setup_registration.add_argument(
+        "--no-register",
+        action="store_true",
+        help="不加入 Console 的全局工作区列表；适合 CI 与临时环境",
+    )
+    setup_registration.add_argument(
+        "--default",
+        dest="make_default",
+        action="store_true",
+        help="登记后设为裸 dyro 的默认项目",
+    )
     setup_mode = setup.add_mutually_exclusive_group()
     setup_mode.add_argument("--interactive", action="store_true", help="强制运行交互式首次设置")
     setup_mode.add_argument("--non-interactive", action="store_true", help="禁用交互提示；适合脚本与 CI")

--- a/src/dyro/console/assets.py
+++ b/src/dyro/console/assets.py
@@ -22,18 +22,18 @@ class ConsoleAsset:
 ASSET_MANIFEST = {
     "index.html": (
         "text/html; charset=utf-8",
-        "8980f489da7e7fbd6c6023fc3338c7ff768e14dfade2c13d6b53b69f6304821a",
-        1949,
+        "4018afa6a9bfa3b694fa7c1c8cbc2fec0b31a9594691c5fe9ca123ad519ea389",
+        3040,
     ),
     "app.js": (
         "text/javascript; charset=utf-8",
-        "034405c85e20d7fbcde3d07b0bf0a29abf2c20c9ce5be16b579b48561d69965f",
-        10484,
+        "2ece45334c7e51ece5bb13122c7f09575c7664c4b3bfa43451fb01b7cbed3805",
+        14011,
     ),
     "styles.css": (
         "text/css; charset=utf-8",
-        "4759e04327b0a29d0bcc039d09d64f633670014ecf7fe111244ec78f60d091af",
-        4842,
+        "c622a5eda03264a2495f15830a8a061308a3bed6235c6425155b8995eb5069b9",
+        10178,
     ),
 }
 

--- a/src/dyro/console/assets/app.js
+++ b/src/dyro/console/assets/app.js
@@ -1,6 +1,15 @@
 const SAFE_ID = /^[A-Za-z0-9][A-Za-z0-9._-]{0,79}$/;
 const TOKEN_KEY = "dyro.console.bearer";
 const state = { bearer: "", etags: new Map(), timer: null, focus: "" };
+const HEALTH_LABELS = { healthy: "健康", degraded: "需关注", unavailable: "不可用" };
+const FRESHNESS_LABELS = { fresh: "新鲜", partial: "部分可用", stale: "待更新" };
+const AVAILABILITY_LABELS = { available: "可用", unavailable: "不可用" };
+const ERROR_LABELS = {
+  LOCAL_READ_UNAVAILABLE: "本地状态暂时不可读取",
+  OVERVIEW_UNAVAILABLE: "工作区概览暂时不可读取",
+  WORKSPACE_UNAVAILABLE: "工作区当前不可用",
+  SESSION_REJECTED: "本地会话未建立",
+};
 
 const $ = (id) => document.getElementById(id);
 
@@ -16,6 +25,16 @@ function text(value) {
 
 function count(value) {
   return Number.isInteger(value) && value >= 0 ? value : 0;
+}
+
+function displayLabel(value, labels) {
+  const raw = text(value);
+  return labels[raw] || raw || "未提供";
+}
+
+function userError(value) {
+  const code = text(value);
+  return ERROR_LABELS[code] || "本地状态暂时不可读取";
 }
 
 function element(name, value = "") {
@@ -84,6 +103,55 @@ function addBadge(parent, label, level = "") {
   parent.append(badge);
 }
 
+function workspaceAttention(summary) {
+  const attention = summary.attention_counts || {};
+  if (count(attention.repair_required)) return 0;
+  if (count(attention.needs_user)) return 1;
+  if (count(attention.ready)) return 2;
+  if (count(attention.waiting)) return 3;
+  if (count(attention.paused)) return 4;
+  return 5;
+}
+
+function priorityWorkspace(workspaces) {
+  const focused = workspaces.find((summary) => text(summary.alias) === state.focus);
+  if (focused && text(focused.recommendation && focused.recommendation.command)) return focused;
+  return [...workspaces]
+    .sort((left, right) => workspaceAttention(left) - workspaceAttention(right))
+    .find((summary) => text(summary.recommendation && summary.recommendation.command));
+}
+
+function overviewState(attention) {
+  if (count(attention && attention.repair_required)) return "需要修复";
+  if (count(attention && attention.needs_user)) return "等待你的处理";
+  if (count(attention && attention.ready)) return "有工作可推进";
+  if (count(attention && attention.waiting)) return "等待外部条件";
+  if (count(attention && attention.paused)) return "存在已暂停工作";
+  return "全部正常";
+}
+
+function renderPrimaryAction(workspaces) {
+  const summary = priorityWorkspace(workspaces);
+  const guidance = $("primary-guidance");
+  const command = $("primary-command");
+  const button = $("primary-copy");
+  const recommendation = summary && summary.recommendation;
+  const nextCommand = text(recommendation && recommendation.command);
+  if (!summary || !nextCommand) {
+    guidance.textContent = "下一步 · 等待工作区建议";
+    command.textContent = "尚无可复制的推荐命令";
+    button.dataset.command = "";
+    button.disabled = true;
+    button.textContent = "复制命令";
+    return;
+  }
+  guidance.textContent = `下一步 · ${text(summary.display_name) || text(summary.alias)}`;
+  command.textContent = nextCommand;
+  button.dataset.command = nextCommand;
+  button.disabled = false;
+  button.textContent = "复制命令";
+}
+
 async function copyCommand(command, button) {
   try {
     await navigator.clipboard.writeText(command);
@@ -124,6 +192,9 @@ function renderCounts(attention) {
   ]) {
     const card = element("div");
     card.className = "count";
+    if (key === "repair_required" && count(attention && attention[key])) card.dataset.level = "danger";
+    if (key === "needs_user" && count(attention && attention[key])) card.dataset.level = "warning";
+    if (!count(attention && attention[key])) card.dataset.level = "success";
     card.append(element("strong", String(count(attention && attention[key]))), element("span", label));
     root.append(card);
   }
@@ -131,42 +202,46 @@ function renderCounts(attention) {
 
 function renderWorkspaceCard(summary) {
   const card = element("article");
-  card.className = "workspace-card";
-  const header = element("header");
+  card.className = "workspace-row";
+  const identity = element("div");
+  identity.className = "workspace-identity";
   const title = element("h3", text(summary.display_name) || text(summary.alias) || "未命名工作区");
-  const badges = element("div");
-  badges.className = "badges";
-  addBadge(badges, text(summary.health) || "unavailable", attentionLevel(summary));
-  addBadge(badges, text(summary.freshness) || "partial");
-  header.append(title, badges);
-  card.append(header);
-
-  const meta = element("p", `别名：${text(summary.alias)} · Task：${count(summary.task_count)} · Active Objective：${count(summary.active_objective_count)}`);
+  const meta = element("p", `别名：${text(summary.alias)} · 任务 ${count(summary.task_count)} · 活跃目标 ${count(summary.active_objective_count)}`);
   meta.className = "workspace-meta";
-  card.append(meta);
-  const statuses = summary.task_status_counts && typeof summary.task_status_counts === "object"
-    ? Object.entries(summary.task_status_counts).filter(([, value]) => Number.isInteger(value) && value > 0)
-    : [];
-  if (statuses.length) {
-    const execution = element("p", `任务状态：${statuses.map(([key, value]) => `${key} ${value}`).join(" · ")}`);
-    execution.className = "workspace-meta";
-    card.append(execution);
-  }
+  identity.append(title, meta);
+  card.append(identity);
 
-  const recommendation = summary.recommendation || {};
-  const reason = text(recommendation.reason) || "LOCAL_READ_UNAVAILABLE";
-  const priority = element("p", `当前关注：${reason}`);
-  priority.className = "priority";
-  card.append(priority);
-  const command = text(recommendation.command);
-  if (command) card.append(commandRow(command));
+  const health = element("div");
+  health.className = "workspace-signal";
+  health.append(element("span", "状态"));
+  health.firstChild.className = "workspace-signal-label";
+  addBadge(health, displayLabel(summary.health, HEALTH_LABELS), attentionLevel(summary));
+  card.append(health);
 
-  const footer = element("footer");
+  const freshness = element("div");
+  freshness.className = "workspace-signal";
+  freshness.append(element("span", "新鲜度"));
+  freshness.firstChild.className = "workspace-signal-label";
+  addBadge(freshness, displayLabel(summary.freshness, FRESHNESS_LABELS));
+  card.append(freshness);
+
+  const tasks = element("div", String(count(summary.task_count)));
+  tasks.className = "workspace-count";
+  tasks.dataset.label = "任务数";
+  card.append(tasks);
+  const objectives = element("div", String(count(summary.objective_count)));
+  objectives.className = "workspace-count";
+  objectives.dataset.label = "目标数";
+  card.append(objectives);
+
+  const action = element("div");
+  action.className = "workspace-action";
   const view = element("button", "查看摘要");
+  view.className = "secondary";
   view.type = "button";
   view.addEventListener("click", () => loadWorkspace(text(summary.alias)));
-  footer.append(view);
-  card.append(footer);
+  action.append(view);
+  card.append(action);
   return card;
 }
 
@@ -174,9 +249,12 @@ function renderOverview(payload) {
   const data = payload && payload.data;
   if (!data || !Array.isArray(data.workspaces)) throw new Error("OVERVIEW_UNAVAILABLE");
   const total = count(data.total_workspaces);
-  $("overview-summary").textContent = total ? `已加载 ${total} 个本地工作区；先处理有明确恢复路径的事项。` : "尚未登记工作区。可运行 dyro setup、dyro join 或 dyro workspace add。";
-  $("captured-at").textContent = text(payload.captured_at) ? `采样时间：${text(payload.captured_at)}` : "";
+  const attention = data.attention_counts || {};
+  $("overview-heading").textContent = total ? overviewState(attention) : "尚未登记工作区";
+  $("overview-summary").textContent = total ? `已加载 ${total} 个本地工作区；优先使用下一步命令继续已识别的工程工作。` : "尚未登记工作区。可运行 dyro setup、dyro join 或 dyro workspace add。";
+  $("captured-at").textContent = text(payload.captured_at) ? `采样于 ${new Date(text(payload.captured_at)).toLocaleString("zh-CN")}` : "";
   renderCounts(data.attention_counts || {});
+  renderPrimaryAction(data.workspaces);
   const list = $("workspace-list");
   list.replaceChildren();
   if (!data.workspaces.length) {
@@ -186,7 +264,6 @@ function renderOverview(payload) {
     return;
   }
   for (const summary of data.workspaces) list.append(renderWorkspaceCard(summary));
-  if (state.focus) loadWorkspace(state.focus, true);
 }
 
 function definition(label, value) {
@@ -208,11 +285,11 @@ async function loadWorkspace(alias, silent = false) {
     grid.className = "detail-grid";
     grid.append(
       definition("别名", text(summary.alias)),
-      definition("健康", text(summary.health)),
-      definition("可用性", text(summary.availability)),
-      definition("Task 总数", String(count(summary.task_count))),
+      definition("健康", displayLabel(summary.health, HEALTH_LABELS)),
+      definition("可用性", displayLabel(summary.availability, AVAILABILITY_LABELS)),
+      definition("任务总数", String(count(summary.task_count))),
       definition("开发线", String(count(summary.line_count))),
-      definition("Objective", String(count(summary.objective_count))),
+      definition("目标", String(count(summary.objective_count))),
     );
     content.replaceChildren(grid);
     const command = text(summary.recommendation && summary.recommendation.command);
@@ -230,10 +307,11 @@ async function loadWorkspace(alias, silent = false) {
 
 function showError(error) {
   const code = text(error && error.message) || "LOCAL_READ_UNAVAILABLE";
-  setStatus(`无法读取本地状态：${code}。可重新运行 dyro console。`, true);
+  const message = userError(code);
+  setStatus(`${message}。可重新运行 dyro console。`, true);
   const list = $("workspace-list");
   list.replaceChildren();
-  const notice = element("p", `读取失败：${code}。Console 未修改任何项目文件。`);
+  const notice = element("p", `${message}。Console 未修改任何项目文件。`);
   notice.className = "error";
   list.append(notice);
 }
@@ -262,6 +340,11 @@ function scheduleRefresh() {
 
 async function start() {
   $("refresh").addEventListener("click", async () => { await refresh(); scheduleRefresh(); });
+  $("primary-copy").addEventListener("click", () => {
+    const button = $("primary-copy");
+    const command = text(button.dataset.command);
+    if (command) copyCommand(command, button);
+  });
   $("detail-close").addEventListener("click", () => { $("workspace-detail").hidden = true; });
   document.addEventListener("visibilitychange", () => {
     if (document.hidden) {

--- a/src/dyro/console/assets/index.html
+++ b/src/dyro/console/assets/index.html
@@ -3,39 +3,67 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <meta name="color-scheme" content="light dark">
+    <meta name="color-scheme" content="dark">
     <title>Dyro Console</title>
     <link rel="stylesheet" href="/assets/styles.css">
     <script type="module" src="/assets/app.js"></script>
   </head>
   <body>
     <header class="site-header">
-      <div>
-        <p class="eyebrow">LOCAL · READ ONLY</p>
-        <h1>Dyro Console</h1>
+      <div class="brand-lockup">
+        <div>
+          <p class="eyebrow">DYRO · LOCAL CONSOLE</p>
+          <h1>Dyro Console</h1>
+        </div>
+        <span class="read-only-badge">本地只读</span>
       </div>
       <p id="session-status" class="session-status" role="status" aria-live="polite">正在建立安全本地会话…</p>
     </header>
     <main id="console-main" tabindex="-1">
-      <section class="hero" aria-labelledby="overview-heading">
-        <div>
-          <p class="eyebrow">项目总览</p>
-          <h2 id="overview-heading">优先处理需要关注的工程</h2>
-          <p id="overview-summary">正在读取本地工作区状态。</p>
+      <section class="command-center" aria-labelledby="overview-heading">
+        <div class="command-center-top">
+          <div>
+            <p class="eyebrow">项目态势</p>
+            <h2 id="overview-heading">正在读取工程状态</h2>
+            <p id="overview-summary">正在读取本地工作区状态。</p>
+          </div>
+          <button id="refresh" type="button" class="secondary">刷新状态</button>
         </div>
-        <button id="refresh" type="button" class="secondary">刷新</button>
+        <section aria-label="全局计数" class="counts" id="attention-counts"></section>
+        <div class="next-step" aria-live="polite">
+          <div class="next-step-copy">
+            <p id="primary-guidance" class="next-step-label">下一步</p>
+            <code id="primary-command">正在准备推荐命令…</code>
+          </div>
+          <button id="primary-copy" type="button" class="primary-action" disabled>复制命令</button>
+        </div>
       </section>
-      <section aria-label="全局计数" class="counts" id="attention-counts"></section>
       <section aria-labelledby="workspace-heading">
         <div class="section-heading">
-          <h2 id="workspace-heading">工作区</h2>
+          <div>
+            <p class="eyebrow">注册项目</p>
+            <h2 id="workspace-heading">工作区</h2>
+          </div>
           <p id="captured-at"></p>
         </div>
-        <div id="workspace-list" class="workspace-list" aria-live="polite"></div>
+        <div class="workspace-surface">
+          <div class="workspace-column-headings" aria-hidden="true">
+            <span>工作区</span>
+            <span>状态</span>
+            <span>新鲜度</span>
+            <span>任务数</span>
+            <span>目标数</span>
+            <span>操作</span>
+          </div>
+          <div id="workspace-list" class="workspace-list" aria-live="polite"></div>
+        </div>
       </section>
       <section id="workspace-detail" class="workspace-detail" hidden aria-labelledby="detail-heading">
         <div class="section-heading">
-          <h2 id="detail-heading">工作区摘要</h2>
+          <div>
+            <p class="eyebrow">工作区详情</p>
+            <h2 id="detail-heading" tabindex="-1">工作区摘要</h2>
+          </div>
           <button id="detail-close" type="button" class="secondary">关闭</button>
         </div>
         <div id="detail-content"></div>

--- a/src/dyro/console/assets/styles.css
+++ b/src/dyro/console/assets/styles.css
@@ -1,40 +1,34 @@
 :root {
-  color-scheme: light dark;
-  --surface: #ffffff;
-  --surface-muted: #f4f7fb;
-  --text: #14213d;
-  --muted: #58677f;
-  --border: #d5deeb;
-  --accent: #1455d9;
+  color-scheme: dark;
+  --canvas: #061323;
+  --surface: #091a2f;
+  --surface-strong: #0d2340;
+  --surface-muted: #102843;
+  --text: #f0f6ff;
+  --muted: #a6b7cb;
+  --subtle: #7289a3;
+  --border: #28425f;
+  --border-strong: #38618c;
+  --accent: #438cff;
+  --accent-hover: #72aaff;
   --accent-contrast: #ffffff;
-  --danger: #b42318;
-  --warning: #9a6700;
-  --success: #16794a;
-  --shadow: 0 12px 35px rgb(20 33 61 / 8%);
+  --danger: #ff9a9a;
+  --danger-surface: #3d1922;
+  --warning: #ffd181;
+  --warning-surface: #3b2b18;
+  --success: #75dfae;
+  --success-surface: #123a35;
+  --radius-large: 1rem;
+  --radius-medium: .65rem;
   font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
-}
-
-@media (prefers-color-scheme: dark) {
-  :root {
-    --surface: #111827;
-    --surface-muted: #192338;
-    --text: #f5f8ff;
-    --muted: #b5c0d4;
-    --border: #3b4961;
-    --accent: #8cb4ff;
-    --accent-contrast: #0b1730;
-    --danger: #ffb4ab;
-    --warning: #ffd98a;
-    --success: #7de6aa;
-    --shadow: none;
-  }
 }
 
 * { box-sizing: border-box; }
 
 body {
   margin: 0;
-  background: var(--surface-muted);
+  min-width: 20rem;
+  background: var(--canvas);
   color: var(--text);
   line-height: 1.5;
 }
@@ -42,85 +36,239 @@ body {
 button, code { font: inherit; }
 
 button {
-  cursor: pointer;
-  border: 1px solid var(--accent);
+  border: 1px solid transparent;
   border-radius: .5rem;
-  background: var(--accent);
-  color: var(--accent-contrast);
-  font-weight: 650;
-  padding: .55rem .85rem;
+  cursor: pointer;
+  font-weight: 700;
+  padding: .65rem .9rem;
 }
 
+button:disabled { cursor: not-allowed; opacity: .48; }
 button:focus-visible { outline: 3px solid var(--warning); outline-offset: 3px; }
 
-button.secondary { background: var(--surface); color: var(--accent); }
+button.secondary {
+  background: transparent;
+  border-color: var(--border-strong);
+  color: var(--text);
+}
+
+button.secondary:hover:not(:disabled) { border-color: var(--accent-hover); color: var(--accent-hover); }
+
+button.primary-action {
+  align-self: center;
+  background: var(--accent);
+  color: var(--accent-contrast);
+  min-width: 7.25rem;
+}
+
+button.primary-action:hover:not(:disabled) { background: var(--accent-hover); }
 
 .site-header, main, footer {
-  width: min(1120px, calc(100% - 2rem));
+  width: min(1400px, calc(100% - 3.5rem));
   margin: 0 auto;
 }
 
 .site-header {
   align-items: center;
   display: flex;
-  gap: 1rem;
+  gap: 1.5rem;
   justify-content: space-between;
-  min-height: 8.25rem;
+  min-height: 4.75rem;
 }
 
+.brand-lockup { align-items: center; display: flex; gap: 1rem; }
+.brand-lockup > div { align-items: center; display: flex; }
+.brand-lockup .eyebrow { display: none; }
+.brand-lockup h1 { font-size: clamp(1.25rem, 2vw, 1.6rem); letter-spacing: -.035em; margin: 0; }
+
+.eyebrow {
+  color: var(--accent-hover);
+  font-size: .72rem;
+  font-weight: 800;
+  letter-spacing: .12em;
+  margin: 0 0 .45rem;
+}
+
+.read-only-badge {
+  border: 1px solid #2b60a3;
+  border-radius: 999px;
+  color: var(--accent-hover);
+  font-size: .82rem;
+  font-weight: 750;
+  padding: .25rem .6rem;
+}
+
+.session-status {
+  color: var(--muted);
+  font-size: .92rem;
+  margin: 0;
+  max-width: 28rem;
+  text-align: right;
+}
+
+main { border-top: 1px solid var(--border); padding: 1.9rem 0 3.25rem; }
 h1, h2, h3, p { margin-top: 0; }
-h1 { margin-bottom: .2rem; }
-h2 { font-size: clamp(1.25rem, 2vw, 1.65rem); margin-bottom: .35rem; }
+h2 { font-size: clamp(1.8rem, 3.2vw, 2.85rem); letter-spacing: -.045em; margin-bottom: .45rem; }
 
-.eyebrow { color: var(--accent); font-size: .78rem; font-weight: 800; letter-spacing: .09em; margin-bottom: .35rem; }
-.session-status, .section-heading p, #overview-summary, .workspace-meta, footer { color: var(--muted); }
-.session-status { max-width: 28rem; text-align: right; }
-
-main { padding-bottom: 2rem; }
-.hero, .workspace-card, .workspace-detail, .count {
+.command-center {
   background: var(--surface);
   border: 1px solid var(--border);
-  border-radius: .85rem;
-  box-shadow: var(--shadow);
+  border-radius: var(--radius-large);
+  padding: clamp(1.35rem, 3vw, 2.35rem);
 }
 
-.hero { align-items: center; display: flex; justify-content: space-between; gap: 1rem; padding: 1.4rem; }
-.counts { display: grid; gap: .8rem; grid-template-columns: repeat(5, minmax(0, 1fr)); margin: 1rem 0 2rem; }
-.count { min-height: 6.2rem; padding: .85rem; }
-.count strong { display: block; font-size: 1.75rem; }
-.count span { color: var(--muted); font-size: .85rem; }
+.command-center-top { align-items: flex-start; display: flex; gap: 1.5rem; justify-content: space-between; }
+#overview-summary { color: var(--muted); font-size: 1rem; margin-bottom: 0; max-width: 42rem; }
 
-.section-heading { align-items: baseline; display: flex; gap: 1rem; justify-content: space-between; }
-.workspace-list { display: grid; gap: 1rem; grid-template-columns: repeat(auto-fit, minmax(290px, 1fr)); }
-.workspace-card { display: flex; flex-direction: column; gap: .9rem; padding: 1.1rem; }
-.workspace-card h3 { margin: 0; }
-.workspace-card header, .workspace-card footer { align-items: center; display: flex; gap: .6rem; justify-content: space-between; width: auto; margin: 0; }
-.badges { display: flex; flex-wrap: wrap; gap: .4rem; }
-.badge { border: 1px solid var(--border); border-radius: 999px; font-size: .78rem; font-weight: 700; padding: .15rem .5rem; }
-.badge[data-level="danger"] { border-color: var(--danger); color: var(--danger); }
-.badge[data-level="warning"] { border-color: var(--warning); color: var(--warning); }
-.badge[data-level="success"] { border-color: var(--success); color: var(--success); }
+.counts {
+  display: grid;
+  grid-template-columns: repeat(5, minmax(0, 1fr));
+  margin: 2.4rem 0 1.8rem;
+}
 
-.priority { border-left: 3px solid var(--accent); margin: 0; padding-left: .7rem; }
-.command { align-items: center; display: flex; gap: .5rem; }
-code { background: var(--surface-muted); border-radius: .35rem; color: var(--text); overflow-wrap: anywhere; padding: .35rem .45rem; }
+.count { border-left: 1px solid var(--border); min-height: 5.2rem; padding: .2rem 1.4rem; }
+.count:first-child { border-left: 0; padding-left: 0; }
+.count strong { display: block; font-size: clamp(1.7rem, 3vw, 2.5rem); letter-spacing: -.04em; line-height: 1; }
+.count span { color: var(--muted); display: block; font-size: .84rem; margin-top: .6rem; }
+.count[data-level="danger"] strong { color: var(--danger); }
+.count[data-level="warning"] strong { color: var(--warning); }
+.count[data-level="success"] strong { color: var(--success); }
+
+.next-step {
+  align-items: center;
+  background: #07182b;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-medium);
+  display: flex;
+  gap: 1.25rem;
+  justify-content: space-between;
+  padding: 1.15rem 1.35rem;
+}
+
+.next-step-copy { min-width: 0; }
+.next-step-label { color: var(--muted); font-size: .82rem; font-weight: 750; margin-bottom: .45rem; }
+code {
+  color: #dceaff;
+  font-family: "SFMono-Regular", Consolas, "Liberation Mono", monospace;
+  font-size: .95rem;
+  overflow-wrap: anywhere;
+}
+
+.section-heading { align-items: end; display: flex; gap: 1rem; justify-content: space-between; margin: 3.1rem 0 1rem; }
+.section-heading h2 { font-size: 1.55rem; margin: 0; }
+.section-heading .eyebrow { margin-bottom: .3rem; }
+.section-heading > p { color: var(--muted); font-size: .86rem; margin: 0; }
+
+.workspace-surface { background: var(--surface); border: 1px solid var(--border); border-radius: var(--radius-large); overflow: hidden; }
+.workspace-column-headings, .workspace-row {
+  display: grid;
+  grid-template-columns: minmax(15rem, 2.5fr) minmax(6rem, 1fr) minmax(6rem, 1fr) minmax(4.5rem, .7fr) minmax(4.5rem, .7fr) minmax(6rem, .9fr);
+}
+
+.workspace-column-headings {
+  border-bottom: 1px solid var(--border);
+  color: var(--subtle);
+  font-size: .78rem;
+  font-weight: 750;
+  letter-spacing: .04em;
+  padding: .8rem 1.35rem;
+}
+
+.workspace-list { min-height: 1px; }
+.workspace-row { align-items: center; border-bottom: 1px solid var(--border); gap: .75rem; padding: 1.25rem 1.35rem; }
+.workspace-row:last-child { border-bottom: 0; }
+.workspace-row:hover { background: var(--surface-strong); }
+.workspace-identity h3 { font-size: 1rem; letter-spacing: -.012em; margin: 0 0 .3rem; }
+.workspace-meta { color: var(--muted); font-size: .86rem; margin: 0; }
+
+.workspace-signal { align-items: center; display: flex; gap: .45rem; }
+.workspace-signal-label { color: var(--subtle); display: none; font-size: .74rem; }
+.badge {
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  color: var(--muted);
+  display: inline-flex;
+  font-size: .8rem;
+  font-weight: 750;
+  line-height: 1;
+  padding: .38rem .58rem;
+}
+.badge[data-level="danger"] { background: var(--danger-surface); border-color: var(--danger); color: var(--danger); }
+.badge[data-level="warning"] { background: var(--warning-surface); border-color: var(--warning); color: var(--warning); }
+.badge[data-level="success"] { background: var(--success-surface); border-color: #2b806a; color: var(--success); }
+.workspace-count { color: var(--text); font-variant-numeric: tabular-nums; }
+.workspace-action { justify-self: end; }
+.workspace-action button { font-size: .84rem; padding: .48rem .72rem; }
+
+.workspace-detail {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-large);
+  margin-top: 1.5rem;
+  padding: 0 1.35rem 1.35rem;
+}
+.detail-grid { display: grid; gap: .75rem; grid-template-columns: repeat(3, minmax(0, 1fr)); }
+.detail-grid div { border-top: 1px solid var(--border); padding-top: .75rem; }
+.detail-grid dt { color: var(--subtle); font-size: .8rem; }
+.detail-grid dd { font-weight: 750; margin: .25rem 0 0; }
+.command { align-items: center; background: var(--surface-muted); border: 1px solid var(--border); border-radius: var(--radius-medium); display: flex; gap: .75rem; margin-top: 1rem; padding: .9rem; }
 .command code { flex: 1; }
-.command button { flex: 0 0 auto; padding: .35rem .55rem; }
-.workspace-detail { margin-top: 1.5rem; padding: 1.1rem; }
-.detail-grid { display: grid; gap: .75rem; grid-template-columns: repeat(2, minmax(0, 1fr)); }
-.detail-grid div { border-top: 1px solid var(--border); padding-top: .55rem; }
-.detail-grid dt { color: var(--muted); font-size: .85rem; }
-.detail-grid dd { font-weight: 700; margin: .2rem 0 0; }
-.empty, .error { border: 1px dashed var(--border); border-radius: .7rem; color: var(--muted); padding: 1.2rem; }
-.error { border-color: var(--danger); color: var(--danger); }
-footer { border-top: 1px solid var(--border); font-size: .85rem; padding: 1.4rem 0 2.5rem; }
+.command button { background: var(--accent); color: var(--accent-contrast); flex: 0 0 auto; }
 
-@media (max-width: 720px) {
-  .site-header, .hero, .section-heading { align-items: flex-start; flex-direction: column; }
-  .site-header { justify-content: center; }
-  .session-status { text-align: left; }
-  .counts { grid-template-columns: repeat(2, minmax(0, 1fr)); }
-  .detail-grid { grid-template-columns: 1fr; }
+.empty, .error { color: var(--muted); margin: 0; padding: 1.35rem; }
+.error { color: var(--danger); }
+footer { border-top: 1px solid var(--border); color: var(--muted); font-size: .84rem; padding: 1.35rem 0 2.5rem; }
+
+@media (min-width: 901px) {
+  .command-center {
+    display: grid;
+    gap: 2rem 2.8rem;
+    grid-template-columns: minmax(18rem, .92fr) minmax(28rem, 1.18fr);
+    position: relative;
+  }
+  .command-center-top { display: block; }
+  .command-center-top .secondary { position: absolute; right: clamp(1.35rem, 3vw, 2.35rem); top: clamp(1.35rem, 3vw, 2.35rem); }
+  .command-center-top > div { max-width: 24rem; }
+  .counts { align-self: center; grid-column: 2; grid-row: 1; margin: 0; }
+  .count { min-height: 5.7rem; padding: .2rem 1rem; }
+  .next-step { grid-column: 1 / -1; }
 }
 
-@media (prefers-reduced-motion: reduce) { *, *::before, *::after { scroll-behavior: auto !important; transition-duration: 0.01ms !important; } }
+@media (max-width: 900px) {
+  .counts { grid-template-columns: repeat(3, minmax(0, 1fr)); row-gap: 1.2rem; }
+  .count:nth-child(4) { border-left: 0; padding-left: 0; }
+  .workspace-column-headings { display: none; }
+  .workspace-row { gap: 1rem; grid-template-columns: minmax(10rem, 1.6fr) minmax(5.5rem, .7fr) minmax(5.5rem, .7fr) 3.5rem 3.5rem; }
+  .workspace-action { grid-column: 1 / -1; justify-self: start; }
+}
+
+@media (max-width: 640px) {
+  .site-header, main, footer { width: min(100% - 2rem, 1400px); }
+  .site-header { align-items: flex-start; flex-direction: column; gap: .7rem; justify-content: center; min-height: 8rem; padding: 1rem 0; }
+  .brand-lockup { align-items: flex-start; flex-direction: column; gap: .5rem; }
+  .brand-lockup > div { display: block; }
+  .session-status { max-width: none; text-align: left; }
+  main { padding-top: 1.25rem; }
+  .command-center { padding: 1.2rem; }
+  .command-center-top, .next-step, .section-heading { align-items: flex-start; flex-direction: column; }
+  .command-center-top .secondary { align-self: stretch; }
+  .counts { grid-template-columns: repeat(2, minmax(0, 1fr)); margin: 1.8rem 0 1.25rem; row-gap: 1rem; }
+  .count, .count:nth-child(4) { border-left: 1px solid var(--border); padding: .2rem 1rem; }
+  .count:nth-child(odd) { border-left: 0; padding-left: 0; }
+  .next-step { padding: 1rem; }
+  .next-step .primary-action { align-self: stretch; width: 100%; }
+  .section-heading { gap: .45rem; margin-top: 2.2rem; }
+  .workspace-row { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); padding: 1.1rem; }
+  .workspace-identity { grid-column: 1 / -1; }
+  .workspace-signal { align-items: flex-start; flex-direction: column; gap: .3rem; }
+  .workspace-signal-label { display: block; }
+  .workspace-count::before { color: var(--subtle); content: attr(data-label); display: block; font-size: .74rem; margin-bottom: .3rem; }
+  .workspace-action { grid-column: 1 / -1; margin-top: .2rem; }
+  .workspace-action button { width: 100%; }
+  .detail-grid { grid-template-columns: 1fr; }
+  .command { align-items: stretch; flex-direction: column; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *, *::before, *::after { scroll-behavior: auto !important; transition-duration: 0.01ms !important; }
+}

--- a/src/dyro/console/inspection.py
+++ b/src/dyro/console/inspection.py
@@ -375,7 +375,7 @@ class IsolatedOverviewService:
         escaped_alias = re.escape(alias)
         return bool(
             re.fullmatch(
-                rf"dyro --workspace {escaped_alias} (?:doctor|task next|objective explain [A-Za-z0-9][A-Za-z0-9._-]{{0,79}})",
+                rf"dyro --workspace {escaped_alias}(?: (?:doctor|task next|objective explain [A-Za-z0-9][A-Za-z0-9._-]{{0,79}}))?",
                 command,
             )
         )

--- a/src/dyro/console/overview.py
+++ b/src/dyro/console/overview.py
@@ -343,7 +343,10 @@ class ConsoleOverviewService:
         self, alias: str, attention: object
     ) -> dict[str, str] | None:
         if not isinstance(attention, list) or not attention:
-            return {"reason": "NO_ATTENTION", "command": f"dyro --workspace {alias} task next"}
+            return {
+                "reason": "HOME_GUIDANCE",
+                "command": f"dyro --workspace {alias}",
+            }
         item = attention[0]
         if not isinstance(item, dict):
             return None

--- a/src/dyro/home.py
+++ b/src/dyro/home.py
@@ -8,7 +8,7 @@ import shutil
 import sys
 from urllib.parse import urlencode
 
-from .config import CONFIG_NAME, Config, expand_argv, load
+from .config import CONFIG_NAME, Config, expand_argv, load, validate_id
 from .errors import DyroError, ValidationError
 from .hub import (
     WorkspaceRecord,
@@ -35,7 +35,19 @@ from .tooling import (
     tool_definition,
     tool_definition_for_command,
 )
-from .workspace import Line, doctor, get_line, line_root, list_lines, status_rows
+from .process import git
+from .terminal import danger, muted, success, title, value, warning
+from .workspace import (
+    Line,
+    create_line,
+    doctor,
+    get_line,
+    line_root,
+    list_lines,
+    preflight_line,
+    repository_path,
+    status_rows,
+)
 
 
 DISCOVERABLE_AGENTS = tuple(
@@ -72,18 +84,52 @@ class HomeTool:
         return self.state in {ToolState.READY, ToolState.NEEDS_SETUP}
 
 
+@dataclass(frozen=True)
+class HomeChoice:
+    value: str
+    label: str
+    recommended: bool = False
+
+
+@dataclass(frozen=True)
+class HomeBase:
+    base: str
+    label: str
+    repository_bases: tuple[tuple[str, str], ...] = ()
+
+    def base_for(self, repo_id: str) -> str:
+        return dict(self.repository_bases).get(repo_id, self.base)
+
+    def overrides(self) -> dict[str, str]:
+        return dict(self.repository_bases)
+
+
+_BACK = object()
+
+
+def _is_back(value: object) -> bool:
+    return value is _BACK
+
+
 def interactive_terminal() -> bool:
     return sys.stdin.isatty() and sys.stdout.isatty()
 
 
 def print_status(config: Config) -> None:
+    print("\n" + title("━━ 当前项目状态 ━━"))
     print(
-        f"{'SCOPE':24} {'REPOSITORY':14} {'BRANCH':24} {'HEAD':12} {'DIRTY':>5} UPSTREAM"
+        muted(
+            f"{'SCOPE':24} {'REPOSITORY':14} {'BRANCH':24} {'HEAD':12} {'DIRTY':>5} UPSTREAM"
+        )
     )
     for scope, repo_id, branch, head, upstream, dirty in status_rows(config):
         dirty_text = "-" if dirty < 0 else str(dirty)
+        dirty_display = (
+            danger(f"{dirty_text:>5}") if dirty > 0 else muted(f"{dirty_text:>5}")
+        )
         print(
-            f"{scope:24} {repo_id:14} {branch:24} {head:12} {dirty_text:>5} {upstream}"
+            f"{scope:24} {value(f'{repo_id:14}')} {value(f'{branch:24}')} "
+            f"{head:12} {dirty_display} {upstream}"
         )
 
 
@@ -92,14 +138,16 @@ def print_all_status() -> None:
     if not registry.workspaces:
         print("还没有登记全局工作区。下一步：dyro workspace add <路径>")
         return
+    print("\n" + title("━━ 全部项目状态 ━━"))
+    print(muted("按全局工作区逐一检查；不会修改项目文件。"))
     for index, record in enumerate(registry.workspaces):
         if index:
             print()
-        print(f"工作区：{record.name} ({record.root})")
+        print(f"工作区：{value(record.name)} ({value(record.root)})")
         try:
             config = load(record.root)
         except (DyroError, ValidationError) as exc:
-            print(f"不可用：{exc}")
+            print(danger(f"不可用：{exc}"))
             continue
         print_status(config)
 
@@ -410,7 +458,18 @@ def print_agent_discovery(config: Config) -> None:
     for adapter_id in config.adapters:
         command = Path(_adapter_executable(config, adapter_id)).name
         configured_commands.setdefault(command, []).append(adapter_id)
-    print(f"{'命令':16} {'本机':10} {'Dyro 状态':16} 说明")
+    print("\n" + title("━━ 本机编码工具 ━━"))
+    print(muted("已配置工具可由 Dyro 启动；其他工具只会打开工作区。"))
+    print(muted(f"{'命令':16} {'本机':10} {'Dyro 状态':16} 说明"))
+
+    def state_cell(state: str, *, installed: bool, configured: bool) -> str:
+        rendered = f"{state:16}"
+        if configured and installed:
+            return success(rendered)
+        if configured or installed:
+            return warning(rendered)
+        return muted(rendered)
+
     known_commands = {command for command, _ in DISCOVERABLE_AGENTS}
     for command, integrated in DISCOVERABLE_AGENTS:
         definition = tool_definition_for_command(command)
@@ -435,23 +494,29 @@ def print_agent_discovery(config: Config) -> None:
                 if definition and definition.install
                 else "未安装；暂无内置安装方案"
             )
-        print(f"{command:16} {'已检测' if installed else '-':10} {state:16} {note}")
+        installed_cell = success(f"{'已检测':10}") if installed else muted(f"{'-':10}")
+        print(
+            f"{value(f'{command:16}')}{installed_cell}"
+            f"{state_cell(state, installed=installed, configured=bool(configured_as))} "
+            f"{muted(note)}"
+        )
     for definition in TOOL_DEFINITIONS:
         if definition.interface != "desktop":
             continue
-        desktop_tool = _launcher_tool(
-            definition, config=config, workspace=config.root
-        )
-        desktop_state = "已检测" if desktop_tool.available else "-"
+        desktop_tool = _launcher_tool(definition, config=config, workspace=config.root)
+        installed = desktop_tool.available
+        desktop_state = "已检测" if installed else "-"
         desktop_note = (
             "首页可打开工作区；不获得执行、门禁或复核权限"
-            if desktop_tool.available
+            if installed
             else f"未安装；可运行 dyro tool install {definition.id}"
         )
-        desktop_integration = "尚未集成" if desktop_tool.available else "-"
+        desktop_integration = "尚未集成" if installed else "-"
         print(
-            f"{definition.id:16} {desktop_state:10} "
-            f"{desktop_integration:16} {desktop_note}"
+            f"{value(f'{definition.id:16}')}"
+            f"{success(f'{desktop_state:10}') if installed else muted(f'{desktop_state:10}')}"
+            f"{warning(f'{desktop_integration:16}') if installed else muted(f'{desktop_integration:16}')} "
+            f"{muted(desktop_note)}"
         )
     for adapter_id in sorted(config.adapters):
         executable = _adapter_executable(config, adapter_id)
@@ -462,7 +527,11 @@ def print_agent_discovery(config: Config) -> None:
         note = (
             "可由当前 Profile 启动" if installed else "命令不可用；请检查 adapter 配置"
         )
-        print(f"{executable:16} {'已检测' if installed else '-':10} {state:16} {note}")
+        installed_cell = success(f"{'已检测':10}") if installed else muted(f"{'-':10}")
+        print(
+            f"{value(f'{executable:16}')}{installed_cell}"
+            f"{state_cell(state, installed=installed, configured=True)} {muted(note)}"
+        )
 
 
 def launch_adapter(
@@ -639,42 +708,58 @@ def resolve_home_config(
     record = _record_for_root(config.root)
     if record is None and not dry_run:
         record = ensure_workspace(config.root)
-        print(f"已将当前项目加入全局首页：{record.name}")
+        print(success(f"已将当前项目加入全局首页：{record.name}"))
     return config, record
 
 
 def _first_use(dry_run: bool) -> None:
-    print("欢迎使用 Dyro。这里还没有可直接打开的工作区。")
+    print("\n" + title("━━ 欢迎使用 Dyro ━━"))
+    print(muted("这里还没有可直接打开的工作区。选择一种开始方式：") + "\n")
     print("  1) 加入团队工作区：dyro join <蓝图地址>")
     print("  2) 设置一个新项目：dyro setup")
     print("  3) 登记已有工作区：dyro workspace add <路径>")
     if not interactive_terminal():
         print("在交互终端中再次运行 dyro，可直接选择下一步。")
         return
-    choice = input("\n请选择（直接回车默认加入团队工作区，q 退出）：").strip().lower()
-    if choice in {"q", "quit"}:
-        print("已退出；没有修改任何文件。")
-    elif choice in {"", "1"}:
-        source = input("团队蓝图地址或本地文件：").strip()
-        if source:
-            print(f"下一步：dyro join {shlex.quote(source)}")
-        else:
-            print("下一步：dyro join <蓝图地址>")
-    elif choice == "2":
-        print("下一步：dyro setup（确认设置计划前不会修改任何文件）")
-    elif choice == "3":
-        raw_path = input("已有 Dyro 工作区路径：").strip()
-        if not raw_path:
-            print("已取消；没有修改任何文件。")
-        elif dry_run:
-            config = load(Path(raw_path).expanduser())
-            print(f"DRY RUN: 将登记工作区 {config.name} -> {config.root.resolve()}")
-        else:
-            config = load(Path(raw_path).expanduser())
+    while True:
+        choice = (
+            input("\n请选择（直接回车默认加入团队工作区，q 退出）：").strip().lower()
+        )
+        if choice in {"q", "quit"}:
+            print("已退出；没有修改任何文件。")
+            return
+        if choice in {"", "1"}:
+            source = input("团队蓝图地址或本地文件（q 返回）：").strip()
+            if source.lower() in {"q", "quit"}:
+                continue
+            if source:
+                print(f"下一步：dyro join {shlex.quote(source)}")
+                return
+            print("需要团队蓝图地址或本地文件；请重新选择。")
+            continue
+        if choice == "2":
+            print("下一步：dyro setup（确认设置计划前不会修改任何文件）")
+            return
+        if choice == "3":
+            raw_path = input("已有 Dyro 工作区路径（q 返回）：").strip()
+            if raw_path.lower() in {"q", "quit"}:
+                continue
+            if not raw_path:
+                print("需要工作区路径；请重新选择。")
+                continue
+            try:
+                config = load(Path(raw_path).expanduser())
+            except (DyroError, OSError) as exc:
+                print(f"无法登记该路径：{exc}。请检查路径后重试。")
+                continue
+            if dry_run:
+                print(f"DRY RUN: 将登记工作区 {config.name} -> {config.root.resolve()}")
+                return
             record = add_workspace(config.root, name=config.name, make_default=True)
-            print(f"已登记工作区：{record.name}。再次运行 dyro 即可进入。")
-    else:
-        raise DyroError("请选择 1、2、3 或 q")
+            print(f"已登记工作区：{record.name}。接下来选择要做什么。")
+            _run_config_home(config, record, dry_run)
+            return
+        print("请选择 1、2、3 或 q。")
 
 
 def _targets(config: Config, record: WorkspaceRecord | None) -> list[HomeTarget]:
@@ -712,10 +797,19 @@ def _targets(config: Config, record: WorkspaceRecord | None) -> list[HomeTarget]
 def _choose_action(
     targets: list[HomeTarget], *, can_switch: bool
 ) -> tuple[str, str] | None:
-    print("\n今天做什么？\n")
+    print("\n" + title("━━ 今天做什么 ━━"))
+    if targets:
+        print("\n" + muted("继续工作"))
     for index, target in enumerate(targets, start=1):
-        print(f"  {index}) {target.label}")
+        prefix, delimiter, target_value = target.label.partition("：")
+        rendered_target = (
+            f"{prefix}{delimiter}{value(target_value)}"
+            if delimiter
+            else value(target.label)
+        )
+        print(f"  {index}) {rendered_target}")
     status_index = len(targets) + 1
+    print("\n" + muted("查看与管理"))
     print(f"  {status_index}) 查看当前项目状态")
     console_index = status_index + 1
     print(f"  {console_index}) 查看全部项目控制台")
@@ -724,35 +818,40 @@ def _choose_action(
         print(f"  {switch_index}) 切换项目")
     new_line_index = switch_index + 1 if can_switch else console_index + 1
     new_hotfix_index = new_line_index + 1
+    print("\n" + muted("开始新的工作"))
     print(f"  {new_line_index}) 开启新的功能开发线")
     print(f"  {new_hotfix_index}) 处理新的线上问题 / Hotfix")
-    print("  q) 退出")
+    print("  " + muted("q) 退出"))
     if not interactive_terminal():
         print(
             "\n在交互终端运行 dyro 可选择并直接进入；也可使用 dyro open 或 dyro task open。"
         )
         return None
-    default = "1" if targets else str(status_index)
-    raw = input(f"\n请选择（直接回车默认 {default}）：").strip().lower() or default
-    if raw in {"q", "quit"}:
-        return None
-    if not raw.isdigit():
-        raise DyroError("请输入菜单编号或 q")
-    selected = int(raw)
-    if 1 <= selected <= len(targets):
-        target = targets[selected - 1]
-        return target.kind, target.id
-    if selected == status_index:
-        return "status", ""
-    if selected == console_index:
-        return "console", ""
-    if can_switch and selected == switch_index:
-        return "switch", ""
-    if selected == new_line_index:
-        return "new-line", ""
-    if selected == new_hotfix_index:
-        return "new-hotfix", ""
-    raise DyroError("菜单编号超出范围")
+    default = "1" if targets else str(new_line_index)
+    while True:
+        raw = (
+            input(f"\n输入编号（回车={default}，q=退出）：").strip().lower() or default
+        )
+        if raw in {"q", "quit"}:
+            return None
+        if not raw.isdigit():
+            print(warning("请输入菜单编号，或输入 q 退出。"))
+            continue
+        selected = int(raw)
+        if 1 <= selected <= len(targets):
+            target = targets[selected - 1]
+            return target.kind, target.id
+        if selected == status_index:
+            return "status", ""
+        if selected == console_index:
+            return "console", ""
+        if can_switch and selected == switch_index:
+            return "switch", ""
+        if selected == new_line_index:
+            return "new-line", ""
+        if selected == new_hotfix_index:
+            return "new-hotfix", ""
+        print(warning("该编号不在当前菜单中；请重新选择，或输入 q 退出。"))
 
 
 def _tool_state_labels(
@@ -873,9 +972,7 @@ def _choose_tool(
     )
     ready = [tool for tool in tools if tool.state == ToolState.READY]
     selectable = [
-        tool
-        for tool in tools
-        if tool.available or tool.state == ToolState.INSTALLABLE
+        tool for tool in tools if tool.available or tool.state == ToolState.INSTALLABLE
     ]
     if not selectable:
         print_agent_discovery(config)
@@ -894,7 +991,12 @@ def _choose_tool(
                 preferences=preferences,
             )
         )
-        print("\n全部编码工具：\n" if show_all else "\n常用编码工具：\n")
+        if show_all:
+            print("\n" + title("━━ 全部编码工具 ━━"))
+            print(muted("可用、可安装与暂不可用工具均列在这里。"))
+        else:
+            print("\n" + title("━━ 常用编码工具 ━━"))
+            print(muted("按上次使用、项目推荐与个人偏好排序。"))
         for index, tool in enumerate(displayed, start=1):
             labels = _tool_state_labels(
                 tool,
@@ -903,28 +1005,26 @@ def _choose_tool(
                 recommended_tool=config.recommended_tool,
                 preferences=preferences,
             )
-            print(f"  {index}) {tool.label}（{'，'.join(labels)}）")
+            print(f"  {index:>2}) {value(tool.label)}")
+            print(f"      {muted(' · '.join(labels))}")
         if show_all:
-            print("  b) 返回常用工具")
+            print("  " + muted("b) 返回常用工具"))
         else:
             hidden_ready = sum(
                 tool.available and tool not in displayed for tool in tools
             )
-            installable = sum(
-                tool.state == ToolState.INSTALLABLE for tool in tools
-            )
+            installable = sum(tool.state == ToolState.INSTALLABLE for tool in tools)
             details = []
             if hidden_ready:
                 details.append(f"{hidden_ready} 个已安装")
             if installable:
                 details.append(f"{installable} 个可安装")
             suffix = f"（{'，'.join(details)}）" if details else ""
-            print(f"  m) 更多工具{suffix}")
-        print("  q) 退出")
+            print("  " + muted(f"m) 更多工具{suffix}"))
+        print("  " + muted("q) 退出"))
+        controls = "b=常用" if show_all else "m=更多"
         raw = (
-            input(
-                f"\n请选择（编号或工具名，直接回车默认 {default.label}）："
-            )
+            input(f"\n输入编号或工具名（回车={default.label}，{controls}，q=退出）：")
             .strip()
             .lower()
         )
@@ -941,9 +1041,24 @@ def _choose_tool(
         if raw.isdigit() and 1 <= int(raw) <= len(displayed):
             selected = displayed[int(raw) - 1]
         else:
-            selected = next((tool for tool in tools if _matches_home_tool(tool, raw)), None)
+            selected = next(
+                (tool for tool in tools if _matches_home_tool(tool, raw)), None
+            )
         if selected is None:
-            raise DyroError("无效的编码工具选择")
+            print(
+                warning(
+                    "未找到该编码工具；请重新选择、输入 m 查看全部工具，或输入 q 退出。"
+                )
+            )
+            continue
+        if selected.state == ToolState.UNAVAILABLE:
+            print(
+                warning(
+                    f"{selected.label} 当前不可用；请选择可用工具，"
+                    "或选择标有“未安装，可引导安装”的工具。"
+                )
+            )
+            continue
         break
     if selected.state == ToolState.INSTALLABLE:
         install_id = _install_id(config, selected)
@@ -961,11 +1076,6 @@ def _choose_tool(
                 f"安装命令已完成，但当前终端仍未检测到 {install_id}；"
                 "请重新打开终端后再运行 dyro"
             )
-    if selected.state == ToolState.UNAVAILABLE:
-        raise DyroError(
-            f"{selected.label} 未安装或不可执行，且暂无内置安装方案；"
-            "运行 dyro agent discover 查看详情"
-        )
     if not _confirm_setup(selected, workspace=workspace, dry_run=dry_run):
         print("已取消初始化；没有修改工作区。")
         return None
@@ -982,36 +1092,843 @@ def _switch_workspace(dry_run: bool) -> None:
         available.append(record)
     if len(available) < 2:
         raise DyroError("没有其他可用工作区；运行 dyro workspace add <路径> 添加项目")
-    print("请选择工作区：")
-    for index, record in enumerate(available, start=1):
-        print(f"  {index}) {record.name}")
-    raw = input("编号：").strip()
-    if not raw.isdigit() or not (1 <= int(raw) <= len(available)):
-        raise DyroError("无效的工作区选择")
-    record = available[int(raw) - 1]
-    _run_config_home(load(record.root), record, dry_run)
+    while True:
+        print("\n" + title("━━ 切换项目 ━━"))
+        print(muted("选择一个已登记的工作区："))
+        for index, record in enumerate(available, start=1):
+            print(f"  {index}) {value(record.name)}")
+        print("  " + muted("q) 返回"))
+        raw = input("输入编号（q=返回）：").strip().lower()
+        if raw in {"q", "quit"}:
+            return
+        if raw.isdigit() and 1 <= int(raw) <= len(available):
+            record = available[int(raw) - 1]
+            _run_config_home(load(record.root), record, dry_run)
+            return
+        print(warning("请输入有效编号，或输入 q 返回。"))
 
 
-def _print_new_line_guidance(config: Config) -> None:
-    print("\n新功能开发线会创建隔离 Git worktree。")
-    print("先确认功能 ID、范围、参与仓库与基线；确认后才会修改 Git 工作区。")
-    print(
-        "下一步："
-        f"dyro line create <ID> --base {shlex.quote(config.policy.default_base)} --yes"
+def _ask_hotfix_id() -> str | None:
+    while True:
+        raw = input("问题 ID（字母、数字、点、下划线或连字符；q 取消）：").strip()
+        if raw.lower() in {"q", "quit"}:
+            print("已取消；没有修改任何 Git 工作区。")
+            return None
+        try:
+            return validate_id(raw, "问题 ID")
+        except ValidationError as exc:
+            print(f"{exc}。请重新输入，或输入 q 取消。")
+
+
+def _ask_choice(
+    question: str,
+    choices: tuple[HomeChoice, ...],
+    *,
+    allow_back: bool = False,
+) -> HomeChoice | object | None:
+    if not choices:
+        raise ValueError("至少提供一个选项")
+    default_index = next(
+        (index for index, choice in enumerate(choices, start=1) if choice.recommended),
+        1,
+    )
+    print("\n" + title(question))
+    for index, choice in enumerate(choices, start=1):
+        suffix = success("（推荐）") if choice.recommended else ""
+        print(f"  {index}) {choice.label}{suffix}")
+    if allow_back:
+        print("  " + muted("b) 返回上一步"))
+    print("  " + muted("q) 取消"))
+    while True:
+        controls = "b=上一步，q=取消" if allow_back else "q=取消"
+        raw = input(f"输入编号（回车={default_index}，{controls}）：").strip().lower()
+        if raw in {"q", "quit"}:
+            print("已取消；没有修改任何 Git 工作区。")
+            return None
+        if allow_back and raw in {"b", "back", "返回"}:
+            return _BACK
+        selected = default_index if not raw else int(raw) if raw.isdigit() else 0
+        if 1 <= selected <= len(choices):
+            return choices[selected - 1]
+        print("请输入有效编号，或输入 q 取消。")
+
+
+def _ask_line_id() -> str | None:
+    while True:
+        raw = input(
+            "\n[1/3] 功能 ID（字母、数字、点、下划线或连字符；q 取消）："
+        ).strip()
+        if raw.lower() in {"q", "quit"}:
+            print("已取消；没有修改任何 Git 工作区。")
+            return None
+        try:
+            return validate_id(raw, "功能 ID")
+        except ValidationError as exc:
+            print(f"{exc}。请重新输入，或输入 q 取消。")
+
+
+def _ask_line_repositories(config: Config) -> tuple[str, ...] | object | None:
+    repositories = tuple(config.repositories)
+    if len(repositories) == 1:
+        print(f"\n[2/3] 参与仓库：{repositories[0]}（唯一已配置仓库）")
+        return repositories
+    custom_choice = HomeChoice("", "自定义：仅选择受影响的仓库")
+    choice = _ask_choice(
+        "\n[2/3] 选择参与仓库：",
+        (
+            HomeChoice(
+                "all",
+                f"全部已配置仓库（{len(repositories)} 个）",
+                recommended=True,
+            ),
+            custom_choice,
+        ),
+        allow_back=True,
+    )
+    if _is_back(choice):
+        return _BACK
+    if choice is None:
+        return None
+    if choice is not custom_choice:
+        return repositories
+    print("\n可选仓库：")
+    for repo_id in repositories:
+        print(f"  - {repo_id}")
+    while True:
+        raw = input("输入受影响的仓库 ID（逗号分隔；b 上一步，q 取消）：").strip()
+        if raw.lower() in {"q", "quit"}:
+            print("已取消；没有修改任何 Git 工作区。")
+            return None
+        if raw.lower() in {"b", "back", "返回"}:
+            return _BACK
+        selected = tuple(
+            dict.fromkeys(item.strip() for item in raw.split(",") if item.strip())
+        )
+        if not selected:
+            print("至少选择一个仓库，或输入 q 取消。")
+            continue
+        unknown = [
+            repo_id for repo_id in selected if repo_id not in config.repositories
+        ]
+        if unknown:
+            print(f"未配置的仓库：{'、'.join(unknown)}。请重新选择。")
+            continue
+        return selected
+
+
+def _ask_line_base(config: Config) -> str | object | None:
+    manual_choice = HomeChoice("", "其他：输入分支、tag 或 commit SHA")
+    choice = _ask_choice(
+        "\n[3/3] 选择功能开发基线：",
+        (
+            HomeChoice(
+                config.policy.default_base,
+                f"{config.policy.default_base}（工作区默认基线）",
+                recommended=True,
+            ),
+            manual_choice,
+        ),
+        allow_back=True,
+    )
+    if _is_back(choice):
+        return _BACK
+    if choice is None:
+        return None
+    if choice is not manual_choice:
+        return choice.value
+    while True:
+        raw = input(
+            "功能开发基线（分支、tag 或 commit SHA；b 上一步，q 取消）："
+        ).strip()
+        if raw.lower() in {"q", "quit"}:
+            print("已取消；没有修改任何 Git 工作区。")
+            return None
+        if raw.lower() in {"b", "back", "返回"}:
+            return _BACK
+        if raw:
+            return raw
+        print("开发基线不能为空；请重新输入，或输入 q 取消。")
+
+
+def _unresolved_base_repositories(
+    config: Config,
+    repositories: tuple[str, ...],
+    selection: HomeBase,
+) -> tuple[tuple[str, str], ...]:
+    unresolved: list[tuple[str, str]] = []
+    for repo_id in repositories:
+        base = selection.base_for(repo_id)
+        if (
+            git(
+                repository_path(config, repo_id),
+                "rev-parse",
+                "--verify",
+                f"{base}^{{commit}}",
+            ).code
+            != 0
+        ):
+            unresolved.append((repo_id, base))
+    return tuple(unresolved)
+
+
+def _resolve_repository_base(
+    config: Config, repo_id: str, requested_base: str
+) -> str | None:
+    """Resolve a user-friendly branch spelling against one repository anchor."""
+    anchor = repository_path(config, repo_id)
+    candidates = [requested_base]
+    if requested_base.startswith("origin/"):
+        candidates.append(requested_base.removeprefix("origin/"))
+    elif "/" not in requested_base:
+        candidates.append(f"origin/{requested_base}")
+    for candidate in dict.fromkeys(candidates):
+        if git(anchor, "rev-parse", "--verify", f"{candidate}^{{commit}}").code == 0:
+            return candidate
+    return None
+
+
+def _normalize_repository_bases(
+    config: Config,
+    repositories: tuple[str, ...],
+    requested_base: str,
+) -> HomeBase | object | None:
+    """Resolve equivalent refs per repository and ask only for true exceptions."""
+    bases: dict[str, str] = {}
+    unresolved: list[str] = []
+    for repo_id in repositories:
+        resolved = _resolve_repository_base(config, repo_id, requested_base)
+        if resolved is None:
+            unresolved.append(repo_id)
+        else:
+            bases[repo_id] = resolved
+    for repo_id in unresolved:
+        print(
+            f"{repo_id} 无法解析 {requested_base}；请为这个仓库单独选择已核实的基线。"
+        )
+        selected = _ask_repository_base(config, repo_id, requested_base)
+        if _is_back(selected):
+            return _BACK
+        if selected is None:
+            return None
+        bases[repo_id] = selected
+    base = bases[repositories[0]]
+    overrides = tuple(
+        (repo_id, repo_base)
+        for repo_id, repo_base in bases.items()
+        if repo_base != base
+    )
+    return HomeBase(base, requested_base, overrides)
+
+
+def _print_unresolved_bases(unresolved: tuple[tuple[str, str], ...]) -> None:
+    print("\n基线未就绪；尚未创建任何 Git worktree：")
+    for repo_id, base in unresolved:
+        print(f"  - {repo_id}: {base}")
+    print("请重新选择基线，或输入 q 取消。")
+
+
+def _print_repository_base_map(
+    repositories: tuple[str, ...], selection: HomeBase | Line
+) -> None:
+    """Render a short, scannable per-repository base map for terminal users."""
+    width = max(len(repo_id) for repo_id in repositories)
+    for repo_id in repositories:
+        marker = "默认" if selection.base_for(repo_id) == selection.base else "覆盖"
+        print(
+            f"    {value(f'{repo_id:<{width}}')}  "
+            f"{value(selection.base_for(repo_id))}  {muted(f'[{marker}]')}"
+        )
+
+
+def _retry_after_preflight_failure(kind: str, exc: Exception) -> bool:
+    print("\n" + danger(f"━━ 创建{kind}前检查未通过 ━━"))
+    print(muted("尚未创建任何 Git worktree。"))
+    print(danger(f"原因：{exc}"))
+    next_step = _ask_choice(
+        "下一步：",
+        (
+            HomeChoice("retry", f"重新填写{kind}信息", recommended=True),
+            HomeChoice("home", "返回首页"),
+        ),
+    )
+    return next_step is not None and next_step.value == "retry"
+
+
+def _previous_editable_step(config: Config) -> int:
+    """Return the preceding editable wizard step for a selected base."""
+    return 2 if len(config.repositories) > 1 else 1
+
+
+def _create_line_from_home(config: Config, dry_run: bool) -> Line | None:
+    print("\n" + title("━━ 开启功能开发线 ━━"))
+    print(muted("新功能开发线会创建隔离 Git worktree；确认前不会修改 Git 工作区。"))
+    print(muted("步骤：功能 ID → 参与仓库 → 开发基线 → 创建确认"))
+    step = 1
+    line_id = ""
+    repositories: tuple[str, ...] = ()
+    while True:
+        if step == 1:
+            line_id = _ask_line_id()
+            if line_id is None:
+                return None
+            step = 2
+            continue
+        if step == 2:
+            selected_repositories = _ask_line_repositories(config)
+            if _is_back(selected_repositories):
+                step = 1
+                continue
+            if selected_repositories is None:
+                return None
+            repositories = selected_repositories
+            step = 3
+            continue
+        if step == 3:
+            base = _ask_line_base(config)
+            if _is_back(base):
+                step = _previous_editable_step(config)
+                continue
+            if base is None:
+                return None
+            base_selection = _normalize_repository_bases(config, repositories, base)
+            if _is_back(base_selection):
+                continue
+            if base_selection is None:
+                return None
+            base_selection = _ask_repository_base_overrides(
+                config,
+                base_selection,
+                kind="功能开发线",
+                repositories=repositories,
+            )
+            if _is_back(base_selection):
+                continue
+            if base_selection is None:
+                return None
+            unresolved = _unresolved_base_repositories(
+                config, repositories, base_selection
+            )
+            if not unresolved:
+                step = 4
+                continue
+            _print_unresolved_bases(unresolved)
+            continue
+
+        branch = f"feat/{line_id}"
+        try:
+            planned = preflight_line(
+                config,
+                line_id=line_id,
+                branch=branch,
+                base=base_selection.base,
+                repositories=repositories,
+                repository_bases=base_selection.overrides(),
+                kind="line",
+            )
+        except (DyroError, ValidationError, OSError) as exc:
+            if _retry_after_preflight_failure("功能开发线", exc):
+                step = 1
+                continue
+            return None
+        print("\n" + title("━━ 创建前确认 ━━"))
+        print(f"  功能 ID：{value(line_id)}")
+        print(f"  分支：{value(branch)}")
+        print(f"  基线：{value(base_selection.base)}")
+        if base_selection.repository_bases:
+            print("  仓库基线：")
+            _print_repository_base_map(planned.repositories, planned)
+        print(f"  仓库：{value('、'.join(repositories))}")
+        print(f"  位置：{value(line_root(config, planned))}")
+        if dry_run:
+            print("DRY RUN: 已展示创建计划；不会创建 Git worktree。")
+            return None
+        confirmation = (
+            input("\n确认创建这些隔离 worktree？[y/b/N；b 返回基线]：").strip().lower()
+        )
+        if confirmation in {"b", "back", "返回"}:
+            step = 3
+            continue
+        if confirmation not in {"y", "yes"}:
+            print("已取消；没有修改任何 Git 工作区。")
+            return None
+        try:
+            line = create_line(
+                config,
+                line_id=line_id,
+                branch=branch,
+                base=base_selection.base,
+                repositories=repositories,
+                repository_bases=base_selection.overrides(),
+                kind="line",
+            )
+        except (DyroError, ValidationError, OSError) as exc:
+            print(danger(f"创建功能开发线失败：{exc}"))
+            print(warning("没有完整创建开发线；请重新运行 dyro 后重试。"))
+            return None
+        print(
+            success("已创建功能开发线：")
+            + value(line.id)
+            + "。接下来选择编码工具并打开隔离工作区。"
+        )
+        return line
+
+
+def _shared_tag_candidates(
+    config: Config,
+    *,
+    repositories: tuple[str, ...] | None = None,
+    limit: int = 4,
+) -> tuple[HomeBase, ...]:
+    """Return recent tags that resolve from every selected repository anchor."""
+    selected_repositories = repositories or tuple(config.repositories)
+    common: set[str] | None = None
+    ordered: list[str] = []
+    for repo_id in selected_repositories:
+        result = git(
+            repository_path(config, repo_id),
+            "for-each-ref",
+            "--sort=-creatordate",
+            "--format=%(refname:short)",
+            "refs/tags",
+        )
+        if result.code != 0:
+            return ()
+        tags = [tag.strip() for tag in result.stdout.splitlines() if tag.strip()]
+        if common is None:
+            ordered = tags
+            common = set(tags)
+        else:
+            common.intersection_update(tags)
+    candidates: list[HomeBase] = []
+    for tag in ordered:
+        if tag not in (common or set()):
+            continue
+        if all(
+            git(
+                repository_path(config, repo_id),
+                "rev-parse",
+                "--verify",
+                f"{tag}^{{commit}}",
+            ).code
+            == 0
+            for repo_id in selected_repositories
+        ):
+            candidates.append(
+                HomeBase(tag, f"发布 tag {tag}（所有已配置仓库均可解析）")
+            )
+        if len(candidates) == limit:
+            break
+    return tuple(candidates)
+
+
+def _shared_release_branch_candidates(
+    config: Config,
+    *,
+    repositories: tuple[str, ...] | None = None,
+    limit: int = 4,
+) -> tuple[HomeBase, ...]:
+    """Return common release branch names, allowing per-repository ref spelling.
+
+    A repository can expose the same branch as ``origin/release`` while another
+    only has a local ``release`` branch.  ``create_line`` already supports this
+    through repository-specific bases, so the home flow should surface it rather
+    than asking the user to guess a string that works everywhere.
+    """
+    selected_repositories = repositories or tuple(config.repositories)
+    common: set[str] | None = None
+    ordered: list[str] = []
+    refs_by_repo: dict[str, dict[str, str]] = {}
+    for repo_id in selected_repositories:
+        result = git(
+            repository_path(config, repo_id),
+            "for-each-ref",
+            "--sort=-committerdate",
+            "--format=%(refname)",
+            "refs/heads",
+            "refs/remotes",
+        )
+        if result.code != 0:
+            return ()
+        refs: dict[str, tuple[int, str]] = {}
+        for ref in (item.strip() for item in result.stdout.splitlines()):
+            if ref.startswith("refs/heads/"):
+                name = ref.removeprefix("refs/heads/")
+                priority = 1
+                short_ref = name
+            elif ref.startswith("refs/remotes/"):
+                remote_and_name = ref.removeprefix("refs/remotes/")
+                remote, separator, name = remote_and_name.partition("/")
+                if not separator:
+                    continue
+                priority = 3 if remote == "origin" else 2
+                short_ref = f"{remote}/{name}"
+            else:
+                continue
+            if name == "HEAD" or not (name == "release" or name.startswith("release/")):
+                continue
+            current = refs.get(name)
+            if current is None or priority > current[0]:
+                refs[name] = (priority, short_ref)
+            if repo_id == selected_repositories[0] and name not in ordered:
+                ordered.append(name)
+        refs_by_repo[repo_id] = {name: ref for name, (_, ref) in refs.items()}
+        names = set(refs_by_repo[repo_id])
+        if common is None:
+            common = names
+        else:
+            common.intersection_update(names)
+
+    candidates: list[HomeBase] = []
+    for name in ordered:
+        if name not in (common or set()):
+            continue
+        bases = tuple(
+            (repo_id, refs_by_repo[repo_id][name]) for repo_id in selected_repositories
+        )
+        base = bases[0][1]
+        selection = HomeBase(
+            base,
+            f"发布分支 {name}（所有已配置仓库均可解析）",
+            tuple((repo_id, ref) for repo_id, ref in bases if ref != base),
+        )
+        if not _unresolved_base_repositories(config, selected_repositories, selection):
+            candidates.append(selection)
+        if len(candidates) == limit:
+            break
+    return tuple(candidates)
+
+
+def _repository_base_suggestions(
+    config: Config, repo_id: str, current_base: str
+) -> tuple[str, ...]:
+    """Return safe, local candidates when a single repository needs a base override."""
+    anchor = repository_path(config, repo_id)
+    result = git(
+        anchor,
+        "for-each-ref",
+        "--format=%(refname:short)",
+        "refs/heads/main",
+        "refs/heads/master",
+        "refs/heads/release",
+        "refs/remotes/origin/main",
+        "refs/remotes/origin/master",
+        "refs/remotes/origin/release",
+        "refs/tags",
+    )
+    candidates = [current_base]
+    if result.code == 0:
+        candidates.extend(
+            ref.strip() for ref in result.stdout.splitlines() if ref.strip()
+        )
+    return tuple(
+        dict.fromkeys(
+            ref
+            for ref in candidates
+            if git(anchor, "rev-parse", "--verify", f"{ref}^{{commit}}").code == 0
+        )
     )
 
 
-def _print_new_hotfix_guidance() -> None:
-    print("\nHotfix 需要已核实的生产 release 分支、tag 或部署 SHA。")
-    print("确认问题 ID 和基线后，才会创建隔离的 Hotfix worktree。")
-    print("下一步：dyro hotfix create <问题ID> --base <已核实的 release/tag/SHA> --yes")
+def _ask_repository_base(
+    config: Config, repo_id: str, current_base: str
+) -> str | object | None:
+    suggestions = _repository_base_suggestions(config, repo_id, current_base)
+    manual_choice = HomeChoice("", "其他：输入分支、tag 或 commit SHA")
+    choices = tuple(
+        HomeChoice(
+            base,
+            f"{base}{'（当前映射）' if base == current_base else ''}",
+            recommended=base == current_base,
+        )
+        for base in suggestions
+    ) + (manual_choice,)
+    choice = _ask_choice(f"选择 {repo_id} 的已核实生产基线：", choices, allow_back=True)
+    if _is_back(choice):
+        return _BACK
+    if choice is None:
+        return None
+    if choice is not manual_choice:
+        return choice.value
+    anchor = repository_path(config, repo_id)
+    while True:
+        raw = input(
+            f"{repo_id} 的生产基线（分支、tag 或 commit SHA；b 上一步，q 取消）："
+        ).strip()
+        if raw.lower() in {"q", "quit"}:
+            print("已取消；没有修改任何 Git 工作区。")
+            return None
+        if raw.lower() in {"b", "back", "返回"}:
+            return _BACK
+        if not raw:
+            print("生产基线不能为空；请重新输入，或输入 q 取消。")
+            continue
+        if git(anchor, "rev-parse", "--verify", f"{raw}^{{commit}}").code == 0:
+            return raw
+        print(f"{repo_id} 无法解析 {raw}；该仓库当前没有这个分支、tag 或提交。")
+
+
+def _ask_repository_base_overrides(
+    config: Config,
+    selection: HomeBase,
+    *,
+    kind: str,
+    repositories: tuple[str, ...] | None = None,
+) -> HomeBase | object | None:
+    selected_repositories = repositories or tuple(config.repositories)
+    if len(selected_repositories) == 1:
+        return selection
+    initial_mapping = {
+        repo_id: selection.base_for(repo_id) for repo_id in selected_repositories
+    }
+    print("\n当前仓库基线：")
+    _print_repository_base_map(selected_repositories, selection)
+    scope = _ask_choice(
+        f"确认{kind}的仓库基线：",
+        (
+            HomeChoice("keep", "使用当前映射", recommended=True),
+            HomeChoice("adjust", "按仓库单独调整基线"),
+        ),
+        allow_back=True,
+    )
+    if _is_back(scope):
+        return _BACK
+    if scope is None:
+        return None
+    if scope.value == "keep":
+        return selection
+
+    bases = dict(initial_mapping)
+    while True:
+        choices = tuple(
+            HomeChoice(repo_id, f"{repo_id}：{bases[repo_id]}")
+            for repo_id in selected_repositories
+        ) + (HomeChoice("done", "完成仓库基线设置", recommended=True),)
+        repository_choice = _ask_choice("选择要调整的仓库：", choices, allow_back=True)
+        if _is_back(repository_choice):
+            return _BACK
+        if repository_choice is None:
+            return None
+        if repository_choice.value == "done":
+            overrides = tuple(
+                (repo_id, base)
+                for repo_id, base in bases.items()
+                if base != selection.base
+            )
+            return HomeBase(selection.base, selection.label, overrides)
+        repo_id = repository_choice.value
+        base = _ask_repository_base(config, repo_id, bases[repo_id])
+        if _is_back(base):
+            continue
+        if base is None:
+            return None
+        bases[repo_id] = base
+
+
+def _ask_manual_hotfix_base(kind: str) -> HomeBase | object | None:
+    while True:
+        raw = input(f"已核实的生产 {kind}（b 上一步，q 取消）：").strip()
+        if raw.lower() in {"q", "quit"}:
+            print("已取消；没有修改任何 Git 工作区。")
+            return None
+        if raw.lower() in {"b", "back", "返回"}:
+            return _BACK
+        if raw:
+            return HomeBase(raw, raw)
+        print("生产基线不能为空；Dyro 不会替你猜测或默认选择 main。")
+
+
+def _ask_hotfix_base(
+    config: Config, repositories: tuple[str, ...]
+) -> HomeBase | object | None:
+    candidates = _shared_tag_candidates(
+        config, repositories=repositories
+    ) + _shared_release_branch_candidates(config, repositories=repositories)
+    if candidates:
+        manual_choice = HomeChoice(
+            "", "其他：输入已核实的 release 分支、tag 或部署 SHA"
+        )
+        choices = tuple(
+            HomeChoice(
+                str(index),
+                candidate.label,
+                recommended=index == 0,
+            )
+            for index, candidate in enumerate(candidates)
+        ) + (manual_choice,)
+        print("Dyro 找到以下共同 Git 基线；它们只是可解析的候选，不代表已部署到生产。")
+        choice = _ask_choice("选择你已核实的生产基线：", choices, allow_back=True)
+        if _is_back(choice):
+            return _BACK
+        if choice is None:
+            return None
+        if choice is not manual_choice:
+            return _ask_repository_base_overrides(
+                config,
+                candidates[int(choice.value)],
+                kind="Hotfix",
+                repositories=repositories,
+            )
+        selection = _ask_manual_hotfix_base("基线（release 分支、tag 或部署 SHA）")
+        if _is_back(selection):
+            return _BACK
+        normalized = (
+            _normalize_repository_bases(config, repositories, selection.base)
+            if selection is not None
+            else None
+        )
+        if _is_back(normalized):
+            return _BACK
+        return (
+            _ask_repository_base_overrides(
+                config, normalized, kind="Hotfix", repositories=repositories
+            )
+            if normalized is not None
+            else None
+        )
+
+    print("Dyro 没有发现可供推荐的共同 Git 基线；请按已核实的部署记录选择基线形式。")
+    choice = _ask_choice(
+        "选择生产基线形式：",
+        (
+            HomeChoice("release 分支", "已发布的 release 分支", recommended=True),
+            HomeChoice("tag", "已发布的 tag"),
+            HomeChoice("部署 SHA", "已部署的 commit SHA"),
+        ),
+        allow_back=True,
+    )
+    if _is_back(choice):
+        return _BACK
+    if choice is None:
+        return None
+    selection = _ask_manual_hotfix_base(choice.value)
+    if _is_back(selection):
+        return _BACK
+    normalized = (
+        _normalize_repository_bases(config, repositories, selection.base)
+        if selection is not None
+        else None
+    )
+    if _is_back(normalized):
+        return _BACK
+    return (
+        _ask_repository_base_overrides(
+            config, normalized, kind="Hotfix", repositories=repositories
+        )
+        if normalized is not None
+        else None
+    )
+
+
+def _create_hotfix_from_home(config: Config, dry_run: bool) -> Line | None:
+    print("\n" + title("━━ 处理线上问题 / Hotfix ━━"))
+    print(muted("Hotfix 需要已核实的生产 release 分支、tag 或部署 SHA。"))
+    print(muted("Dyro 只校验 Git 可解析性；是否已部署到生产仍须由你确认。"))
+    print(muted("步骤：问题 ID → 参与仓库 → 生产基线 → 创建确认"))
+    step = 1
+    issue_id = ""
+    repositories: tuple[str, ...] = ()
+    while True:
+        if step == 1:
+            issue_id = _ask_hotfix_id()
+            if issue_id is None:
+                return None
+            step = 2
+            continue
+        if step == 2:
+            selected_repositories = _ask_line_repositories(config)
+            if _is_back(selected_repositories):
+                step = 1
+                continue
+            if selected_repositories is None:
+                return None
+            repositories = selected_repositories
+            step = 3
+            continue
+        if step == 3:
+            base_selection = _ask_hotfix_base(config, repositories)
+            if _is_back(base_selection):
+                step = _previous_editable_step(config)
+                continue
+            if base_selection is None:
+                return None
+            unresolved = _unresolved_base_repositories(
+                config, repositories, base_selection
+            )
+            if not unresolved:
+                step = 4
+                continue
+            _print_unresolved_bases(unresolved)
+            continue
+
+        branch = f"hotfix/{issue_id}"
+        try:
+            planned = preflight_line(
+                config,
+                line_id=issue_id,
+                branch=branch,
+                base=base_selection.base,
+                repositories=repositories,
+                repository_bases=base_selection.overrides(),
+                kind="hotfix",
+            )
+        except (DyroError, ValidationError, OSError) as exc:
+            if _retry_after_preflight_failure("Hotfix", exc):
+                step = 1
+                continue
+            return None
+        print("\n" + title("━━ 创建前确认 ━━"))
+        print(f"  问题 ID：{value(issue_id)}")
+        print(f"  分支：{value(branch)}")
+        print(f"  已核实的生产基线：{value(base_selection.base)}")
+        if base_selection.repository_bases:
+            print("  仓库基线：")
+            _print_repository_base_map(planned.repositories, planned)
+        print(f"  仓库：{value('、'.join(planned.repositories))}")
+        print(f"  位置：{value(line_root(config, planned))}")
+        if dry_run:
+            print("DRY RUN: 已展示创建计划；不会创建 Git worktree。")
+            return None
+
+        confirmation = (
+            input(
+                "\n确认该基线已在生产核实，并创建这些隔离 worktree？[y/b/N；b 返回基线]："
+            )
+            .strip()
+            .lower()
+        )
+        if confirmation in {"b", "back", "返回"}:
+            step = 3
+            continue
+        if confirmation not in {"y", "yes"}:
+            print("已取消；没有修改任何 Git 工作区。")
+            return None
+        try:
+            line = create_line(
+                config,
+                line_id=issue_id,
+                branch=branch,
+                base=base_selection.base,
+                repositories=repositories,
+                repository_bases=base_selection.overrides(),
+                kind="hotfix",
+            )
+        except (DyroError, ValidationError, OSError) as exc:
+            print(danger(f"创建 Hotfix 失败：{exc}"))
+            print(warning("没有完整创建 Hotfix；请重新运行 dyro 后重试。"))
+            return None
+        print(
+            success("已创建 Hotfix：")
+            + value(line.id)
+            + "。接下来选择编码工具并打开隔离工作区。"
+        )
+        return line
 
 
 def _run_config_home(
     config: Config, record: WorkspaceRecord | None, dry_run: bool
 ) -> None:
-    print(f"\n项目：{config.name}")
-    print(f"位置：{config.root}")
+    print("\n" + title(f"━━ {config.name} ━━"))
+    print(f"工作区  {value(config.root)}")
     failures = [finding for finding in doctor(config) if finding.startswith("FAIL")]
     if failures:
         print(
@@ -1049,11 +1966,15 @@ def _run_config_home(
         _switch_workspace(dry_run)
         return
     if kind == "new-line":
-        _print_new_line_guidance(config)
-        return
+        line = _create_line_from_home(config, dry_run)
+        if line is None:
+            return
+        kind, target_id = line.kind, line.id
     if kind == "new-hotfix":
-        _print_new_hotfix_guidance()
-        return
+        line = _create_hotfix_from_home(config, dry_run)
+        if line is None:
+            return
+        kind, target_id = line.kind, line.id
     if kind == "task":
         task = load_task(config, target_id)
         target_workspace = existing_task_workspace(config, task)
@@ -1077,9 +1998,12 @@ def _run_config_home(
 
 
 def run_home(*, root: str | None, workspace: str | None, dry_run: bool) -> None:
-    resolved = resolve_home_config(root=root, workspace=workspace, dry_run=dry_run)
-    if resolved is None:
-        _first_use(dry_run)
-        return
-    config, record = resolved
-    _run_config_home(config, record, dry_run)
+    try:
+        resolved = resolve_home_config(root=root, workspace=workspace, dry_run=dry_run)
+        if resolved is None:
+            _first_use(dry_run)
+            return
+        config, record = resolved
+        _run_config_home(config, record, dry_run)
+    except (KeyboardInterrupt, EOFError):
+        print("\n已中断当前引导；没有执行后续步骤。")

--- a/src/dyro/home.py
+++ b/src/dyro/home.py
@@ -200,11 +200,26 @@ def _cursor_desktop_argv(workspace: Path) -> tuple[tuple[str, ...], bool]:
     return ("cursor", str(workspace)), False
 
 
+def _zcode_desktop_argv(workspace: Path) -> tuple[tuple[str, ...], bool]:
+    if shutil.which("zcode") is not None:
+        return ("zcode", str(workspace)), True
+    if sys.platform == "darwin":
+        candidates = (
+            Path("/Applications/ZCode.app"),
+            Path.home() / "Applications" / "ZCode.app",
+        )
+        if any(candidate.is_dir() for candidate in candidates) and shutil.which("open"):
+            return ("open", "-a", "ZCode", str(workspace)), True
+    return ("zcode", str(workspace)), False
+
+
 def _launcher_tool(
     definition: ToolDefinition, *, config: Config, workspace: Path
 ) -> HomeTool:
     if definition.id == "cursor-desktop":
         argv, installed = _cursor_desktop_argv(workspace)
+    elif definition.id == "zcode":
+        argv, installed = _zcode_desktop_argv(workspace)
     else:
         argv = expand_argv(
             definition.launch,
@@ -669,6 +684,10 @@ def _choose_action(
     switch_index = console_index + 1
     if can_switch:
         print(f"  {switch_index}) 切换项目")
+    new_line_index = switch_index + 1 if can_switch else console_index + 1
+    new_hotfix_index = new_line_index + 1
+    print(f"  {new_line_index}) 开启新的功能开发线")
+    print(f"  {new_hotfix_index}) 处理新的线上问题 / Hotfix")
     print("  q) 退出")
     if not interactive_terminal():
         print(
@@ -691,6 +710,10 @@ def _choose_action(
         return "console", ""
     if can_switch and selected == switch_index:
         return "switch", ""
+    if selected == new_line_index:
+        return "new-line", ""
+    if selected == new_hotfix_index:
+        return "new-hotfix", ""
     raise DyroError("菜单编号超出范围")
 
 
@@ -705,38 +728,72 @@ def _tool_state_labels(
     definition = tool_definition(tool.id)
     if tool.kind == "adapter":
         if tool.state == ToolState.READY:
-            labels = ["已配置"]
+            labels = ["Dyro 已接入"]
         elif tool.state == ToolState.INSTALLABLE:
-            labels = ["已配置但不可用", "可引导安装"]
+            labels = ["已接入，待安装"]
         else:
-            labels = ["已配置但不可用"]
+            labels = ["已接入但不可用"]
     elif tool.state == ToolState.READY:
         interface = definition.interface if definition else "terminal"
         if interface == "desktop":
-            labels = ["已安装", "桌面应用", "仅打开工作区"]
+            labels = ["桌面应用"]
         elif interface == "runtime":
-            labels = ["已安装", "外部运行时", "仅打开工作区"]
+            labels = ["外部运行时"]
         elif tool.id == "shell":
             labels = ["终端兜底"]
         else:
-            labels = ["已安装", "仅打开工作区"]
+            labels = ["打开工作区"]
     elif tool.state == ToolState.NEEDS_SETUP:
-        labels = ["已安装", "待初始化", "仅打开工作区"]
+        labels = ["待初始化"]
     elif tool.state == ToolState.INSTALLABLE:
-        labels = ["未安装", "可引导安装"]
+        labels = ["未安装，可引导安装"]
     else:
-        labels = ["未安装", "暂无内置安装方案"]
+        labels = ["不可用"]
     if tool.id == last_tool:
-        labels.append("上次使用")
+        labels.append("上次")
     if tool.id == recommended_tool:
         labels.append("项目推荐")
     if tool.id == preferences.default_tool:
-        labels.append("个人默认")
+        labels.append("默认")
     if tool.id in preferences.pinned_tools:
-        labels.append("已置顶")
+        labels.append("置顶")
     if tool.id == default.id:
         labels.append("回车默认")
     return labels
+
+
+def _primary_home_tools(
+    tools: list[HomeTool],
+    *,
+    default: HomeTool,
+    last_tool: str,
+    recommended_tool: str,
+    preferences: ToolPreferences,
+) -> list[HomeTool]:
+    by_id = {tool.id: tool for tool in tools}
+    preferred_ids = (
+        default.id,
+        last_tool,
+        recommended_tool,
+        preferences.default_tool,
+        *preferences.pinned_tools,
+    )
+    primary: list[HomeTool] = []
+    for tool_id in preferred_ids:
+        tool = by_id.get(tool_id)
+        if tool and (tool.available or tool == default) and tool not in primary:
+            primary.append(tool)
+    for tool in tools:
+        if tool.kind == "adapter" and tool.available and tool not in primary:
+            primary.append(tool)
+    return primary[:3]
+
+
+def _matches_home_tool(tool: HomeTool, value: str) -> bool:
+    if tool.id.lower() == value or tool.label.lower() == value:
+        return True
+    definition = tool_definition(tool.id)
+    return bool(definition and definition.command.lower() == value)
 
 
 def _install_id(config: Config, tool: HomeTool) -> str:
@@ -777,44 +834,79 @@ def _choose_tool(
         preferences=preferences,
     )
     ready = [tool for tool in tools if tool.state == ToolState.READY]
-    available = [tool for tool in tools if tool.available]
-    if not available:
+    selectable = [
+        tool
+        for tool in tools
+        if tool.available or tool.state == ToolState.INSTALLABLE
+    ]
+    if not selectable:
         print_agent_discovery(config)
         raise DyroError("当前项目没有可启动的编码工具；请选择可引导安装的工具")
-    default = ready[0] if ready else available[0]
-    print("\n使用哪个编码工具？\n")
-    for index, tool in enumerate(tools, start=1):
-        labels = _tool_state_labels(
-            tool,
-            default=default,
-            last_tool=last_tool,
-            recommended_tool=config.recommended_tool,
-            preferences=preferences,
+    default = ready[0] if ready else selectable[0]
+    show_all = False
+    while True:
+        displayed = (
+            tools
+            if show_all
+            else _primary_home_tools(
+                tools,
+                default=default,
+                last_tool=last_tool,
+                recommended_tool=config.recommended_tool,
+                preferences=preferences,
+            )
         )
-        print(f"  {index}) {tool.label}（{'，'.join(labels)}）")
-    print("  q) 退出")
-    raw = (
-        input(f"\n请选择（输入编号或工具名，直接回车默认 {default.label}）：")
-        .strip()
-        .lower()
-    )
-    if not raw:
-        return default
-    if raw in {"q", "quit"}:
-        return None
-    if raw.isdigit() and 1 <= int(raw) <= len(tools):
-        selected = tools[int(raw) - 1]
-    else:
-        selected = next(
-            (
-                tool
-                for tool in tools
-                if tool.id.lower() == raw or tool.label.lower() == raw
-            ),
-            None,
+        print("\n全部编码工具：\n" if show_all else "\n常用编码工具：\n")
+        for index, tool in enumerate(displayed, start=1):
+            labels = _tool_state_labels(
+                tool,
+                default=default,
+                last_tool=last_tool,
+                recommended_tool=config.recommended_tool,
+                preferences=preferences,
+            )
+            print(f"  {index}) {tool.label}（{'，'.join(labels)}）")
+        if show_all:
+            print("  b) 返回常用工具")
+        else:
+            hidden_ready = sum(
+                tool.available and tool not in displayed for tool in tools
+            )
+            installable = sum(
+                tool.state == ToolState.INSTALLABLE for tool in tools
+            )
+            details = []
+            if hidden_ready:
+                details.append(f"{hidden_ready} 个已安装")
+            if installable:
+                details.append(f"{installable} 个可安装")
+            suffix = f"（{'，'.join(details)}）" if details else ""
+            print(f"  m) 更多工具{suffix}")
+        print("  q) 退出")
+        raw = (
+            input(
+                f"\n请选择（编号或工具名，直接回车默认 {default.label}）："
+            )
+            .strip()
+            .lower()
         )
-    if selected is None:
-        raise DyroError("无效的编码工具选择")
+        if not raw:
+            return default
+        if raw in {"q", "quit"}:
+            return None
+        if raw in {"m", "more", "更多"}:
+            show_all = True
+            continue
+        if raw in {"b", "back", "返回"} and show_all:
+            show_all = False
+            continue
+        if raw.isdigit() and 1 <= int(raw) <= len(displayed):
+            selected = displayed[int(raw) - 1]
+        else:
+            selected = next((tool for tool in tools if _matches_home_tool(tool, raw)), None)
+        if selected is None:
+            raise DyroError("无效的编码工具选择")
+        break
     if selected.state == ToolState.INSTALLABLE:
         install_id = _install_id(config, selected)
         if not install_tool(install_id, yes=False, dry_run=dry_run):
@@ -862,6 +954,21 @@ def _switch_workspace(dry_run: bool) -> None:
     _run_config_home(load(record.root), record, dry_run)
 
 
+def _print_new_line_guidance(config: Config) -> None:
+    print("\n新功能开发线会创建隔离 Git worktree。")
+    print("先确认功能 ID、范围、参与仓库与基线；确认后才会修改 Git 工作区。")
+    print(
+        "下一步："
+        f"dyro line create <ID> --base {shlex.quote(config.policy.default_base)} --yes"
+    )
+
+
+def _print_new_hotfix_guidance() -> None:
+    print("\nHotfix 需要已核实的生产 release 分支、tag 或部署 SHA。")
+    print("确认问题 ID 和基线后，才会创建隔离的 Hotfix worktree。")
+    print("下一步：dyro hotfix create <问题ID> --base <已核实的 release/tag/SHA> --yes")
+
+
 def _run_config_home(
     config: Config, record: WorkspaceRecord | None, dry_run: bool
 ) -> None:
@@ -902,6 +1009,12 @@ def _run_config_home(
         return
     if kind == "switch":
         _switch_workspace(dry_run)
+        return
+    if kind == "new-line":
+        _print_new_line_guidance(config)
+        return
+    if kind == "new-hotfix":
+        _print_new_hotfix_guidance()
         return
     if kind == "task":
         task = load_task(config, target_id)

--- a/src/dyro/home.py
+++ b/src/dyro/home.py
@@ -6,6 +6,7 @@ from pathlib import Path
 import shlex
 import shutil
 import sys
+from urllib.parse import urlencode
 
 from .config import CONFIG_NAME, Config, expand_argv, load
 from .errors import DyroError, ValidationError
@@ -200,6 +201,41 @@ def _cursor_desktop_argv(workspace: Path) -> tuple[tuple[str, ...], bool]:
     return ("cursor", str(workspace)), False
 
 
+def _macos_app_name(*names: str) -> str | None:
+    if sys.platform != "darwin":
+        return None
+    for name in names:
+        candidates = (
+            Path("/Applications") / f"{name}.app",
+            Path.home() / "Applications" / f"{name}.app",
+        )
+        if any(candidate.is_dir() for candidate in candidates):
+            return name
+    return None
+
+
+def _codex_desktop_argv(workspace: Path) -> tuple[tuple[str, ...], bool]:
+    argv = ("codex", "app", str(workspace))
+    app_name = _macos_app_name("Codex", "ChatGPT")
+    if app_name is None:
+        return argv, False
+    if shutil.which("codex") is not None:
+        return argv, True
+    if shutil.which("open") is not None:
+        return ("open", "-a", app_name, str(workspace)), True
+    return argv, False
+
+
+def _claude_desktop_argv(workspace: Path) -> tuple[tuple[str, ...], bool]:
+    url = "claude://code/new?" + urlencode({"folder": str(workspace)})
+    if (
+        _macos_app_name("Claude", "Claude Code URL Handler") is not None
+        and shutil.which("open") is not None
+    ):
+        return ("open", url), True
+    return ("open", url), False
+
+
 def _zcode_desktop_argv(workspace: Path) -> tuple[tuple[str, ...], bool]:
     if shutil.which("zcode") is not None:
         return ("zcode", str(workspace)), True
@@ -218,6 +254,10 @@ def _launcher_tool(
 ) -> HomeTool:
     if definition.id == "cursor-desktop":
         argv, installed = _cursor_desktop_argv(workspace)
+    elif definition.id == "codex-desktop":
+        argv, installed = _codex_desktop_argv(workspace)
+    elif definition.id == "claude-desktop":
+        argv, installed = _claude_desktop_argv(workspace)
     elif definition.id == "zcode":
         argv, installed = _zcode_desktop_argv(workspace)
     else:
@@ -396,25 +436,23 @@ def print_agent_discovery(config: Config) -> None:
                 else "未安装；暂无内置安装方案"
             )
         print(f"{command:16} {'已检测' if installed else '-':10} {state:16} {note}")
-    cursor_definition = next(
-        definition
-        for definition in TOOL_DEFINITIONS
-        if definition.id == "cursor-desktop"
-    )
-    cursor_desktop = _launcher_tool(
-        cursor_definition, config=config, workspace=config.root
-    )
-    desktop_state = "已检测" if cursor_desktop.available else "-"
-    desktop_note = (
-        "首页可打开工作区；不获得执行、门禁或复核权限"
-        if cursor_desktop.available
-        else "未安装；可运行 dyro tool install cursor-desktop"
-    )
-    desktop_integration = "尚未集成" if cursor_desktop.available else "-"
-    print(
-        f"{'cursor-desktop':16} {desktop_state:10} "
-        f"{desktop_integration:16} {desktop_note}"
-    )
+    for definition in TOOL_DEFINITIONS:
+        if definition.interface != "desktop":
+            continue
+        desktop_tool = _launcher_tool(
+            definition, config=config, workspace=config.root
+        )
+        desktop_state = "已检测" if desktop_tool.available else "-"
+        desktop_note = (
+            "首页可打开工作区；不获得执行、门禁或复核权限"
+            if desktop_tool.available
+            else f"未安装；可运行 dyro tool install {definition.id}"
+        )
+        desktop_integration = "尚未集成" if desktop_tool.available else "-"
+        print(
+            f"{definition.id:16} {desktop_state:10} "
+            f"{desktop_integration:16} {desktop_note}"
+        )
     for adapter_id in sorted(config.adapters):
         executable = _adapter_executable(config, adapter_id)
         if Path(executable).name in known_commands:

--- a/src/dyro/hub.py
+++ b/src/dyro/hub.py
@@ -32,6 +32,16 @@ class WorkspaceRegistry:
     workspaces: tuple[WorkspaceRecord, ...] = ()
 
 
+@dataclass(frozen=True)
+class WorkspaceRegistrationPlan:
+    """A read-only preview of adding one workspace to the global entry list."""
+
+    name: str
+    root: Path
+    already_registered: bool
+    becomes_default: bool
+
+
 def registry_home() -> Path:
     override = os.environ.get("DYRO_HOME", "").strip()
     if override:
@@ -166,6 +176,32 @@ def _profile_root(path: str | Path) -> Config:
         raise DyroError(
             f"这里不是可用的 Dyro 工作区：{candidate}；请确认其中存在有效 dyro.toml"
         ) from exc
+
+
+def preview_workspace_registration(
+    path: str | Path, *, name: str, make_default: bool = False
+) -> WorkspaceRegistrationPlan:
+    """Validate and describe a future global workspace registration without writing."""
+
+    root = Path(path).expanduser().absolute().resolve()
+    alias = validate_id(name, "工作区别名")
+    registry = load_registry()
+    same_name = next(
+        (item for item in registry.workspaces if item.name == alias), None
+    )
+    same_root = next(
+        (item for item in registry.workspaces if item.root == root), None
+    )
+    if same_name is not None and same_name.root != root:
+        raise DyroError(f"工作区别名 {alias} 已指向 {same_name.root}")
+    if same_root is not None and same_root.name != alias:
+        raise DyroError(f"工作区路径已经登记为 {same_root.name}：{root}")
+    return WorkspaceRegistrationPlan(
+        name=alias,
+        root=root,
+        already_registered=same_name is not None or same_root is not None,
+        becomes_default=make_default or not registry.default,
+    )
 
 
 def add_workspace(

--- a/src/dyro/terminal.py
+++ b/src/dyro/terminal.py
@@ -1,0 +1,72 @@
+"""Small, dependency-free terminal presentation helpers.
+
+The CLI is often consumed by scripts, redirected into evidence files, and run
+in terminals with widely different capabilities.  Keep color opt-in by
+terminal capability, while allowing users to force or disable it with the
+common ``NO_COLOR`` convention or ``DYRO_COLOR=always|never|auto``.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from typing import TextIO
+
+
+_RESET = "\033[0m"
+_STYLES = {
+    "title": "1;35",
+    "value": "1;36",
+    "success": "1;32",
+    "warning": "1;33",
+    "danger": "1;31",
+    "muted": "2;37",
+}
+
+
+def color_enabled(stream: TextIO | None = None) -> bool:
+    """Return whether ANSI color is appropriate for this output stream."""
+    preference = os.environ.get("DYRO_COLOR", "auto").strip().lower()
+    if preference in {"never", "no", "false", "0"}:
+        return False
+    if "NO_COLOR" in os.environ:
+        return False
+    if preference in {"always", "yes", "true", "1"}:
+        return True
+    target = stream or sys.stdout
+    return (
+        bool(getattr(target, "isatty", lambda: False)())
+        and os.environ.get("TERM", "").lower() != "dumb"
+    )
+
+
+def style(text: object, role: str, *, stream: TextIO | None = None) -> str:
+    """Apply one semantic presentation role when color is enabled."""
+    value = str(text)
+    if not color_enabled(stream) or role not in _STYLES:
+        return value
+    return f"\033[{_STYLES[role]}m{value}{_RESET}"
+
+
+def title(text: object, *, stream: TextIO | None = None) -> str:
+    return style(text, "title", stream=stream)
+
+
+def value(text: object, *, stream: TextIO | None = None) -> str:
+    return style(text, "value", stream=stream)
+
+
+def success(text: object, *, stream: TextIO | None = None) -> str:
+    return style(text, "success", stream=stream)
+
+
+def warning(text: object, *, stream: TextIO | None = None) -> str:
+    return style(text, "warning", stream=stream)
+
+
+def danger(text: object, *, stream: TextIO | None = None) -> str:
+    return style(text, "danger", stream=stream)
+
+
+def muted(text: object, *, stream: TextIO | None = None) -> str:
+    return style(text, "muted", stream=stream)

--- a/src/dyro/tooling.py
+++ b/src/dyro/tooling.py
@@ -62,6 +62,18 @@ _NPM_RISK = "将联网下载软件包，并可能执行软件包提供的安装�
 
 TOOL_DEFINITIONS = (
     ToolDefinition(
+        "antigravity",
+        "Antigravity CLI",
+        "agy",
+        "terminal",
+        ("agy",),
+        install=InstallGuide(
+            "https://antigravity.google/download",
+            "Antigravity 官方用户级安装目录",
+            remote_script_only=True,
+        ),
+    ),
+    ToolDefinition(
         "codex",
         "Codex",
         "codex",
@@ -168,6 +180,32 @@ TOOL_DEFINITIONS = (
             ("npm", "install", "-g", "@moonshot-ai/kimi-code@latest"),
             prerequisite="npm",
             risk=_NPM_RISK,
+        ),
+    ),
+    ToolDefinition(
+        "qoder",
+        "Qoder CLI",
+        "qodercli",
+        "terminal",
+        ("qodercli",),
+        install=InstallGuide(
+            "https://docs.qoder.com/en/cli/quick-start",
+            _NPM_SCOPE,
+            ("npm", "install", "-g", "@qoder-ai/qodercli"),
+            prerequisite="npm",
+            risk=_NPM_RISK,
+        ),
+    ),
+    ToolDefinition(
+        "zcode",
+        "ZCode",
+        "zcode",
+        "desktop",
+        ("zcode", "{workspace}"),
+        install=InstallGuide(
+            "https://zcode.z.ai/en/docs/install",
+            "当前操作系统的桌面应用",
+            remote_script_only=True,
         ),
     ),
 )

--- a/src/dyro/tooling.py
+++ b/src/dyro/tooling.py
@@ -88,6 +88,18 @@ TOOL_DEFINITIONS = (
         ),
     ),
     ToolDefinition(
+        "codex-desktop",
+        "Codex App",
+        "codex-desktop",
+        "desktop",
+        ("codex", "app", "{workspace}"),
+        install=InstallGuide(
+            "https://openai.com/codex/",
+            "当前操作系统的 Codex 桌面应用",
+            remote_script_only=True,
+        ),
+    ),
+    ToolDefinition(
         "claude",
         "Claude Code",
         "claude",
@@ -99,6 +111,18 @@ TOOL_DEFINITIONS = (
             ("npm", "install", "-g", "@anthropic-ai/claude-code@latest"),
             prerequisite="npm",
             risk=_NPM_RISK,
+        ),
+    ),
+    ToolDefinition(
+        "claude-desktop",
+        "Claude Code Desktop",
+        "claude-desktop",
+        "desktop",
+        (),
+        install=InstallGuide(
+            "https://claude.com/download",
+            "当前操作系统的 Claude 桌面应用",
+            remote_script_only=True,
         ),
     ),
     ToolDefinition(

--- a/src/dyro/workspace.py
+++ b/src/dyro/workspace.py
@@ -206,7 +206,7 @@ def _rollback_line_creations(config: Config, line: Line, created: list[str]) -> 
     return failures
 
 
-def create_line(
+def _build_line(
     config: Config,
     *,
     line_id: str,
@@ -216,9 +216,8 @@ def create_line(
     repository_bases: Mapping[str, str] | None = None,
     storage_modes: Mapping[str, str] | None = None,
     kind: str = "line",
-    dry_run: bool = False,
 ) -> Line:
-    """Create isolated linked worktrees from configured repository anchors."""
+    """Validate line arguments and turn them into one immutable creation plan."""
     validate_id(line_id, "开发线 ID")
     if not branch or not base:
         raise ValidationError("branch 与 base 都必须明确指定")
@@ -244,14 +243,20 @@ def create_line(
     for repo_id, storage_mode in storage_overrides.items():
         if storage_mode not in STORAGE_MODES:
             raise ValidationError(f"{repo_id} 的存储方式必须是：{', '.join(sorted(STORAGE_MODES))}")
-    line = Line(line_id, kind, branch, base, selected, base_overrides, storage_overrides)
+    return Line(line_id, kind, branch, base, selected, base_overrides, storage_overrides)
+
+
+def _plan_line_creation(
+    config: Config, line: Line
+) -> list[tuple[str, Path, tuple[str, ...]]]:
+    """Validate every Git-side prerequisite without creating a worktree."""
     target_root = line_root(config, line)
     if target_root.exists() and any(target_root.iterdir()):
         raise DyroError(f"目标工作区已存在且非空：{target_root}")
 
     # Validate every repository before mutating any worktree so partial creates are rare.
     planned: list[tuple[str, Path, tuple[str, ...]]] = []
-    for repo_id in selected:
+    for repo_id in line.repositories:
         anchor = repository_path(config, repo_id)
         destination = line_repository_path(config, line, repo_id)
         if not _is_git_repo(anchor):
@@ -261,22 +266,91 @@ def create_line(
         require_ok(git(anchor, "rev-parse", "--verify", f"{repo_base}^{{commit}}"), f"校验 {repo_id} 基线 {repo_base}")
         if destination.exists() or destination.is_symlink():
             raise DyroError(f"worktree 目标已存在：{destination}")
-        branch_check = git(anchor, "show-ref", "--verify", "--quiet", f"refs/heads/{branch}")
+        branch_check = git(
+            anchor, "show-ref", "--verify", "--quiet", f"refs/heads/{line.branch}"
+        )
         if branch_check.code == 0:
-            ancestry = git(anchor, "merge-base", "--is-ancestor", repo_base, branch)
+            ancestry = git(
+                anchor, "merge-base", "--is-ancestor", repo_base, line.branch
+            )
             if ancestry.code != 0:
-                raise DyroError(f"{repo_id} 既有分支 {branch} 不包含声明的基线 {repo_base}")
+                raise DyroError(
+                    f"{repo_id} 既有分支 {line.branch} 不包含声明的基线 {repo_base}"
+                )
         if line.storage_for(repo_id) == "anchor-reference":
             anchor_branch = require_ok(git(anchor, "branch", "--show-current"), f"读取 {repo_id} anchor 分支").stdout.strip()
-            if anchor_branch != branch:
-                raise DyroError(f"{repo_id} 的 anchor-reference 要求 anchor 正位于 {branch}，当前为 {anchor_branch or 'DETACHED'}")
+            if anchor_branch != line.branch:
+                raise DyroError(
+                    f"{repo_id} 的 anchor-reference 要求 anchor 正位于 {line.branch}，"
+                    f"当前为 {anchor_branch or 'DETACHED'}"
+                )
             planned.append((repo_id, destination, ()))
             continue
         command = ("worktree", "add")
         if branch_check.code != 0:
-            command += ("-b", branch)
-        command += (str(destination), branch if branch_check.code == 0 else repo_base)
+            command += ("-b", line.branch)
+        command += (
+            str(destination), line.branch if branch_check.code == 0 else repo_base
+        )
         planned.append((repo_id, destination, command))
+    return planned
+
+
+def preflight_line(
+    config: Config,
+    *,
+    line_id: str,
+    branch: str,
+    base: str,
+    repositories: Iterable[str] | None = None,
+    repository_bases: Mapping[str, str] | None = None,
+    storage_modes: Mapping[str, str] | None = None,
+    kind: str = "line",
+) -> Line:
+    """Verify that a line can be created without changing Git state.
+
+    The home wizard uses this before asking for confirmation. ``create_line``
+    repeats the check immediately before mutation because repositories can
+    change between the preview and the user's confirmation.
+    """
+    line = _build_line(
+        config,
+        line_id=line_id,
+        branch=branch,
+        base=base,
+        repositories=repositories,
+        repository_bases=repository_bases,
+        storage_modes=storage_modes,
+        kind=kind,
+    )
+    _plan_line_creation(config, line)
+    return line
+
+
+def create_line(
+    config: Config,
+    *,
+    line_id: str,
+    branch: str,
+    base: str,
+    repositories: Iterable[str] | None = None,
+    repository_bases: Mapping[str, str] | None = None,
+    storage_modes: Mapping[str, str] | None = None,
+    kind: str = "line",
+    dry_run: bool = False,
+) -> Line:
+    """Create isolated linked worktrees from configured repository anchors."""
+    line = _build_line(
+        config,
+        line_id=line_id,
+        branch=branch,
+        base=base,
+        repositories=repositories,
+        repository_bases=repository_bases,
+        storage_modes=storage_modes,
+        kind=kind,
+    )
+    planned = _plan_line_creation(config, line)
 
     created: list[str] = []
     try:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,5 +1,6 @@
 from pathlib import Path
 import json
+import os
 import tempfile
 import unittest
 from contextlib import redirect_stderr, redirect_stdout
@@ -9,6 +10,7 @@ from unittest.mock import patch
 from dyro.cli import _route_experiment_surface, _setup_provider_preset, main
 from dyro.changesets import get_changeset
 from dyro.config import load
+from dyro.hub import load_registry
 from dyro.tasks import load_task, status, task_template
 from dyro.workspace import create_line, get_line
 
@@ -16,6 +18,17 @@ from .support import WorkspaceCase
 
 
 class CliTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.registry_tmp = tempfile.TemporaryDirectory(prefix="dyro-registry-")
+        self.registry_environment = patch.dict(
+            os.environ, {"DYRO_HOME": self.registry_tmp.name}, clear=False
+        )
+        self.registry_environment.start()
+
+    def tearDown(self) -> None:
+        self.registry_environment.stop()
+        self.registry_tmp.cleanup()
+
     def test_runtime_is_not_an_experiment_surface(self) -> None:
         routed = _route_experiment_surface(
             [
@@ -98,6 +111,111 @@ class CliTests(unittest.TestCase):
             self.assertTrue((root / ".dyro/tasks").is_dir())
             self.assertEqual(get_line(config, "dev").branch, "feat/dev")
             self.assertTrue((root / "versions/dev/api").is_dir())
+
+            registry = load_registry()
+            self.assertEqual(registry.default, "demo")
+            self.assertEqual(
+                [(record.name, record.root) for record in registry.workspaces],
+                [("demo", root.resolve())],
+            )
+
+    def test_setup_keeps_an_existing_default_workspace(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="dyro-cli-") as tmp:
+            root = Path(tmp) / "workspace"
+            repository = root / "repositories/api"
+            repository.mkdir(parents=True)
+            from .support import shell
+
+            shell("git", "init", "-b", "main", cwd=repository)
+            shell("git", "config", "user.name", "Test User", cwd=repository)
+            shell("git", "config", "user.email", "test@example.com", cwd=repository)
+            repository.joinpath("README.md").write_text("anchor\n", encoding="utf-8")
+            shell("git", "add", "README.md", cwd=repository)
+            shell("git", "commit", "-m", "chore: initial", cwd=repository)
+
+            existing = Path(tmp) / "existing"
+            main(["init", str(existing), "--name", "existing"])
+            main(["workspace", "add", str(existing), "--default"])
+
+            main(["setup", str(root), "--name", "demo", "--no-line"])
+
+            registry = load_registry()
+            self.assertEqual(registry.default, "existing")
+            self.assertEqual(
+                {record.name for record in registry.workspaces}, {"demo", "existing"}
+            )
+
+    def test_setup_can_explicitly_set_the_default_workspace(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="dyro-cli-") as tmp:
+            root = Path(tmp) / "workspace"
+            repository = root / "repositories/api"
+            repository.mkdir(parents=True)
+            from .support import shell
+
+            shell("git", "init", "-b", "main", cwd=repository)
+
+            existing = Path(tmp) / "existing"
+            main(["init", str(existing), "--name", "existing"])
+            main(["workspace", "add", str(existing), "--default"])
+
+            main(
+                [
+                    "setup",
+                    str(root),
+                    "--name",
+                    "demo",
+                    "--no-line",
+                    "--default",
+                ]
+            )
+
+            self.assertEqual(load_registry().default, "demo")
+
+    def test_setup_can_skip_global_workspace_registration(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="dyro-cli-") as tmp:
+            root = Path(tmp) / "workspace"
+            repository = root / "repositories/api"
+            repository.mkdir(parents=True)
+            from .support import shell
+
+            shell("git", "init", "-b", "main", cwd=repository)
+
+            main(
+                [
+                    "setup",
+                    str(root),
+                    "--name",
+                    "demo",
+                    "--no-line",
+                    "--no-register",
+                ]
+            )
+
+            self.assertEqual(load_registry().workspaces, ())
+
+    def test_setup_rejects_an_alias_conflict_before_writing_a_profile(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="dyro-cli-") as tmp:
+            existing = Path(tmp) / "existing"
+            main(["init", str(existing), "--name", "demo"])
+            main(["workspace", "add", str(existing)])
+
+            root = Path(tmp) / "workspace"
+            repository = root / "repositories/api"
+            repository.mkdir(parents=True)
+            from .support import shell
+
+            shell("git", "init", "-b", "main", cwd=repository)
+
+            stderr = StringIO()
+            with (
+                redirect_stderr(stderr),
+                self.assertRaises(SystemExit) as raised,
+            ):
+                main(["setup", str(root), "--name", "demo", "--no-line"])
+
+            self.assertEqual(raised.exception.code, 2)
+            self.assertIn("工作区别名 demo 已指向", stderr.getvalue())
+            self.assertFalse((root / "dyro.toml").exists())
 
     def test_setup_accepts_dry_run_after_the_command_without_writing(self) -> None:
         with tempfile.TemporaryDirectory(prefix="dyro-cli-") as tmp:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -7,7 +7,13 @@ from contextlib import redirect_stderr, redirect_stdout
 from io import StringIO
 from unittest.mock import patch
 
-from dyro.cli import _route_experiment_surface, _setup_provider_preset, main
+from dyro.cli import (
+    _print_doctor_finding,
+    _print_setup_completion,
+    _route_experiment_surface,
+    _setup_provider_preset,
+    main,
+)
 from dyro.changesets import get_changeset
 from dyro.config import load
 from dyro.hub import load_registry
@@ -53,6 +59,44 @@ class CliTests(unittest.TestCase):
         self.assertEqual(raised.exception.code, 2)
         self.assertIn("invalid choice", stderr.getvalue())
 
+    def test_interrupted_setup_exits_without_a_traceback(self) -> None:
+        stderr = StringIO()
+        with (
+            patch("dyro.cli._interactive_setup", side_effect=KeyboardInterrupt),
+            redirect_stderr(stderr),
+            self.assertRaises(SystemExit) as raised,
+        ):
+            main(["setup", "--interactive"])
+
+        self.assertEqual(raised.exception.code, 130)
+        self.assertIn("已停止当前操作", stderr.getvalue())
+        self.assertIn("dyro doctor", stderr.getvalue())
+
+    def test_management_views_have_clear_plain_text_headings(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="dyro-cli-") as tmp:
+            root = Path(tmp) / "workspace"
+            repository = root / "repositories/api"
+            repository.mkdir(parents=True)
+            from .support import shell
+
+            shell("git", "init", "-b", "main", cwd=repository)
+            shell("git", "config", "user.name", "Test User", cwd=repository)
+            shell("git", "config", "user.email", "test@example.com", cwd=repository)
+            repository.joinpath("README.md").write_text("anchor\n", encoding="utf-8")
+            shell("git", "add", "README.md", cwd=repository)
+            shell("git", "commit", "-m", "chore: initial", cwd=repository)
+            main(["setup", str(root), "--name", "demo", "--no-line"])
+            output = StringIO()
+            with redirect_stdout(output):
+                main(["workspace", "list"])
+                main(["--root", str(root), "doctor"])
+
+            rendered = output.getvalue()
+            self.assertIn("━━ 全局工作区 ━━", rendered)
+            self.assertIn("●", rendered)
+            self.assertIn("━━ Dyro 健康检查 ━━", rendered)
+            self.assertIn("检查通过。", rendered)
+
     def test_init_creates_workspace_contract(self) -> None:
         with tempfile.TemporaryDirectory(prefix="dyro-cli-") as tmp:
             root = Path(tmp) / "workspace"
@@ -60,6 +104,22 @@ class CliTests(unittest.TestCase):
             self.assertTrue((root / "dyro.toml").exists())
             self.assertTrue((root / ".dyro/tasks").is_dir())
             self.assertEqual(load(root).name, "demo")
+
+    def test_setup_presentation_uses_semantic_color_when_enabled(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="dyro-cli-") as tmp:
+            root = Path(tmp) / "workspace"
+            main(["init", str(root), "--name", "demo"])
+            output = StringIO()
+            with patch.dict(os.environ, {"DYRO_COLOR": "always"}):
+                os.environ.pop("NO_COLOR", None)
+                with redirect_stdout(output):
+                    _print_setup_completion(load(root), None)
+                    _print_doctor_finding("PASS repository api: ready")
+
+            rendered = output.getvalue()
+            self.assertIn("\033[1;32m━━ 设置完成 ━━\033[0m", rendered)
+            self.assertIn("\033[1;36mdemo\033[0m", rendered)
+            self.assertIn("\033[1;32mPASS repository api: ready\033[0m", rendered)
 
     def test_init_discover_creates_config_from_local_git_repositories(self) -> None:
         with tempfile.TemporaryDirectory(prefix="dyro-cli-") as tmp:
@@ -241,7 +301,9 @@ class CliTests(unittest.TestCase):
         self.assertEqual(raised.exception.code, 2)
         self.assertIn("not allowed with argument", stderr.getvalue())
 
-    def test_setup_reports_detected_but_unintegrated_providers_without_registering_them(self) -> None:
+    def test_setup_reports_detected_but_unintegrated_providers_without_registering_them(
+        self,
+    ) -> None:
         discovered = {
             "agy",
             "claude",
@@ -254,7 +316,12 @@ class CliTests(unittest.TestCase):
         }
         output = StringIO()
         with (
-            patch("dyro.cli.shutil.which", side_effect=lambda command: f"/fake/{command}" if command in discovered else None),
+            patch(
+                "dyro.cli.shutil.which",
+                side_effect=lambda command: (
+                    f"/fake/{command}" if command in discovered else None
+                ),
+            ),
             redirect_stdout(output),
         ):
             self.assertIsNone(_setup_provider_preset())
@@ -355,7 +422,9 @@ class CliTests(unittest.TestCase):
             self.assertEqual(len(config.repositories), 1)
             self.assertTrue((sibling / "versions/dev").is_dir())
 
-    def test_interactive_setup_uses_the_source_branch_as_the_suggested_base(self) -> None:
+    def test_interactive_setup_uses_the_source_branch_as_the_suggested_base(
+        self,
+    ) -> None:
         with tempfile.TemporaryDirectory(prefix="dyro-cli-") as tmp:
             parent = Path(tmp)
             remote = parent / "api-origin.git"
@@ -390,7 +459,18 @@ class StartTests(WorkspaceCase):
     def test_start_dry_run_uses_selected_line_and_adapter(self) -> None:
         config = load(self.root)
         create_line(config, line_id="alpha", branch="feat/alpha", base="main")
-        main(["--root", str(self.root), "--dry-run", "start", "--line", "alpha", "--agent", "noop"])
+        main(
+            [
+                "--root",
+                str(self.root),
+                "--dry-run",
+                "start",
+                "--line",
+                "alpha",
+                "--agent",
+                "noop",
+            ]
+        )
 
     def test_next_without_a_profile_explains_how_to_begin(self) -> None:
         with tempfile.TemporaryDirectory(prefix="dyro-cli-") as tmp:
@@ -403,7 +483,9 @@ class StartTests(WorkspaceCase):
 
 
 class LineCommandsTests(WorkspaceCase):
-    def test_line_create_records_per_repository_base_and_storage_without_toml_edits(self) -> None:
+    def test_line_create_records_per_repository_base_and_storage_without_toml_edits(
+        self,
+    ) -> None:
         main(
             [
                 "--root",
@@ -423,34 +505,66 @@ class LineCommandsTests(WorkspaceCase):
         self.assertEqual(line.base_for("api"), "main")
         self.assertEqual(line.storage_for("api"), "linked-worktree")
 
-    def test_changeset_create_records_a_delivery_line_without_manual_toml_edit(self) -> None:
+    def test_changeset_create_records_a_delivery_line_without_manual_toml_edit(
+        self,
+    ) -> None:
         config = load(self.root)
         create_line(config, line_id="alpha", branch="feat/alpha", base="main")
 
-        main(["--root", str(self.root), "changeset", "create", "alpha-ready", "--line", "alpha"])
+        main(
+            [
+                "--root",
+                str(self.root),
+                "changeset",
+                "create",
+                "alpha-ready",
+                "--line",
+                "alpha",
+            ]
+        )
 
         self.assertEqual(get_changeset(load(self.root), "alpha-ready").line, "alpha")
 
 
 class RepositoryCommandsTests(WorkspaceCase):
-    def test_repo_add_registers_an_existing_git_repository_without_manual_toml_edit(self) -> None:
+    def test_repo_add_registers_an_existing_git_repository_without_manual_toml_edit(
+        self,
+    ) -> None:
         web = self.root / "repositories/web"
         web.mkdir(parents=True)
         from .support import shell
 
         shell("git", "init", "-b", "main", cwd=web)
-        shell("git", "remote", "add", "origin", "https://example.test/acme/web.git", cwd=web)
+        shell(
+            "git",
+            "remote",
+            "add",
+            "origin",
+            "https://example.test/acme/web.git",
+            cwd=web,
+        )
         main(["--root", str(self.root), "repo", "add", "repositories/web"])
 
         config = load(self.root)
         self.assertEqual(config.repositories["web"].path, "repositories/web")
         self.assertEqual(config.repositories["web"].mount, "web")
-        self.assertEqual(config.repositories["web"].remote, "https://example.test/acme/web.git")
+        self.assertEqual(
+            config.repositories["web"].remote, "https://example.test/acme/web.git"
+        )
 
 
 class ProfileCommandsTests(WorkspaceCase):
     def test_config_and_agent_management_do_not_require_manual_toml_edits(self) -> None:
-        main(["--root", str(self.root), "config", "set", "policy.execution_mode", "external"])
+        main(
+            [
+                "--root",
+                str(self.root),
+                "config",
+                "set",
+                "policy.execution_mode",
+                "external",
+            ]
+        )
         self.assertEqual(load(self.root).policy.execution_mode, "external")
 
         main(["--root", str(self.root), "agent", "add", "isolated", "--preset", "noop"])
@@ -528,12 +642,16 @@ class ObjectiveCliTests(WorkspaceCase):
         directory = self.config.task_specs_dir / "TASK-A"
         directory.mkdir(parents=True)
         directory.joinpath("task.toml").write_text(
-            task_template("TASK-A", "Task A", "alpha", "api", "services/api").replace('agent = "codex"', 'agent = "noop"'),
+            task_template("TASK-A", "Task A", "alpha", "api", "services/api").replace(
+                'agent = "codex"', 'agent = "noop"'
+            ),
             encoding="utf-8",
         )
         directory.joinpath("handoff.md").write_text("# handoff\n", encoding="utf-8")
 
-    def test_objective_start_dry_run_has_zero_writes_and_lifecycle_commands_work(self) -> None:
+    def test_objective_start_dry_run_has_zero_writes_and_lifecycle_commands_work(
+        self,
+    ) -> None:
         root = str(self.root)
         main(
             [
@@ -582,7 +700,9 @@ class ObjectiveCliTests(WorkspaceCase):
             main(["--root", root, "objective", "status", "release"])
         self.assertIn("Derived result: incomplete", output.getvalue())
 
-    def test_objective_read_only_plan_explain_graph_tick_and_attention_do_not_mutate_state(self) -> None:
+    def test_objective_read_only_plan_explain_graph_tick_and_attention_do_not_mutate_state(
+        self,
+    ) -> None:
         root = str(self.root)
         main(
             [
@@ -602,7 +722,11 @@ class ObjectiveCliTests(WorkspaceCase):
             ]
         )
         objective_dir = self.config.objectives_dir / "release"
-        before = {path.relative_to(objective_dir): path.read_bytes() for path in objective_dir.rglob("*") if path.is_file()}
+        before = {
+            path.relative_to(objective_dir): path.read_bytes()
+            for path in objective_dir.rglob("*")
+            if path.is_file()
+        }
         plan_output = StringIO()
         with redirect_stdout(plan_output):
             main(["--root", root, "objective", "plan", "release", "--format", "json"])
@@ -613,7 +737,9 @@ class ObjectiveCliTests(WorkspaceCase):
         self.assertIn("Objective: release", explain_output.getvalue())
         graph_output = StringIO()
         with redirect_stdout(graph_output):
-            main(["--root", root, "objective", "graph", "release", "--format", "mermaid"])
+            main(
+                ["--root", root, "objective", "graph", "release", "--format", "mermaid"]
+            )
         self.assertIn("flowchart LR", graph_output.getvalue())
         tick_output = StringIO()
         with redirect_stdout(tick_output):
@@ -622,38 +748,84 @@ class ObjectiveCliTests(WorkspaceCase):
         self.assertIn('"wave"', tick_output.getvalue())
         attention_output = StringIO()
         with redirect_stdout(attention_output):
-            main(["--root", root, "objective", "attention", "release", "--format", "json"])
+            main(
+                [
+                    "--root",
+                    root,
+                    "objective",
+                    "attention",
+                    "release",
+                    "--format",
+                    "json",
+                ]
+            )
         self.assertIn('"attention_sha256"', attention_output.getvalue())
         self.assertIn('"items"', attention_output.getvalue())
-        after = {path.relative_to(objective_dir): path.read_bytes() for path in objective_dir.rglob("*") if path.is_file()}
+        after = {
+            path.relative_to(objective_dir): path.read_bytes()
+            for path in objective_dir.rglob("*")
+            if path.is_file()
+        }
         self.assertEqual(before, after)
 
     def test_objective_apply_dry_run_shows_the_exact_wave_without_writing(self) -> None:
         root = str(self.root)
         main(
             [
-                "--root", root, "objective", "start", "--id", "release", "--title", "Release",
-                "--line", "alpha", "--targets", "TASK-A", "--yes",
+                "--root",
+                root,
+                "objective",
+                "start",
+                "--id",
+                "release",
+                "--title",
+                "Release",
+                "--line",
+                "alpha",
+                "--targets",
+                "TASK-A",
+                "--yes",
             ]
         )
         objective_dir = self.config.objectives_dir / "release"
-        before = {path.relative_to(objective_dir): path.read_bytes() for path in objective_dir.rglob("*") if path.is_file()}
+        before = {
+            path.relative_to(objective_dir): path.read_bytes()
+            for path in objective_dir.rglob("*")
+            if path.is_file()
+        }
         output = StringIO()
         with redirect_stdout(output):
             main(["--root", root, "--dry-run", "objective", "apply", "release"])
-        after = {path.relative_to(objective_dir): path.read_bytes() for path in objective_dir.rglob("*") if path.is_file()}
+        after = {
+            path.relative_to(objective_dir): path.read_bytes()
+            for path in objective_dir.rglob("*")
+            if path.is_file()
+        }
         self.assertIn("Tick SHA-256", output.getvalue())
         self.assertIn("DRY RUN", output.getvalue())
         self.assertEqual(before, after)
 
-    def test_objective_apply_noninteractive_uses_stable_confirmation_and_json_envelope(self) -> None:
+    def test_objective_apply_noninteractive_uses_stable_confirmation_and_json_envelope(
+        self,
+    ) -> None:
         from dyro.continuation.supervision import build_supervised_wave
 
         root = str(self.root)
         main(
             [
-                "--root", root, "objective", "start", "--id", "release", "--title", "Release",
-                "--line", "alpha", "--targets", "TASK-A", "--yes",
+                "--root",
+                root,
+                "objective",
+                "start",
+                "--id",
+                "release",
+                "--title",
+                "Release",
+                "--line",
+                "alpha",
+                "--targets",
+                "TASK-A",
+                "--yes",
             ]
         )
         confirmation = build_supervised_wave(self.config, "release").confirmation_sha256
@@ -664,8 +836,16 @@ class ObjectiveCliTests(WorkspaceCase):
         ):
             main(
                 [
-                    "--root", root, "objective", "apply", "release", "--yes",
-                    "--confirm-sha", confirmation, "--format", "json",
+                    "--root",
+                    root,
+                    "objective",
+                    "apply",
+                    "release",
+                    "--yes",
+                    "--confirm-sha",
+                    confirmation,
+                    "--format",
+                    "json",
                 ]
             )
         payload = json.loads(output.getvalue())
@@ -681,8 +861,19 @@ class ObjectiveCliTests(WorkspaceCase):
         root = str(self.root)
         main(
             [
-                "--root", root, "objective", "start", "--id", "release", "--title", "Release",
-                "--line", "alpha", "--targets", "TASK-A", "--yes",
+                "--root",
+                root,
+                "objective",
+                "start",
+                "--id",
+                "release",
+                "--title",
+                "Release",
+                "--line",
+                "alpha",
+                "--targets",
+                "TASK-A",
+                "--yes",
             ]
         )
         confirmation = build_supervised_wave(self.config, "release").confirmation_sha256
@@ -695,8 +886,14 @@ class ObjectiveCliTests(WorkspaceCase):
         ):
             main(
                 [
-                    "--root", root, "objective", "apply", "release", "--yes",
-                    "--confirm-sha", confirmation,
+                    "--root",
+                    root,
+                    "objective",
+                    "apply",
+                    "release",
+                    "--yes",
+                    "--confirm-sha",
+                    confirmation,
                 ]
             )
         self.assertEqual(rejected.exception.code, 2)
@@ -715,9 +912,9 @@ class DaemonSelectionTests(WorkspaceCase):
         task_path = config.task_specs_dir / "TASK-DAEMON"
         task_path.mkdir(parents=True)
         task_path.joinpath("task.toml").write_text(
-            task_template("TASK-DAEMON", "daemon backlog", "alpha", "api", "services/api").replace(
-                'agent = "codex"', 'agent = "noop"'
-            ),
+            task_template(
+                "TASK-DAEMON", "daemon backlog", "alpha", "api", "services/api"
+            ).replace('agent = "codex"', 'agent = "noop"'),
             encoding="utf-8",
         )
         task_path.joinpath("handoff.md").write_text("# handoff\n", encoding="utf-8")
@@ -736,9 +933,9 @@ class DaemonSelectionTests(WorkspaceCase):
         task_path = config.task_specs_dir / "TASK-ONCE"
         task_path.mkdir(parents=True)
         task_path.joinpath("task.toml").write_text(
-            task_template("TASK-ONCE", "daemon once", "alpha", "api", "services/api").replace(
-                'agent = "codex"', 'agent = "noop"'
-            ),
+            task_template(
+                "TASK-ONCE", "daemon once", "alpha", "api", "services/api"
+            ).replace('agent = "codex"', 'agent = "noop"'),
             encoding="utf-8",
         )
         task_path.joinpath("handoff.md").write_text("# handoff\n", encoding="utf-8")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -242,7 +242,16 @@ class CliTests(unittest.TestCase):
         self.assertIn("not allowed with argument", stderr.getvalue())
 
     def test_setup_reports_detected_but_unintegrated_providers_without_registering_them(self) -> None:
-        discovered = {"claude", "cursor-agent", "grok", "opencode", "hermes", "kimi"}
+        discovered = {
+            "agy",
+            "claude",
+            "cursor-agent",
+            "grok",
+            "opencode",
+            "hermes",
+            "kimi",
+            "qodercli",
+        }
         output = StringIO()
         with (
             patch("dyro.cli.shutil.which", side_effect=lambda command: f"/fake/{command}" if command in discovered else None),

--- a/tests/test_console_assets.py
+++ b/tests/test_console_assets.py
@@ -60,6 +60,16 @@ class ConsoleAssetTests(unittest.TestCase):
         self.assertNotIn(b"dyro.toml", body)
         self.assertNotIn(b"bootstrap=", body)
 
+    def test_shell_exposes_a_semantic_command_center(self) -> None:
+        shell = load_asset("index.html")
+
+        self.assertIn(b'id="primary-command"', shell.body)
+        self.assertIn(b'aria-live="polite"', shell.body)
+        self.assertIn(b'class="workspace-column-headings"', shell.body)
+        script = load_asset("app.js")
+        self.assertIn(b"AVAILABILITY_LABELS", script.body)
+        self.assertIn("任务总数".encode(), script.body)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_console_overview.py
+++ b/tests/test_console_overview.py
@@ -175,6 +175,14 @@ class ConsoleOverviewServiceTests(unittest.TestCase):
         with self.assertRaisesRegex(ConsoleOverviewError, "OVERVIEW_CURSOR_INVALID"):
             self.service.page(cursor=cursor, limit=1)
 
+    def test_empty_attention_recommends_the_guided_home_not_task_next(self) -> None:
+        recommendation = self.service._recommendation("alpha", [])
+
+        self.assertEqual(
+            recommendation,
+            {"reason": "HOME_GUIDANCE", "command": "dyro --workspace alpha"},
+        )
+
     def test_registry_failure_is_stable_and_path_free(self) -> None:
         service = ConsoleOverviewService(
             registry_loader=lambda: (_ for _ in ()).throw(

--- a/tests/test_hub.py
+++ b/tests/test_hub.py
@@ -13,6 +13,8 @@ from dyro.cli import _route_experiment_surface, build_parser, main
 from dyro.config import load
 from dyro.home import (
     HomeTool,
+    _choose_action,
+    _choose_tool,
     _openclaw_needs_setup,
     home_tools,
     sort_home_tools,
@@ -175,6 +177,7 @@ class HubCliTests(WorkspaceCase):
         add_workspace(self.root, name="demo", make_default=True)
         output = StringIO()
         with (
+            patch("dyro.home.Path.cwd", return_value=self.root.parent),
             patch("dyro.home.interactive_terminal", return_value=True),
             patch("builtins.input", return_value=""),
             redirect_stdout(output),
@@ -184,7 +187,7 @@ class HubCliTests(WorkspaceCase):
         rendered = output.getvalue()
         self.assertIn("test-workspace", rendered)
         self.assertIn("alpha", rendered)
-        self.assertIn("使用哪个编码工具", rendered)
+        self.assertIn("常用编码工具", rendered)
         self.assertIn("noop", rendered)
         self.assertIn("/usr/bin/true", rendered)
         self.assertEqual(load_registry().workspaces[0].last_target, "")
@@ -194,6 +197,7 @@ class HubCliTests(WorkspaceCase):
         add_workspace(self.root, name="demo", make_default=True)
         output = StringIO()
         with (
+            patch("dyro.home.Path.cwd", return_value=self.root.parent),
             patch("dyro.home.interactive_terminal", return_value=True),
             patch("builtins.input", return_value="3"),
             patch("dyro.console.launcher.create_console_http_server") as server_factory,
@@ -204,6 +208,55 @@ class HubCliTests(WorkspaceCase):
         self.assertIn("DRY RUN: 将启动只读本地 Console", output.getvalue())
         server_factory.assert_not_called()
 
+    def test_home_lists_safe_new_work_entrypoints(self) -> None:
+        output = StringIO()
+        with (
+            patch("dyro.home.interactive_terminal", return_value=True),
+            patch("builtins.input", return_value="3"),
+            redirect_stdout(output),
+        ):
+            action = _choose_action([], can_switch=False)
+
+        self.assertEqual(action, ("new-line", ""))
+        self.assertIn("开启新的功能开发线", output.getvalue())
+        self.assertIn("处理新的线上问题 / Hotfix", output.getvalue())
+
+    def test_home_new_feature_entrypoint_only_prints_next_step(self) -> None:
+        add_workspace(self.root, name="demo", make_default=True)
+        before_config = self.root.joinpath("dyro.toml").read_bytes()
+        before_registry = load_registry()
+        output = StringIO()
+        with (
+            patch("dyro.home.interactive_terminal", return_value=True),
+            patch("builtins.input", return_value="3"),
+            redirect_stdout(output),
+        ):
+            main(["--root", str(self.root)])
+
+        rendered = output.getvalue()
+        self.assertIn("新功能开发线会创建隔离 Git worktree", rendered)
+        self.assertIn("dyro line create <ID> --base main --yes", rendered)
+        self.assertEqual(self.root.joinpath("dyro.toml").read_bytes(), before_config)
+        self.assertEqual(load_registry(), before_registry)
+
+    def test_home_hotfix_entrypoint_only_prints_next_step(self) -> None:
+        add_workspace(self.root, name="demo", make_default=True)
+        before_config = self.root.joinpath("dyro.toml").read_bytes()
+        before_registry = load_registry()
+        output = StringIO()
+        with (
+            patch("dyro.home.interactive_terminal", return_value=True),
+            patch("builtins.input", return_value="4"),
+            redirect_stdout(output),
+        ):
+            main(["--root", str(self.root)])
+
+        rendered = output.getvalue()
+        self.assertIn("Hotfix 需要已核实的生产 release 分支、tag 或部署 SHA", rendered)
+        self.assertIn("dyro hotfix create <问题ID> --base", rendered)
+        self.assertEqual(self.root.joinpath("dyro.toml").read_bytes(), before_config)
+        self.assertEqual(load_registry(), before_registry)
+
     def test_home_can_open_a_detected_tool_without_granting_adapter_capabilities(
         self,
     ) -> None:
@@ -213,6 +266,7 @@ class HubCliTests(WorkspaceCase):
         answers = iter(["", "claude"])
         output = StringIO()
         with (
+            patch("dyro.home.Path.cwd", return_value=self.root.parent),
             patch("dyro.home.interactive_terminal", return_value=True),
             patch("builtins.input", side_effect=lambda _: next(answers)),
             patch(
@@ -224,8 +278,7 @@ class HubCliTests(WorkspaceCase):
             main(["--dry-run"])
 
         rendered = output.getvalue()
-        self.assertIn("Claude Code", rendered)
-        self.assertIn("仅打开工作区", rendered)
+        self.assertIn("更多工具", rendered)
         self.assertIn("$ claude", rendered)
         self.assertNotIn("claude", load(self.root).adapters)
         self.assertEqual(self.root.joinpath("dyro.toml").read_bytes(), before)
@@ -244,6 +297,67 @@ class HubCliTests(WorkspaceCase):
         self.assertEqual(codex.argv, ("codex", "-C", str(self.root)))
         self.assertTrue(codex.available)
         self.assertNotIn("codex", load(self.root).adapters)
+
+    def test_home_detects_antigravity_qoder_and_zcode_as_launch_only_tools(
+        self,
+    ) -> None:
+        discovered = {"agy", "qodercli", "zcode"}
+        with patch(
+            "dyro.home.shutil.which",
+            side_effect=lambda name: f"/fake/{name}" if name in discovered else None,
+        ):
+            tools = home_tools(load(self.root), workspace=self.root)
+
+        by_id = {tool.id: tool for tool in tools}
+        self.assertEqual(by_id["antigravity"].argv, ("agy",))
+        self.assertEqual(by_id["qoder"].argv, ("qodercli",))
+        self.assertEqual(by_id["zcode"].argv, ("zcode", str(self.root)))
+        for tool_id in ("antigravity", "qoder", "zcode"):
+            self.assertEqual(by_id[tool_id].kind, "launcher")
+            self.assertEqual(by_id[tool_id].state, ToolState.READY)
+            self.assertNotIn(tool_id, load(self.root).adapters)
+
+    def test_home_tool_picker_shows_common_choices_before_full_catalog(self) -> None:
+        discovered = {"agy", "claude", "kimi", "qodercli", "zcode"}
+        answers = iter(["m", "antigravity"])
+        output = StringIO()
+        with (
+            patch(
+                "dyro.home.shutil.which",
+                side_effect=lambda name: f"/fake/{name}" if name in discovered else None,
+            ),
+            patch("builtins.input", side_effect=lambda _: next(answers)),
+            redirect_stdout(output),
+        ):
+            tool = _choose_tool(
+                load(self.root), None, workspace=self.root, dry_run=True
+            )
+
+        self.assertIsNotNone(tool)
+        self.assertEqual(tool.id if tool else "", "antigravity")
+        rendered = output.getvalue()
+        self.assertIn("更多工具", rendered)
+        self.assertIn("Antigravity CLI", rendered)
+
+    def test_home_tool_picker_offers_installable_default_when_nothing_is_ready(
+        self,
+    ) -> None:
+        installable = HomeTool(
+            "qoder", "Qoder CLI", "launcher", ("qodercli",), (), ToolState.INSTALLABLE
+        )
+        output = StringIO()
+        with (
+            patch("dyro.home.home_tools", return_value=[installable]),
+            patch("builtins.input", return_value=""),
+            redirect_stdout(output),
+        ):
+            tool = _choose_tool(
+                load(self.root), None, workspace=self.root, dry_run=True
+            )
+
+        self.assertEqual(tool, installable)
+        self.assertIn("Qoder CLI", output.getvalue())
+        self.assertIn("未安装，可引导安装", output.getvalue())
 
     def test_home_detects_cursor_desktop_separately_from_cursor_cli(self) -> None:
         def detected(name: str) -> str | None:
@@ -408,6 +522,7 @@ class HubCliTests(WorkspaceCase):
         output = StringIO()
         before = self.root.joinpath("dyro.toml").read_bytes()
         with (
+            patch("dyro.home.Path.cwd", return_value=self.root.parent),
             patch("dyro.home.interactive_terminal", return_value=True),
             patch("dyro.home.shutil.which", side_effect=detected),
             patch("dyro.home._openclaw_needs_setup", return_value=True),
@@ -444,6 +559,7 @@ class HubCliTests(WorkspaceCase):
 
         output = StringIO()
         with (
+            patch("dyro.home.Path.cwd", return_value=self.root.parent),
             patch("dyro.home.interactive_terminal", return_value=True),
             patch("builtins.input", return_value=""),
             redirect_stdout(output),
@@ -638,6 +754,7 @@ write = ["codex"]
     def test_first_use_without_registry_is_actionable_and_non_mutating(self) -> None:
         output = StringIO()
         with (
+            patch("dyro.home.Path.cwd", return_value=self.root.parent),
             patch("dyro.home.interactive_terminal", return_value=False),
             redirect_stdout(output),
         ):

--- a/tests/test_hub.py
+++ b/tests/test_hub.py
@@ -15,6 +15,7 @@ from dyro.home import (
     HomeTool,
     _choose_action,
     _choose_tool,
+    _macos_app_name,
     _openclaw_needs_setup,
     home_tools,
     sort_home_tools,
@@ -316,6 +317,66 @@ class HubCliTests(WorkspaceCase):
             self.assertEqual(by_id[tool_id].kind, "launcher")
             self.assertEqual(by_id[tool_id].state, ToolState.READY)
             self.assertNotIn(tool_id, load(self.root).adapters)
+
+    def test_home_detects_codex_and_claude_desktops_as_launch_only_tools(
+        self,
+    ) -> None:
+        def detected(name: str) -> str | None:
+            return "/fake/" + name if name in {"codex", "open"} else None
+
+        with (
+            patch("dyro.home.sys.platform", "darwin"),
+            patch("dyro.home.Path.is_dir", return_value=True),
+            patch("dyro.home.shutil.which", side_effect=detected),
+        ):
+            tools = home_tools(load(self.root), workspace=self.root)
+
+        by_id = {tool.id: tool for tool in tools}
+        self.assertEqual(
+            by_id["codex-desktop"].argv,
+            ("codex", "app", str(self.root)),
+        )
+        claude_argv = by_id["claude-desktop"].argv
+        self.assertEqual(claude_argv[0], "open")
+        self.assertTrue(claude_argv[1].startswith("claude://code/new?folder="))
+        for tool_id in ("codex-desktop", "claude-desktop"):
+            self.assertEqual(by_id[tool_id].kind, "launcher")
+            self.assertEqual(by_id[tool_id].state, ToolState.READY)
+            self.assertNotIn(tool_id, load(self.root).adapters)
+
+    def test_macos_desktop_detection_accepts_codex_and_claude_app_variants(
+        self,
+    ) -> None:
+        with (
+            patch("dyro.home.sys.platform", "darwin"),
+            patch(
+                "dyro.home.Path.is_dir",
+                side_effect=(False, False, True, False, False, True),
+            ),
+        ):
+            self.assertEqual(_macos_app_name("Codex", "ChatGPT"), "ChatGPT")
+            self.assertEqual(
+                _macos_app_name("Claude", "Claude Code URL Handler"),
+                "Claude Code URL Handler",
+            )
+
+    def test_agent_discovery_lists_detected_codex_and_claude_desktops(self) -> None:
+        def detected(name: str) -> str | None:
+            return "/fake/" + name if name in {"codex", "open"} else None
+
+        output = StringIO()
+        with (
+            patch("dyro.home.sys.platform", "darwin"),
+            patch("dyro.home.Path.is_dir", return_value=True),
+            patch("dyro.home.shutil.which", side_effect=detected),
+            redirect_stdout(output),
+        ):
+            main(["--root", str(self.root), "agent", "discover"])
+
+        rendered = output.getvalue()
+        self.assertIn("codex-desktop", rendered)
+        self.assertIn("claude-desktop", rendered)
+        self.assertIn("尚未集成", rendered)
 
     def test_home_tool_picker_shows_common_choices_before_full_catalog(self) -> None:
         discovered = {"agy", "claude", "kimi", "qodercli", "zcode"}

--- a/tests/test_hub.py
+++ b/tests/test_hub.py
@@ -36,7 +36,7 @@ from dyro.tooling import (
     save_tool_preferences,
 )
 from dyro.tasks import task_template
-from dyro.workspace import create_line
+from dyro.workspace import create_line, get_line
 
 from .support import WorkspaceCase, shell
 
@@ -222,41 +222,508 @@ class HubCliTests(WorkspaceCase):
         self.assertIn("开启新的功能开发线", output.getvalue())
         self.assertIn("处理新的线上问题 / Hotfix", output.getvalue())
 
-    def test_home_new_feature_entrypoint_only_prints_next_step(self) -> None:
-        add_workspace(self.root, name="demo", make_default=True)
-        before_config = self.root.joinpath("dyro.toml").read_bytes()
-        before_registry = load_registry()
+    def test_home_uses_semantic_color_when_explicitly_enabled(self) -> None:
+        output = StringIO()
+        with (
+            patch.dict(os.environ, {"DYRO_COLOR": "always"}, clear=True),
+            patch("dyro.home.interactive_terminal", return_value=True),
+            patch("builtins.input", return_value="q"),
+            redirect_stdout(output),
+        ):
+            self.assertIsNone(_choose_action([], can_switch=False))
+
+        rendered = output.getvalue()
+        self.assertIn("\033[1;35m━━ 今天做什么 ━━\033[0m", rendered)
+        self.assertIn("\033[2;37m查看与管理\033[0m", rendered)
+
+    def test_home_action_retries_invalid_input_and_recommends_new_feature_when_empty(
+        self,
+    ) -> None:
+        answers = iter(["not-a-number", "99", ""])
+        prompts: list[str] = []
         output = StringIO()
         with (
             patch("dyro.home.interactive_terminal", return_value=True),
-            patch("builtins.input", return_value="3"),
+            patch(
+                "builtins.input",
+                side_effect=lambda prompt: prompts.append(prompt) or next(answers),
+            ),
+            redirect_stdout(output),
+        ):
+            action = _choose_action([], can_switch=False)
+
+        self.assertEqual(action, ("new-line", ""))
+        rendered = output.getvalue()
+        self.assertIn("请输入菜单编号", rendered)
+        self.assertIn("该编号不在当前菜单中", rendered)
+        self.assertTrue(any("回车=3" in prompt for prompt in prompts))
+
+    def test_home_exits_cleanly_when_terminal_input_is_interrupted(self) -> None:
+        output = StringIO()
+        with (
+            patch("dyro.home.interactive_terminal", return_value=True),
+            patch("builtins.input", side_effect=KeyboardInterrupt),
+            redirect_stdout(output),
+        ):
+            main(["--root", str(self.root)])
+
+        self.assertIn("已中断当前引导；没有执行后续步骤", output.getvalue())
+
+    def test_first_use_registers_an_existing_workspace_then_enters_home(self) -> None:
+        answers = iter(["3", str(self.root), "q"])
+        output = StringIO()
+        with (
+            patch("dyro.home.Path.cwd", return_value=self.root.parent),
+            patch("dyro.home.interactive_terminal", return_value=True),
+            patch("builtins.input", side_effect=lambda _: next(answers)),
+            redirect_stdout(output),
+        ):
+            main([])
+
+        rendered = output.getvalue()
+        self.assertIn("已登记工作区：test-workspace。接下来选择要做什么", rendered)
+        self.assertIn("━━ 今天做什么 ━━", rendered)
+        self.assertEqual(get_workspace("test-workspace").root, self.root.resolve())
+
+    def test_first_use_retries_an_unreadable_workspace_path(self) -> None:
+        answers = iter(["3", str(self.root.parent / "missing"), "q"])
+        output = StringIO()
+        with (
+            patch("dyro.home.Path.cwd", return_value=self.root.parent),
+            patch("dyro.home.interactive_terminal", return_value=True),
+            patch("builtins.input", side_effect=lambda _: next(answers)),
+            redirect_stdout(output),
+        ):
+            main([])
+
+        self.assertIn("无法登记该路径", output.getvalue())
+        self.assertFalse(self.hub_home.exists())
+
+    def test_home_new_feature_entrypoint_creates_confirmed_isolated_worktree(
+        self,
+    ) -> None:
+        add_workspace(self.root, name="demo", make_default=True)
+        answers = iter(["3", "FEATURE-20260804", "", "yes"])
+        output = StringIO()
+        with (
+            patch("dyro.home.interactive_terminal", return_value=True),
+            patch("builtins.input", side_effect=lambda _: next(answers)),
+            patch("dyro.home._choose_tool", return_value=None),
             redirect_stdout(output),
         ):
             main(["--root", str(self.root)])
 
         rendered = output.getvalue()
         self.assertIn("新功能开发线会创建隔离 Git worktree", rendered)
-        self.assertIn("dyro line create <ID> --base main --yes", rendered)
-        self.assertEqual(self.root.joinpath("dyro.toml").read_bytes(), before_config)
-        self.assertEqual(load_registry(), before_registry)
+        self.assertIn("━━ 开启功能开发线 ━━", rendered)
+        self.assertIn("步骤：功能 ID → 参与仓库 → 开发基线 → 创建确认", rendered)
+        self.assertIn("[2/3] 参与仓库", rendered)
+        self.assertIn("main（工作区默认基线）（推荐）", rendered)
+        self.assertIn("━━ 创建前确认 ━━", rendered)
+        self.assertIn("已创建功能开发线：FEATURE-20260804", rendered)
+        line = get_line(load(self.root), "FEATURE-20260804", "line")
+        self.assertEqual(line.base, "main")
+        self.assertTrue(self.root.joinpath("versions", "FEATURE-20260804").is_dir())
 
-    def test_home_hotfix_entrypoint_only_prints_next_step(self) -> None:
+    def test_home_new_feature_entrypoint_cancels_without_creating_worktree(
+        self,
+    ) -> None:
         add_workspace(self.root, name="demo", make_default=True)
-        before_config = self.root.joinpath("dyro.toml").read_bytes()
         before_registry = load_registry()
+        answers = iter(["3", "FEATURE-20260804", "q"])
         output = StringIO()
         with (
             patch("dyro.home.interactive_terminal", return_value=True),
-            patch("builtins.input", return_value="4"),
+            patch("builtins.input", side_effect=lambda _: next(answers)),
+            redirect_stdout(output),
+        ):
+            main(["--root", str(self.root)])
+
+        self.assertIn("已取消；没有修改任何 Git 工作区", output.getvalue())
+        self.assertFalse(
+            self.root.joinpath(".dyro", "lines", "FEATURE-20260804.toml").exists()
+        )
+        self.assertEqual(load_registry(), before_registry)
+
+    def test_home_new_feature_can_return_to_edit_a_previous_step(self) -> None:
+        add_workspace(self.root, name="demo", make_default=True)
+        answers = iter(
+            [
+                "3",
+                "FEATURE-BACK",
+                "b",
+                "FEATURE-BACK",
+                "",
+                "b",
+                "",
+                "yes",
+            ]
+        )
+        output = StringIO()
+        with (
+            patch("dyro.home.interactive_terminal", return_value=True),
+            patch("builtins.input", side_effect=lambda _: next(answers)),
+            patch("dyro.home._choose_tool", return_value=None),
+            redirect_stdout(output),
+        ):
+            main(["--root", str(self.root)])
+
+        rendered = output.getvalue()
+        self.assertIn("b) 返回上一步", rendered)
+        self.assertEqual(rendered.count("━━ 创建前确认 ━━"), 2)
+        self.assertTrue(self.root.joinpath("versions", "FEATURE-BACK").is_dir())
+
+    def test_home_new_feature_rechecks_manual_base_before_confirmation(self) -> None:
+        add_workspace(self.root, name="demo", make_default=True)
+        answers = iter(["3", "FEATURE-BAD-BASE", "2", "missing-release", "q"])
+        output = StringIO()
+        with (
+            patch("dyro.home.interactive_terminal", return_value=True),
+            patch("builtins.input", side_effect=lambda _: next(answers)),
+            redirect_stdout(output),
+        ):
+            main(["--root", str(self.root)])
+
+        rendered = output.getvalue()
+        self.assertIn("api 无法解析 missing-release", rendered)
+        self.assertIn("请为这个仓库单独选择已核实的基线", rendered)
+        self.assertNotIn("将创建隔离功能开发线", rendered)
+        self.assertFalse(
+            self.root.joinpath(".dyro", "lines", "FEATURE-BAD-BASE.toml").exists()
+        )
+
+    def test_home_new_feature_preflights_dirty_repository_before_confirmation(
+        self,
+    ) -> None:
+        add_workspace(self.root, name="demo", make_default=True)
+        self.anchor.joinpath("dirty.txt").write_text(
+            "not committed\n", encoding="utf-8"
+        )
+        answers = iter(["3", "FEATURE-DIRTY", "", "", "q"])
+        output = StringIO()
+        with (
+            patch("dyro.home.interactive_terminal", return_value=True),
+            patch("builtins.input", side_effect=lambda _: next(answers)),
+            redirect_stdout(output),
+        ):
+            main(["--root", str(self.root)])
+
+        rendered = output.getvalue()
+        self.assertIn("创建功能开发线前检查未通过", rendered)
+        self.assertIn("仓库不干净", rendered)
+        self.assertNotIn("确认以上范围与基线", rendered)
+        self.assertFalse(
+            self.root.joinpath(".dyro", "lines", "FEATURE-DIRTY.toml").exists()
+        )
+
+    def test_home_new_feature_normalizes_release_per_repository(self) -> None:
+        config_path = self.root / "dyro.toml"
+        config_path.write_text(
+            config_path.read_text(encoding="utf-8")
+            + """
+[repositories.web]
+path = "repositories/web"
+mount = "web"
+""",
+            encoding="utf-8",
+        )
+        web = self.root / "repositories/web"
+        web.mkdir(parents=True)
+        shell("git", "init", "-b", "main", cwd=web)
+        shell("git", "config", "user.name", "Test User", cwd=web)
+        shell("git", "config", "user.email", "test@example.com", cwd=web)
+        (web / "README.md").write_text("web\n", encoding="utf-8")
+        shell("git", "add", "README.md", cwd=web)
+        shell("git", "commit", "-m", "chore: initial", cwd=web)
+        shell(
+            "git", "update-ref", "refs/remotes/origin/release", "HEAD", cwd=self.anchor
+        )
+
+        add_workspace(self.root, name="demo", make_default=True)
+        answers = iter(["3", "FEATURE-RELEASE", "", "2", "release", "", "", "yes"])
+        output = StringIO()
+        with (
+            patch("dyro.home.interactive_terminal", return_value=True),
+            patch("builtins.input", side_effect=lambda _: next(answers)),
+            patch("dyro.home._choose_tool", return_value=None),
+            redirect_stdout(output),
+        ):
+            main(["--root", str(self.root)])
+
+        rendered = output.getvalue()
+        self.assertIn("当前仓库基线：", rendered)
+        self.assertIn("api  origin/release  [默认]", rendered)
+        self.assertIn("web  main  [覆盖]", rendered)
+        line = get_line(load(self.root), "FEATURE-RELEASE", "line")
+        self.assertEqual(line.base, "origin/release")
+        self.assertEqual(line.repository_bases, {"web": "main"})
+
+    def test_home_new_feature_limits_base_adjustment_to_selected_repositories(
+        self,
+    ) -> None:
+        config_path = self.root / "dyro.toml"
+        config_path.write_text(
+            config_path.read_text(encoding="utf-8")
+            + """
+[repositories.web]
+path = "repositories/web"
+mount = "web"
+""",
+            encoding="utf-8",
+        )
+        web = self.root / "repositories/web"
+        web.mkdir(parents=True)
+        shell("git", "init", "-b", "main", cwd=web)
+        shell("git", "config", "user.name", "Test User", cwd=web)
+        shell("git", "config", "user.email", "test@example.com", cwd=web)
+        web.joinpath("README.md").write_text("web\n", encoding="utf-8")
+        shell("git", "add", "README.md", cwd=web)
+        shell("git", "commit", "-m", "chore: initial", cwd=web)
+        shell("git", "checkout", "-b", "release", cwd=web)
+
+        add_workspace(self.root, name="demo", make_default=True)
+        answers = iter(["3", "FEATURE-WEB", "2", "web", "2", "release", "yes"])
+        output = StringIO()
+        with (
+            patch("dyro.home.interactive_terminal", return_value=True),
+            patch("builtins.input", side_effect=lambda _: next(answers)),
+            patch("dyro.home._choose_tool", return_value=None),
+            redirect_stdout(output),
+        ):
+            main(["--root", str(self.root)])
+
+        rendered = output.getvalue()
+        self.assertIn("可选仓库：", rendered)
+        self.assertNotIn("当前仓库基线：", rendered)
+        line = get_line(load(self.root), "FEATURE-WEB", "line")
+        self.assertEqual(line.repositories, ("web",))
+        self.assertEqual(line.base, "release")
+
+    def test_home_hotfix_limits_baseline_scope_to_selected_repositories(self) -> None:
+        config_path = self.root / "dyro.toml"
+        config_path.write_text(
+            config_path.read_text(encoding="utf-8")
+            + """
+[repositories.web]
+path = "repositories/web"
+mount = "web"
+""",
+            encoding="utf-8",
+        )
+        web = self.root / "repositories/web"
+        web.mkdir(parents=True)
+        shell("git", "init", "-b", "main", cwd=web)
+        shell("git", "config", "user.name", "Test User", cwd=web)
+        shell("git", "config", "user.email", "test@example.com", cwd=web)
+        web.joinpath("README.md").write_text("web\n", encoding="utf-8")
+        shell("git", "add", "README.md", cwd=web)
+        shell("git", "commit", "-m", "chore: initial", cwd=web)
+        shell("git", "checkout", "-b", "release", cwd=web)
+
+        add_workspace(self.root, name="demo", make_default=True)
+        answers = iter(["4", "INC-WEB", "2", "web", "", "yes"])
+        output = StringIO()
+        with (
+            patch("dyro.home.interactive_terminal", return_value=True),
+            patch("builtins.input", side_effect=lambda _: next(answers)),
+            patch("dyro.home._choose_tool", return_value=None),
+            redirect_stdout(output),
+        ):
+            main(["--root", str(self.root)])
+
+        rendered = output.getvalue()
+        self.assertIn("步骤：问题 ID → 参与仓库 → 生产基线 → 创建确认", rendered)
+        self.assertIn("发布分支 release", rendered)
+        line = get_line(load(self.root), "INC-WEB", "hotfix")
+        self.assertEqual(line.repositories, ("web",))
+        self.assertEqual(line.base, "release")
+
+    def test_home_hotfix_entrypoint_creates_confirmed_isolated_worktree(self) -> None:
+        add_workspace(self.root, name="demo", make_default=True)
+        shell("git", "tag", "v2026.08.04", cwd=self.anchor)
+        answers = iter(["4", "INC-20260804", "", "yes"])
+        output = StringIO()
+        with (
+            patch("dyro.home.interactive_terminal", return_value=True),
+            patch("builtins.input", side_effect=lambda _: next(answers)),
+            patch("dyro.home._choose_tool", return_value=None),
             redirect_stdout(output),
         ):
             main(["--root", str(self.root)])
 
         rendered = output.getvalue()
         self.assertIn("Hotfix 需要已核实的生产 release 分支、tag 或部署 SHA", rendered)
-        self.assertIn("dyro hotfix create <问题ID> --base", rendered)
-        self.assertEqual(self.root.joinpath("dyro.toml").read_bytes(), before_config)
+        self.assertIn("共同 Git 基线", rendered)
+        self.assertIn(
+            "发布 tag v2026.08.04（所有已配置仓库均可解析）（推荐）", rendered
+        )
+        self.assertIn("━━ 创建前确认 ━━", rendered)
+        self.assertIn("已创建 Hotfix：INC-20260804", rendered)
+        line = get_line(load(self.root), "INC-20260804", "hotfix")
+        self.assertEqual(line.base, "v2026.08.04")
+        self.assertTrue(self.root.joinpath("hotfixes", "INC-20260804").is_dir())
+
+    def test_home_hotfix_entrypoint_cancels_without_creating_worktree(self) -> None:
+        add_workspace(self.root, name="demo", make_default=True)
+        before_registry = load_registry()
+        answers = iter(["4", "INC-20260804", "1", "main", "no"])
+        output = StringIO()
+        with (
+            patch("dyro.home.interactive_terminal", return_value=True),
+            patch("builtins.input", side_effect=lambda _: next(answers)),
+            redirect_stdout(output),
+        ):
+            main(["--root", str(self.root)])
+
+        self.assertIn("已取消；没有修改任何 Git 工作区", output.getvalue())
+        self.assertFalse(
+            self.root.joinpath(".dyro", "hotfixes", "INC-20260804.toml").exists()
+        )
         self.assertEqual(load_registry(), before_registry)
+
+    def test_home_hotfix_can_return_to_edit_the_verified_baseline(self) -> None:
+        add_workspace(self.root, name="demo", make_default=True)
+        answers = iter(["4", "INC-BACK", "1", "main", "b", "1", "main", "yes"])
+        output = StringIO()
+        with (
+            patch("dyro.home.interactive_terminal", return_value=True),
+            patch("builtins.input", side_effect=lambda _: next(answers)),
+            patch("dyro.home._choose_tool", return_value=None),
+            redirect_stdout(output),
+        ):
+            main(["--root", str(self.root)])
+
+        rendered = output.getvalue()
+        self.assertIn("b) 返回上一步", rendered)
+        self.assertEqual(rendered.count("━━ 创建前确认 ━━"), 2)
+        self.assertTrue(self.root.joinpath("hotfixes", "INC-BACK").is_dir())
+
+    def test_home_hotfix_recommends_per_repository_release_refs(self) -> None:
+        config_path = self.root / "dyro.toml"
+        config_path.write_text(
+            config_path.read_text(encoding="utf-8")
+            + """
+[repositories.web]
+path = "repositories/web"
+mount = "web"
+""",
+            encoding="utf-8",
+        )
+        web = self.root / "repositories/web"
+        web.mkdir(parents=True)
+        shell("git", "init", "-b", "main", cwd=web)
+        shell("git", "config", "user.name", "Test User", cwd=web)
+        shell("git", "config", "user.email", "test@example.com", cwd=web)
+        (web / "README.md").write_text("web\n", encoding="utf-8")
+        shell("git", "add", "README.md", cwd=web)
+        shell("git", "commit", "-m", "chore: initial", cwd=web)
+        shell("git", "checkout", "-b", "release", cwd=web)
+        shell(
+            "git", "update-ref", "refs/remotes/origin/release", "HEAD", cwd=self.anchor
+        )
+
+        add_workspace(self.root, name="demo", make_default=True)
+        answers = iter(["4", "INC-RELEASE", "", "", "", "yes"])
+        output = StringIO()
+        with (
+            patch("dyro.home.interactive_terminal", return_value=True),
+            patch("builtins.input", side_effect=lambda _: next(answers)),
+            patch("dyro.home._choose_tool", return_value=None),
+            redirect_stdout(output),
+        ):
+            main(["--root", str(self.root)])
+
+        rendered = output.getvalue()
+        self.assertIn("发布分支 release（所有已配置仓库均可解析）（推荐）", rendered)
+        self.assertIn("api  origin/release  [默认]", rendered)
+        self.assertIn("web  release  [覆盖]", rendered)
+        line = get_line(load(self.root), "INC-RELEASE", "hotfix")
+        self.assertEqual(line.base, "origin/release")
+        self.assertEqual(line.repository_bases, {"web": "release"})
+
+    def test_home_hotfix_can_override_one_repository_base(self) -> None:
+        config_path = self.root / "dyro.toml"
+        config_path.write_text(
+            config_path.read_text(encoding="utf-8")
+            + """
+[repositories.web]
+path = "repositories/web"
+mount = "web"
+""",
+            encoding="utf-8",
+        )
+        web = self.root / "repositories/web"
+        web.mkdir(parents=True)
+        shell("git", "init", "-b", "main", cwd=web)
+        shell("git", "config", "user.name", "Test User", cwd=web)
+        shell("git", "config", "user.email", "test@example.com", cwd=web)
+        (web / "README.md").write_text("web\n", encoding="utf-8")
+        shell("git", "add", "README.md", cwd=web)
+        shell("git", "commit", "-m", "chore: initial", cwd=web)
+        shell("git", "checkout", "-b", "release", cwd=web)
+        shell(
+            "git", "update-ref", "refs/remotes/origin/release", "HEAD", cwd=self.anchor
+        )
+
+        add_workspace(self.root, name="demo", make_default=True)
+        answers = iter(["4", "INC-OVERRIDE", "", "", "2", "2", "2", "", "yes"])
+        output = StringIO()
+        with (
+            patch("dyro.home.interactive_terminal", return_value=True),
+            patch("builtins.input", side_effect=lambda _: next(answers)),
+            patch("dyro.home._choose_tool", return_value=None),
+            redirect_stdout(output),
+        ):
+            main(["--root", str(self.root)])
+
+        rendered = output.getvalue()
+        self.assertIn("按仓库单独调整基线", rendered)
+        self.assertIn("api  origin/release  [默认]", rendered)
+        self.assertIn("web  main  [覆盖]", rendered)
+        line = get_line(load(self.root), "INC-OVERRIDE", "hotfix")
+        self.assertEqual(line.base, "origin/release")
+        self.assertEqual(line.repository_bases, {"web": "main"})
+
+    def test_home_hotfix_rechecks_manual_base_before_confirmation(self) -> None:
+        add_workspace(self.root, name="demo", make_default=True)
+        answers = iter(["4", "INC-BAD-BASE", "1", "missing-release", "", "q"])
+        output = StringIO()
+        with (
+            patch("dyro.home.interactive_terminal", return_value=True),
+            patch("builtins.input", side_effect=lambda _: next(answers)),
+            redirect_stdout(output),
+        ):
+            main(["--root", str(self.root)])
+
+        rendered = output.getvalue()
+        self.assertIn("api 无法解析 missing-release", rendered)
+        self.assertIn("请为这个仓库单独选择已核实的基线", rendered)
+        self.assertNotIn("将创建隔离 Hotfix worktree", rendered)
+        self.assertFalse(
+            self.root.joinpath(".dyro", "hotfixes", "INC-BAD-BASE.toml").exists()
+        )
+
+    def test_home_hotfix_preflights_dirty_repository_before_confirmation(self) -> None:
+        add_workspace(self.root, name="demo", make_default=True)
+        self.anchor.joinpath("dirty.txt").write_text(
+            "not committed\n", encoding="utf-8"
+        )
+        answers = iter(["4", "INC-DIRTY", "1", "main", "", "q"])
+        output = StringIO()
+        with (
+            patch("dyro.home.interactive_terminal", return_value=True),
+            patch("builtins.input", side_effect=lambda _: next(answers)),
+            redirect_stdout(output),
+        ):
+            main(["--root", str(self.root)])
+
+        rendered = output.getvalue()
+        self.assertIn("创建Hotfix前检查未通过", rendered)
+        self.assertIn("仓库不干净", rendered)
+        self.assertNotIn("确认该基线已在生产核实", rendered)
+        self.assertFalse(
+            self.root.joinpath(".dyro", "hotfixes", "INC-DIRTY.toml").exists()
+        )
 
     def test_home_can_open_a_detected_tool_without_granting_adapter_capabilities(
         self,
@@ -385,7 +852,9 @@ class HubCliTests(WorkspaceCase):
         with (
             patch(
                 "dyro.home.shutil.which",
-                side_effect=lambda name: f"/fake/{name}" if name in discovered else None,
+                side_effect=lambda name: (
+                    f"/fake/{name}" if name in discovered else None
+                ),
             ),
             patch("builtins.input", side_effect=lambda _: next(answers)),
             redirect_stdout(output),
@@ -419,6 +888,41 @@ class HubCliTests(WorkspaceCase):
         self.assertEqual(tool, installable)
         self.assertIn("Qoder CLI", output.getvalue())
         self.assertIn("未安装，可引导安装", output.getvalue())
+
+    def test_home_tool_picker_retries_invalid_choice(self) -> None:
+        ready = HomeTool("codex", "Codex", "launcher", ("codex",), (), ToolState.READY)
+        answers = iter(["missing-tool", "1"])
+        output = StringIO()
+        with (
+            patch("dyro.home.home_tools", return_value=[ready]),
+            patch("builtins.input", side_effect=lambda _: next(answers)),
+            redirect_stdout(output),
+        ):
+            tool = _choose_tool(
+                load(self.root), None, workspace=self.root, dry_run=True
+            )
+
+        self.assertEqual(tool, ready)
+        self.assertIn("未找到该编码工具", output.getvalue())
+
+    def test_home_tool_picker_keeps_user_in_the_menu_for_unavailable_tool(self) -> None:
+        unavailable = HomeTool(
+            "grok", "Grok", "launcher", ("grok",), (), ToolState.UNAVAILABLE
+        )
+        ready = HomeTool("codex", "Codex", "launcher", ("codex",), (), ToolState.READY)
+        answers = iter(["grok", "1"])
+        output = StringIO()
+        with (
+            patch("dyro.home.home_tools", return_value=[unavailable, ready]),
+            patch("builtins.input", side_effect=lambda _: next(answers)),
+            redirect_stdout(output),
+        ):
+            tool = _choose_tool(
+                load(self.root), None, workspace=self.root, dry_run=True
+            )
+
+        self.assertEqual(tool, ready)
+        self.assertIn("Grok 当前不可用", output.getvalue())
 
     def test_home_detects_cursor_desktop_separately_from_cursor_cli(self) -> None:
         def detected(name: str) -> str | None:

--- a/tests/test_terminal.py
+++ b/tests/test_terminal.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+from io import StringIO
+import os
+import unittest
+from unittest.mock import patch
+
+from dyro.terminal import color_enabled, style, title, value
+
+
+class _TtyBuffer(StringIO):
+    def isatty(self) -> bool:
+        return True
+
+
+class TerminalPresentationTests(unittest.TestCase):
+    def test_plain_output_is_preserved_for_non_interactive_streams(self) -> None:
+        with patch.dict(os.environ, {"DYRO_COLOR": "auto"}, clear=True):
+            self.assertFalse(color_enabled(StringIO()))
+            self.assertEqual(title("章节", stream=StringIO()), "章节")
+
+    def test_tty_uses_semantic_ansi_roles(self) -> None:
+        with patch.dict(
+            os.environ, {"DYRO_COLOR": "auto", "TERM": "xterm"}, clear=True
+        ):
+            self.assertTrue(color_enabled(_TtyBuffer()))
+            self.assertEqual(
+                value("feat/demo", stream=_TtyBuffer()), "\033[1;36mfeat/demo\033[0m"
+            )
+
+    def test_no_color_overrides_a_forced_color_preference(self) -> None:
+        with patch.dict(
+            os.environ, {"DYRO_COLOR": "always", "NO_COLOR": "1"}, clear=True
+        ):
+            self.assertFalse(color_enabled(_TtyBuffer()))
+            self.assertEqual(style("文本", "title", stream=_TtyBuffer()), "文本")

--- a/tests/test_tooling.py
+++ b/tests/test_tooling.py
@@ -15,6 +15,7 @@ from dyro.tooling import (
     install_tool,
     load_tool_preferences,
     save_tool_preferences,
+    tool_definition,
 )
 
 
@@ -54,6 +55,19 @@ class ToolPreferenceTests(unittest.TestCase):
 
 
 class GuidedInstallerTests(unittest.TestCase):
+    def test_catalog_includes_antigravity_qoder_and_zcode(self) -> None:
+        antigravity = tool_definition("antigravity")
+        qoder = tool_definition("qoder")
+        zcode = tool_definition("zcode")
+
+        self.assertEqual(antigravity.command if antigravity else "", "agy")
+        self.assertEqual(qoder.command if qoder else "", "qodercli")
+        self.assertEqual(zcode.interface if zcode else "", "desktop")
+        self.assertEqual(
+            qoder.install.argv if qoder and qoder.install else (),
+            ("npm", "install", "-g", "@qoder-ai/qodercli"),
+        )
+
     def test_command_recipe_is_explicit_argv_and_requires_confirmation(self) -> None:
         calls: list[tuple[str, ...]] = []
 

--- a/tests/test_tooling.py
+++ b/tests/test_tooling.py
@@ -55,14 +55,18 @@ class ToolPreferenceTests(unittest.TestCase):
 
 
 class GuidedInstallerTests(unittest.TestCase):
-    def test_catalog_includes_antigravity_qoder_and_zcode(self) -> None:
+    def test_catalog_includes_desktop_and_new_terminal_tools(self) -> None:
         antigravity = tool_definition("antigravity")
+        codex_desktop = tool_definition("codex-desktop")
+        claude_desktop = tool_definition("claude-desktop")
         qoder = tool_definition("qoder")
         zcode = tool_definition("zcode")
 
         self.assertEqual(antigravity.command if antigravity else "", "agy")
         self.assertEqual(qoder.command if qoder else "", "qodercli")
         self.assertEqual(zcode.interface if zcode else "", "desktop")
+        self.assertEqual(codex_desktop.interface if codex_desktop else "", "desktop")
+        self.assertEqual(claude_desktop.interface if claude_desktop else "", "desktop")
         self.assertEqual(
             qoder.install.argv if qoder and qoder.install else (),
             ("npm", "install", "-g", "@qoder-ai/qodercli"),

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -3,7 +3,13 @@ from pathlib import Path
 from dyro.config import load
 from dyro.errors import DyroError
 from dyro.process import Result
-from dyro.workspace import create_line, doctor, line_repository_path, list_lines
+from dyro.workspace import (
+    create_line,
+    doctor,
+    line_repository_path,
+    list_lines,
+    preflight_line,
+)
 
 from .support import WorkspaceCase, shell
 
@@ -44,6 +50,21 @@ class WorkspaceTests(WorkspaceCase):
                 repository_bases={"web": "missing-ref"},
             )
         self.assertFalse((self.root / "versions/partial-preflight").exists())
+        self.assertEqual(list_lines(config), [])
+
+    def test_public_preflight_detects_a_dirty_anchor_without_mutating(self) -> None:
+        config = load(self.root)
+        self.anchor.joinpath("dirty.txt").write_text("pending\n", encoding="utf-8")
+
+        with self.assertRaisesRegex(DyroError, "仓库不干净"):
+            preflight_line(
+                config,
+                line_id="dirty-anchor",
+                branch="feat/dirty-anchor",
+                base="main",
+            )
+
+        self.assertFalse((self.root / "versions/dirty-anchor").exists())
         self.assertEqual(list_lines(config), [])
 
     def test_create_line_rolls_back_when_a_later_repository_fails(self) -> None:


### PR DESCRIPTION
## 变更概要
- `dyro setup` 默认登记全局 Console 工作区，并在写入前展示计划与冲突保护。
- 首页补齐功能开发线与 Hotfix 向导：支持受影响仓库选择、逐仓基线、预检、返回与取消。
- 扩展编码工具发现与启动选择，覆盖 CLI 与桌面端工具，并加入语义化终端配色与无 traceback 的中断提示。
- 重构 Console 为只读的 Signal Room 控制面：汇总工作区、健康状态与下一步命令，操作仅复制或展示 CLI 指令。

## 安全与兼容性
- 终端色彩仅在交互终端启用；`NO_COLOR` 可关闭，`DYRO_COLOR=always` 可强制开启。
- Console 不执行开发、合并或推送操作；Git worktree 创建前重复执行预检。

## 验证
- `uv run python -m unittest tests.test_terminal tests.test_cli tests.test_console_assets tests.test_console_overview tests.test_hub tests.test_workspace`（114 项）
- `uv run ruff check src/dyro/cli.py src/dyro/home.py tests/test_cli.py src/dyro/terminal.py`
- `git diff --check`