### PR TITLE
chore(发布): 准备 0.6.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 0.6.2 - 2026-08-05
+
+- Extend interactive `dyro setup` and Profile onboarding with a single,
+  preview-first personal-preferences step: update checks, optional patch-only
+  auto-updates, a locally detected coding-tool default, and Console project
+  selection can be saved together, while cancel and dry-run remain read-only.
+- Make coding-tool choice easier to scan by showing a short detected list
+  first, exposing the full catalog on demand, and accepting a supported tool
+  identifier directly even when it is not in the initial shortlist.
+
 ## 0.6.1 - 2026-08-04
 
 - Make the global Dyro home, first-run setup, line creation, and Hotfix

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "dyro"
-version = "0.6.1"
+version = "0.6.2"
 description = "DyroEngineeringFlow: local-first automation and delivery control for multi-repository teams"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/uv.lock
+++ b/uv.lock
@@ -282,7 +282,7 @@ wheels = [
 
 [[package]]
 name = "dyro"
-version = "0.6.1"
+version = "0.6.2"
 source = { editable = "." }
 dependencies = [
     { name = "cryptography" },


### PR DESCRIPTION
## 发布内容

- 将包版本升级至 0.6.2，并同步 uv.lock。
- 记录首次设置个人偏好与编码工具选择体验优化。

## 本地验证

- `uv lock --check`
- `uv run ruff check src tests`
- `uv run python -m unittest discover -s tests -t . -q -b`（503 项）
- `uv run python -m build`
- `uv run python -m twine check --strict ...`
- checkout 外全新 Python 3.11 环境分别安装 wheel 与 sdist，并验证资源与 CLI 帮助。

PyPI `dyro 0.6.2` 预检返回 404，尚未占用。