### PR TITLE
chore(发布): 准备 0.6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## 0.6.1 - 2026-08-04
+
+- Make the global Dyro home, first-run setup, line creation, and Hotfix
+  creation genuinely guided: show safe previews, offer meaningful defaults,
+  support retry/back/cancel, and preflight every selected repository before
+  any Git worktree mutation.
+- Register setup Profiles with the global Console by default while preserving
+  an existing default workspace, and make workspace, repository, Agent, and
+  coding-tool management more readable and actionable.
+- Expand the coding-tool catalog across CLI and desktop launchers, including
+  Codex, Claude, Antigravity, ZCode, and Qoder-family tooling; unavailable
+  tools remain informative rather than blocking a workspace launch.
+- Refresh the read-only Console into a compact Signal Room command center and
+  align terminal output with semantic colors, clear status grouping, and
+  graceful interruption recovery.
+
 ## 0.6.0 - 2026-08-04
 
 - Add the native, local-first Continuation engine: versioned Objectives have

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "dyro"
-version = "0.6.0"
+version = "0.6.1"
 description = "DyroEngineeringFlow: local-first automation and delivery control for multi-repository teams"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/uv.lock
+++ b/uv.lock
@@ -282,7 +282,7 @@ wheels = [
 
 [[package]]
 name = "dyro"
-version = "0.6.0"
+version = "0.6.1"
 source = { editable = "." }
 dependencies = [
     { name = "cryptography" },


### PR DESCRIPTION
## 发布内容
- 将 Dyro 版本从 `0.6.0` 更新至 `0.6.1`。
- 记录首页引导、Hotfix/开发线预检、编码工具、终端语义色彩与 Console Signal Room 的发布说明。
- 同步 `uv.lock` 中的项目版本。

## 已完成发布前校验
- `uv lock --check`
- 锁定依赖下全量测试与 Ruff
- wheel/sdist 构建、Twine metadata 校验、干净环境安装与 Console 资源验证
- PyPI `0.6.1` 占用检查：可用

合并后才创建 `v0.6.1` 标签与 GitHub Release。