### PR TITLE
feat: Skill lifecycle hooks and bare dyro update check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Changelog
 
+## Unreleased
+
+- Guide control-plane Skill install during interactive `dyro setup` (preview in
+  the plan; apply only after confirmation; soft-fail if no host is ready).
+- After a successful package update (`dyro update now` or patch auto-update),
+  best-effort sync an already-managed Skill through the fresh `dyro` entry
+  point (`dyro integration sync skill --yes`).
+- On interactive `dyro` / `home` / `start` launches, automatically repair an
+  outdated managed Skill; never first-install on startup.
+- Make bare `dyro update` equivalent to `dyro update check` (common CLI
+  ergonomics; `check` remains as an explicit alias).
+- After a same-turn package auto-update Skill refresh, skip in-process startup
+  Skill sync so stale in-memory assets cannot overwrite the fresh write.
+- Pin post-update Skill sync to this install (`bin/dyro` beside the interpreter,
+  else `python -m dyro`) instead of bare `PATH` lookup.
+- Make setup Skill UX honest when no agent host is present (defer by default;
+  completion reports install outcome).
+
 ## 0.6.3 - 2026-08-12
 
 - Keep the shipping surface as CLI + Skill only. PyPI releases through 0.6.2

--- a/README.de.md
+++ b/README.de.md
@@ -269,13 +269,16 @@ Zum Aktualisieren: `pipx upgrade dyro`. Nutzt das Team `pip`:
 python3 -m pip install --user --upgrade dyro
 ```
 
-Optional: Nach dem Upgrade kannst du das Dyro Control-Plane-Skill an erkannte
-Agent-Homes anbinden mit `dyro integration install skill --dry-run` und danach
+Interaktives `dyro setup` kann das Control-Plane-Skill installieren. Nach
+Paket-Updates synchronisieren sich bereits verwaltete Skills automatisch;
+interaktive Starts reparieren auch ein veraltetes managed Skill. Die
+Erstinstallation bleibt opt-in über Setup oder
 `dyro integration install skill --yes` (Alias: `codex`).
 
 Interaktive Starts mit `dyro`, `dyro home` oder `dyro start` prüfen höchstens einmal pro lokalem Tag den offiziellen PyPI-Endpunkt. Fehler blockieren den Arbeitsbereich nicht. Standardmäßig bleibt jede Aktualisierung bestätigt:
 
 ```bash
+dyro update              # entspricht dyro update check
 dyro update check
 dyro update now
 dyro update auto on      # automatische Patch-Updates aktivieren

--- a/README.de.md
+++ b/README.de.md
@@ -269,6 +269,10 @@ Zum Aktualisieren: `pipx upgrade dyro`. Nutzt das Team `pip`:
 python3 -m pip install --user --upgrade dyro
 ```
 
+Optional: Nach dem Upgrade kannst du das Dyro Control-Plane-Skill an erkannte
+Agent-Homes anbinden mit `dyro integration install skill --dry-run` und danach
+`dyro integration install skill --yes` (Alias: `codex`).
+
 Interaktive Starts mit `dyro`, `dyro home` oder `dyro start` prüfen höchstens einmal pro lokalem Tag den offiziellen PyPI-Endpunkt. Fehler blockieren den Arbeitsbereich nicht. Standardmäßig bleibt jede Aktualisierung bestätigt:
 
 ```bash

--- a/README.es.md
+++ b/README.es.md
@@ -269,6 +269,10 @@ Para actualizar, ejecuta `pipx upgrade dyro`. Si el equipo gestiona paquetes Pyt
 python3 -m pip install --user --upgrade dyro
 ```
 
+Opcional: tras actualizar, vincula el Skill del plano de control de Dyro a los
+directorios de agente detectados con `dyro integration install skill --dry-run`
+y luego `dyro integration install skill --yes` (alias: `codex`).
+
 Los inicios interactivos con `dyro`, `dyro home` o `dyro start` consultan el endpoint oficial de PyPI como máximo una vez al día local. Los errores nunca bloquean el espacio de trabajo y, por defecto, cada actualización requiere confirmación:
 
 ```bash

--- a/README.es.md
+++ b/README.es.md
@@ -269,13 +269,16 @@ Para actualizar, ejecuta `pipx upgrade dyro`. Si el equipo gestiona paquetes Pyt
 python3 -m pip install --user --upgrade dyro
 ```
 
-Opcional: tras actualizar, vincula el Skill del plano de control de Dyro a los
-directorios de agente detectados con `dyro integration install skill --dry-run`
-y luego `dyro integration install skill --yes` (alias: `codex`).
+El `dyro setup` interactivo puede instalar el Skill del plano de control. Tras
+actualizar el paquete, los Skills ya gestionados se sincronizan solos; los
+arranques interactivos también reparan un Skill managed desactualizado. La
+primera instalación sigue siendo opt-in vía setup o
+`dyro integration install skill --yes` (alias: `codex`).
 
 Los inicios interactivos con `dyro`, `dyro home` o `dyro start` consultan el endpoint oficial de PyPI como máximo una vez al día local. Los errores nunca bloquean el espacio de trabajo y, por defecto, cada actualización requiere confirmación:
 
 ```bash
+dyro update              # equivalente a dyro update check
 dyro update check
 dyro update now
 dyro update auto on      # activa actualizaciones automáticas de parches

--- a/README.fr.md
+++ b/README.fr.md
@@ -269,6 +269,10 @@ Pour mettre à jour : `pipx upgrade dyro`. Si l'équipe gère Python avec `pip` 
 python3 -m pip install --user --upgrade dyro
 ```
 
+Optionnel : après la mise à jour, attachez le Skill du plan de contrôle Dyro
+aux répertoires d’agents détectés avec `dyro integration install skill --dry-run`,
+puis `dyro integration install skill --yes` (alias : `codex`).
+
 Les lancements interactifs `dyro`, `dyro home` ou `dyro start` interrogent le point officiel PyPI au plus une fois par jour local. Un échec ne bloque jamais l’espace de travail et chaque mise à jour reste soumise à confirmation par défaut :
 
 ```bash

--- a/README.fr.md
+++ b/README.fr.md
@@ -269,13 +269,16 @@ Pour mettre à jour : `pipx upgrade dyro`. Si l'équipe gère Python avec `pip` 
 python3 -m pip install --user --upgrade dyro
 ```
 
-Optionnel : après la mise à jour, attachez le Skill du plan de contrôle Dyro
-aux répertoires d’agents détectés avec `dyro integration install skill --dry-run`,
-puis `dyro integration install skill --yes` (alias : `codex`).
+Le `dyro setup` interactif peut installer le Skill du plan de contrôle. Après
+une mise à jour du paquet, les Skills déjà gérés se synchronisent
+automatiquement ; les lancements interactifs réparent aussi un Skill managed
+obsolète. La première installation reste opt-in via setup ou
+`dyro integration install skill --yes` (alias : `codex`).
 
 Les lancements interactifs `dyro`, `dyro home` ou `dyro start` interrogent le point officiel PyPI au plus une fois par jour local. Un échec ne bloque jamais l’espace de travail et chaque mise à jour reste soumise à confirmation par défaut :
 
 ```bash
+dyro update              # équivalent à dyro update check
 dyro update check
 dyro update now
 dyro update auto on      # active les mises à jour correctives automatiques

--- a/README.ko.md
+++ b/README.ko.md
@@ -269,13 +269,14 @@ dyro --version
 python3 -m pip install --user --upgrade dyro
 ```
 
-선택 사항: 업그레이드 후 감지된 에이전트 홈에 Dyro 제어면 Skill을 연결하려면
-`dyro integration install skill --dry-run`으로 미리보기한 뒤
-`dyro integration install skill --yes`를 실행하세요(별칭: `codex`).
+대화형 `dyro setup`에서 제어면 Skill을 설치할 수 있습니다. 패키지 업데이트 후에는
+이미 관리 중인 Skill이 자동 동기화되며, 대화형 실행 시 outdated Skill도 자동 복구됩니다.
+최초 설치는 setup에서 선택하거나 `dyro integration install skill --yes`(별칭: `codex`)로 합니다.
 
 대화형 `dyro`, `dyro home`, `dyro start` 실행은 현지 날짜 기준 하루에 한 번만 공식 PyPI 엔드포인트를 확인합니다. 실패해도 작업 공간 진입을 막지 않으며 기본적으로 업데이트 전 확인을 요청합니다.
 
 ```bash
+dyro update              # dyro update check 와 동일
 dyro update check
 dyro update now
 dyro update auto on      # 패치 버전 자동 업데이트 사용

--- a/README.ko.md
+++ b/README.ko.md
@@ -269,6 +269,10 @@ dyro --version
 python3 -m pip install --user --upgrade dyro
 ```
 
+선택 사항: 업그레이드 후 감지된 에이전트 홈에 Dyro 제어면 Skill을 연결하려면
+`dyro integration install skill --dry-run`으로 미리보기한 뒤
+`dyro integration install skill --yes`를 실행하세요(별칭: `codex`).
+
 대화형 `dyro`, `dyro home`, `dyro start` 실행은 현지 날짜 기준 하루에 한 번만 공식 PyPI 엔드포인트를 확인합니다. 실패해도 작업 공간 진입을 막지 않으며 기본적으로 업데이트 전 확인을 요청합니다.
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -283,15 +283,18 @@ To upgrade later, run `pipx upgrade dyro`. If your team manages Python packages 
 python3 -m pip install --user --upgrade dyro
 ```
 
-Optional: after upgrading, attach the Dyro control-plane Skill to detected agent
-homes with `dyro integration install skill --dry-run`, then
-`dyro integration install skill --yes` (alias: `codex`).
+Interactive `dyro setup` can install the control-plane Skill during personal
+preferences. After package updates, already-managed Skills sync automatically;
+interactive launches also repair an outdated managed Skill. First-time install
+remains opt-in via setup or `dyro integration install skill --yes` (alias:
+`codex`).
 
 Interactive `dyro`, `dyro home`, and `dyro start` launches check the official
 PyPI endpoint at most once per local day. A failed or slow check never blocks
 workspace entry. Updates remain confirmation-first by default:
 
 ```bash
+dyro update              # same as: dyro update check
 dyro update check
 dyro update now
 dyro update auto on      # opt in to patch-only automatic updates

--- a/README.pt-BR.md
+++ b/README.pt-BR.md
@@ -269,6 +269,10 @@ Para atualizar, execute `pipx upgrade dyro`. Se a equipe gerencia pacotes Python
 python3 -m pip install --user --upgrade dyro
 ```
 
+Opcional: após atualizar, anexe o Skill do plano de controle Dyro às pastas de
+agente detectadas com `dyro integration install skill --dry-run` e em seguida
+`dyro integration install skill --yes` (alias: `codex`).
+
 Execuções interativas de `dyro`, `dyro home` ou `dyro start` consultam o endpoint oficial do PyPI no máximo uma vez por dia local. Falhas nunca bloqueiam o workspace e, por padrão, toda atualização exige confirmação:
 
 ```bash

--- a/README.pt-BR.md
+++ b/README.pt-BR.md
@@ -269,13 +269,16 @@ Para atualizar, execute `pipx upgrade dyro`. Se a equipe gerencia pacotes Python
 python3 -m pip install --user --upgrade dyro
 ```
 
-Opcional: após atualizar, anexe o Skill do plano de controle Dyro às pastas de
-agente detectadas com `dyro integration install skill --dry-run` e em seguida
+O `dyro setup` interativo pode instalar o Skill do plano de controle. Após
+atualizações do pacote, Skills já gerenciados sincronizam automaticamente;
+lançamentos interativos também repararam um Skill managed desatualizado. A
+primeira instalação continua opt-in via setup ou
 `dyro integration install skill --yes` (alias: `codex`).
 
 Execuções interativas de `dyro`, `dyro home` ou `dyro start` consultam o endpoint oficial do PyPI no máximo uma vez por dia local. Falhas nunca bloqueiam o workspace e, por padrão, toda atualização exige confirmação:
 
 ```bash
+dyro update              # equivalente a dyro update check
 dyro update check
 dyro update now
 dyro update auto on      # ativa atualizações automáticas de patch

--- a/README.ru.md
+++ b/README.ru.md
@@ -269,6 +269,10 @@ dyro --version
 python3 -m pip install --user --upgrade dyro
 ```
 
+По желанию: после обновления подключите Skill плоскости управления Dyro к
+обнаруженным каталогам агентов через `dyro integration install skill --dry-run`,
+затем `dyro integration install skill --yes` (алиас: `codex`).
+
 Интерактивные запуски `dyro`, `dyro home` и `dyro start` проверяют официальный PyPI не чаще одного раза за локальный день. Ошибка не блокирует вход в рабочую область, а по умолчанию обновление требует подтверждения:
 
 ```bash

--- a/README.ru.md
+++ b/README.ru.md
@@ -269,13 +269,16 @@ dyro --version
 python3 -m pip install --user --upgrade dyro
 ```
 
-По желанию: после обновления подключите Skill плоскости управления Dyro к
-обнаруженным каталогам агентов через `dyro integration install skill --dry-run`,
-затем `dyro integration install skill --yes` (алиас: `codex`).
+Интерактивный `dyro setup` может установить Skill плоскости управления. После
+обновления пакета уже управляемые Skill синхронизируются автоматически;
+интерактивный запуск также чинит устаревший managed Skill. Первая установка
+остаётся opt-in через setup или `dyro integration install skill --yes`
+(алиас: `codex`).
 
 Интерактивные запуски `dyro`, `dyro home` и `dyro start` проверяют официальный PyPI не чаще одного раза за локальный день. Ошибка не блокирует вход в рабочую область, а по умолчанию обновление требует подтверждения:
 
 ```bash
+dyro update              # то же, что dyro update check
 dyro update check
 dyro update now
 dyro update auto on      # включить автообновление patch-версий

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -281,12 +281,14 @@ dyro --version
 python3 -m pip install --user --upgrade dyro
 ```
 
-可选：升级后用 `dyro integration install skill --dry-run` 预览，再执行
-`dyro integration install skill --yes`（别名 `codex`），把控制面 Skill 挂到已检测到的 Agent 宿主目录。
+交互式 `dyro setup` 可在个人偏好步骤安装控制面 Skill。包升级后会自动同步**已托管**
+的 Skill；交互启动时也会修复过期的托管安装。首次安装仍需 setup 勾选，或手动运行
+`dyro integration install skill --yes`（别名 `codex`）。
 
 交互运行 `dyro`、`dyro home` 或 `dyro start` 时，Dyro 每个本地自然日最多访问一次官方 PyPI；断网、超时或状态目录不可写都不会阻塞进入工作区。默认仍由用户确认更新：
 
 ```bash
+dyro update              # 等价于 dyro update check
 dyro update check
 dyro update now
 dyro update auto on      # 主动开启补丁版本自动更新

--- a/docs/superpowers/reviews/2026-08-12-dyro-skill-lifecycle-adversarial-review-board.md
+++ b/docs/superpowers/reviews/2026-08-12-dyro-skill-lifecycle-adversarial-review-board.md
@@ -1,0 +1,498 @@
+# Dyro Skill Lifecycle Adversarial Review Board
+
+Date: 2026-08-12
+
+Scope:
+- Repository: `/Users/dandre/DyroProjects/DyroEngineeringFlow/versions/dev/dyroengineeringflow`
+- Branch: `feat/dev` (uncommitted working tree on top of `7bb8c64`)
+- Question: Are the Skill lifecycle hooks (setup guide + post-update sync + startup repair) safe and ready to land?
+
+Reviewed Materials:
+- Working tree diff (exclude user WIP plans): `/tmp/dyro-skill-lifecycle.diff`
+- `src/dyro/cli.py` (`_setup_skill_preference`, `_apply_setup_personal_preferences`, `cmd_integration_sync`, `_refresh_skill_via_new_cli`, `_maybe_sync_managed_skill`, daily-update wiring)
+- `src/dyro/integrations/manager.py` (`sync_managed_skill`)
+- `src/dyro/integrations/__init__.py`
+- Tests: `tests/test_cli.py`, `tests/test_integrations.py`, `tests/test_updates.py`
+- Docs: `CHANGELOG.md` Unreleased, `docs/updates.md`, localized READMEs
+
+SSOT:
+- Product: setup guided first install; package update syncs **managed** Skill only; interactive startup repairs **OUTDATED** managed Skill; never first-install on upgrade/startup
+- Ownership/fail-closed Skill install from 0.6.3 (legacy target allowlist, packaged-asset check) remains binding
+- Preview-first / `--yes` for explicit install; automatic paths may use `--yes` only for managed upgrade/repair
+
+## Rules
+
+1. Each reviewer writes only in their own signed section.
+2. Conflicts are resolved by source code or live contract.
+3. Unprovable claims are marked `须人工核`.
+4. Findings use P0/P1/P2 severity.
+5. Code-review mode: bugs, security, regressions, missing tests, misleading UX first.
+6. Do not reopen “silent first-install for everyone” unless source proves current opt-in is unsafe.
+
+## Fixed Decisions
+
+- First-time Skill install remains opt-in (setup or explicit CLI).
+- Post-update / startup paths must not first-install absent Skills.
+- Post-update sync should use fresh `dyro` entry point when possible (new package assets).
+- Conflict / recovery / unowned states remain fail-closed (soft warn, no mutate).
+
+## Open Micro-Decisions
+
+1. Should startup Skill sync share the daily-update interactive gate only, or also run for other interactive commands?
+2. When post-update CLI sync fails, is “retry next launch” enough, or must update exit non-zero?
+3. Should non-interactive `dyro setup --non-interactive` gain an explicit `--install-skill` flag in this change?
+
+---
+
+# Claude Review Section
+
+Reviewer: Claude (Composer)
+Time: 2026-08-12
+Verdict: Conditional Go
+
+## Summary
+
+End-to-end contract is **correct in source**: `sync_managed_skill` gates `ABSENT` on `allow_first_install`; setup uses preview (`dry_run=True`) then apply (`yes=True`) only after plan confirmation; post-update and startup paths pass `allow_first_install=False`; startup repair triggers **only** on `IntegrationState.OUTDATED`. No path silently first-installs an `ABSENT` Skill on upgrade or launch. Remaining issues are UX accuracy and test gaps, not lifecycle safety.
+
+## Evidence
+
+### P0 — None
+
+No blocker found. `ABSENT` + `allow_first_install=False` returns `None` before `install_integration` (`manager.py:1035-1036`). Startup gate is `status.state is not IntegrationState.OUTDATED` (`cli.py:3855-3856`). Post-update subprocess invokes `integration sync skill --yes` (`cli.py:3827-3828`), which sets `allow_first_install=False` (`cli.py:1560-1563`).
+
+### P1
+
+| ID | Finding | Evidence |
+|----|---------|----------|
+| P1-1 | **Setup completion misreports Skill outcome on soft-fail.** `_apply_setup_personal_preferences` prints a warning and returns early on `DyroError`, but callers always invoke `_print_setup_completion`, which prints `Skill：已请求安装 / 同步` whenever `preferences.install_skill` is true—never whether apply succeeded. | `cli.py:659-669`, `cli.py:782-783`, `cli.py:867-868`, `cli.py:912-913` |
+| P1-2 | **Post-update Skill sync is untested at the subprocess boundary.** `_refresh_skill_via_new_cli` is wired from `cmd_update_now` and `_maybe_run_daily_update` (`cli.py:1618-1619`, `3810`) but has no direct test (only mock-assert in auto-patch test). Subprocess failure modes (non-zero exit, timeout, missing `dyro` on PATH) are unverified. | `cli.py:3815-3846`, `tests/test_updates.py:520-521` (mock only) |
+
+### P2
+
+| ID | Finding | Evidence |
+|----|---------|----------|
+| P2-1 | **Startup OUTDATED repair includes legacy Codex migration without session opt-in.** Pre-existing state machine marks legacy installs `OUTDATED` when manifest is absent (`manager.py:566-574`); new startup hook auto-mutates with `--yes`. Not `ABSENT` first-install, but silent migration—align docs if intentional. | `manager.py:566-574`, `cli.py:3849-3872` |
+| P2-2 | **Same-session post auto-patch drift if subprocess sync fails.** After in-process auto-patch, running interpreter still holds old `ASSET_VERSION`; `_maybe_sync_managed_skill` may see `CURRENT` and skip. Recovery depends on subprocess refresh or next launch. Acceptable per "retry next launch" but worth documenting. | `cli.py:3796-3810`, `3855-3856`, `manager.py:699-730` |
+| P2-3 | **Test gaps:** no test that conflict states (`DRIFTED`, `UNOWNED_CONFLICT`, etc.) force `_setup_skill_preference()` → `False`; no end-to-end interactive setup Skill preview→apply test; no CLI test for `cmd_integration_sync`. | `cli.py:567-580`, `tests/test_cli.py:573-612` |
+| P2-4 | **`cmd_integration_sync` preview path:** when `plan is None`, message conflates ABSENT and CURRENT ("未安装或已是当前版本"). Accurate but coarse for operator debugging. | `cli.py:1565-1566` |
+
+## Verified Contracts (pass)
+
+| Path | `allow_first_install` | First-install possible? |
+|------|----------------------|-------------------------|
+| Setup preview | `True`, `dry_run=True` | Preview only, no writes (`cli.py:640`) |
+| Setup apply | `True`, `yes=True` | Yes, after user confirms plan (`cli.py:661`, `904-912`) |
+| `integration sync` CLI | `False` | No (`cli.py:1560-1563`) |
+| Post-update subprocess | via sync CLI → `False` | No (`cli.py:3827-3828`) |
+| Startup `_maybe_sync_managed_skill` | `False`, OUTDATED only | No (`cli.py:3855-3859`) |
+| Setup dry-run | apply skipped | No (`cli.py:901-903`, `824-826`) |
+| Non-interactive setup | skill preference not invoked | No (`cli.py:1016+`) |
+
+Setup conflict/recovery states are fail-closed in the preference step (`cli.py:567-580`), consistent with SSOT.
+
+## Required Fixes (for unconditional Go)
+
+1. **P1-1:** Track Skill apply outcome (success / soft-fail / skipped) and reflect it in `_print_setup_completion` instead of echoing `preferences.install_skill` alone.
+2. **P1-2:** Add tests for `_refresh_skill_via_new_cli`: success stdout passthrough, non-zero exit warning, timeout/OSError, missing `dyro` on PATH; assert `cmd_update_now` calls it only when `perform_update` returns `True`.
+
+## Open Micro-Decisions — Vote
+
+| # | Question | Vote | Rationale |
+|---|----------|------|-----------|
+| 1 | Startup sync: share daily-update gate only? | **Yes — keep current gate** | Matches docs (`dyro` / `home` / `start`, interactive, not dry-run). `_should_run_daily_update` at `cli.py:3780-3784`; hook at `3888-3890`. Broader scope adds surprise mutations on administrative commands. |
+| 2 | Post-update sync failure: "retry next launch" enough? | **Yes** | Package update already succeeded; non-zero exit would punish a partial best-effort. Subprocess + startup OUTDATED repair provide two retries (`cli.py:3837-3842`, `3857-3865`). |
+| 3 | `--install-skill` for non-interactive setup in this change? | **Defer** | Non-interactive path correctly skips Skill today (`1016+`). Flag is useful but orthogonal; ship lifecycle hooks first. |
+
+---
+
+# OpenCode Review Section
+
+Reviewer: OpenCode (Composer)
+Time: 2026-08-12
+Verdict: **Request changes — do not land until P0 is fixed**
+
+## P0
+
+**1. Same-session stale overwrite after successful auto-update refresh**
+
+**Evidence chain:**
+
+- `src/dyro/cli.py` `main()` (L3888–3890): on interactive `dyro` / `home` / `start`, unconditionally runs `_maybe_run_daily_update()` then `_maybe_sync_managed_skill()` in the same process turn.
+- `src/dyro/cli.py` `_maybe_run_daily_update()` (L3796–3810): when `auto_patch` and patch available, calls `perform_update(..., yes=True)`; on `updated=True`, calls `_refresh_skill_via_new_cli()` then returns — but does **not** skip the subsequent `_maybe_sync_managed_skill()` in `main()`.
+- `src/dyro/cli.py` `_refresh_skill_via_new_cli()` (L3815–3846): spawns subprocess `[dyro_bin, "integration", "sync", "skill", "--yes"]` using a **new** `dyro` entry point (fresh wheel assets on disk).
+- `src/dyro/cli.py` `_maybe_sync_managed_skill()` (L3849–3872): if `integration_status("skill").state is IntegrationState.OUTDATED`, calls `sync_managed_skill(yes=True, allow_first_install=False)` **in-process** via `install_integration()`.
+- `src/dyro/integrations/manager.py` `integration_status()` (L699–730): freshness compares manifest `asset_digest` against `_asset_digest(_asset_inventory())` loaded from the **currently running** Python package (`ASSET_VERSION`, packaged skill files).
+
+**Failure mode:**
+
+1. Old in-process Dyro (pre-patch) runs `perform_update()`; disk now has new package.
+2. Subprocess refresh writes Skill mirror/manifest with **new** package `asset_digest`.
+3. Old process still loads `_asset_inventory()` from **old** wheel; manifest digest ≠ old desired digest → status `OUTDATED` (L724–730).
+4. `_maybe_sync_managed_skill()` reinstalls Skill content from **stale** in-process assets, overwriting the subprocess sync.
+
+This violates board SSOT (“post-update sync should use fresh `dyro` entry point when possible”) and can silently regress Skill assets on the launch that auto-patched.
+
+**Required fix:** Skip `_maybe_sync_managed_skill()` when auto-update or post-update refresh already ran in the same `main()` turn; or re-exec into the new entry point before any in-process Skill mutation; or have `_maybe_run_daily_update()` return a flag consumed by `main()`.
+
+## P1
+
+**2. `_refresh_skill_via_new_cli()` PATH binding not tied to upgrade target** (`src/dyro/cli.py` L3817–3828)
+
+Uses `shutil.which("dyro")` with inherited `PATH`. After `pip --user`, `pipx`, or `uv tool` upgrade, the first `dyro` on `PATH` may not be the installation just updated (multiple installs, shadowed `~/.local/bin`, dev venv vs global wrapper). Subprocess may invoke wrong CLI/assets while parent treats refresh as best-effort complete.
+
+**Required fix:** Derive entry point from active install context (`build_update_plan` / `sys.prefix` / pipx-venv bin); pass explicit `env`; do not rely on bare `which("dyro")`.
+
+**3. Recursion correctly avoided; fallback still uses stale assets**
+
+Subprocess `integration sync` does not re-enter daily update (`_should_run_daily_update()` L3780: `command` must be `{None, "home", "start"}`). When subprocess refresh **fails**, `_maybe_sync_managed_skill()` still runs in-process with old assets — acceptable until restart, but P0 “success then overwrite” is strictly worse.
+
+**4. Test coverage gaps on automatic paths**
+
+Present: `tests/test_updates.py` mocks `_refresh_skill_via_new_cli` on daily auto-patch success/failure; `test_startup_syncs_outdated_managed_skill`; `tests/test_integrations.py` `test_sync_managed_skill_*`.
+
+Missing (required before ship):
+
+| Gap | Risk |
+|-----|------|
+| No test that `_refresh_skill_via_new_cli` invokes expected argv / handles non-zero exit / timeout | Subprocess regressions undetected |
+| No test that `cmd_update_now` (L1618–1619) calls refresh when `perform_update` returns `True` | Wiring drift vs daily path |
+| **No regression test for P0** (auto-update + successful refresh → `_maybe_sync_managed_skill` must not run in-process) | P0 can reappear |
+| No CLI tests for `cmd_integration_sync` (L1557–1570): preview gate, `--yes`, `--dry-run`, ABSENT no-op | DRY-RUN/`--yes` contract untested |
+| No test that refresh is not called on dry-run / failed update | False-positive side effects |
+
+## P2
+
+**5. DRY-RUN / `--yes` semantics: install vs sync**
+
+Shared preview gate in `cmd_integration_install` (L1549–1554) and `cmd_integration_sync` (L1557–1570):
+
+```python
+preview = args.dry_run or not args.yes
+```
+
+- `install`: always produces a plan via `install_integration()` including `ABSENT`; preview prints `DRY RUN:` — good.
+- `sync`: `sync_managed_skill(..., allow_first_install=False)` (`manager.py` L1033–1036) returns `None` for `ABSENT`/`CURRENT`; CLI prints `无需同步；Skill 未安装或已是当前版本。` — correct upgrade-only semantics, conflates two states, not CLI-tested.
+- `--yes` + `--dry-run` → preview-only, no writes — matches install/uninstall — good.
+- Automatic paths (`_refresh_skill_via_new_cli`, `_maybe_sync_managed_skill`, setup apply via `_apply_setup_personal_preferences` L659–673) bypass preview/`--yes` for managed repair only — aligned with board SSOT.
+
+**6. Minor UX / docs**
+
+- Setup preview uses `sync_managed_skill(yes=False, dry_run=True, allow_first_install=True)` (`cli.py` L640); apply uses `yes=True` (L659); dry-run setup returns before apply (L901–903) — verified.
+- Localized READMEs and `docs/updates.md` document `integration sync skill --yes`; no CLI test locks upgrade-only contract.
+
+## Required Fixes (summary)
+
+1. **P0:** Prevent `_maybe_sync_managed_skill()` in `main()` (L3890) after successful auto-update / post-update refresh in the same invocation.
+2. **P1:** Resolve post-update `dyro` binary from upgrade target, not global `PATH`/`which`.
+3. **P1:** Add tests for `_refresh_skill_via_new_cli`, `cmd_update_now` → refresh, P0 regression, and `integration sync` CLI preview/`--yes`/`--dry-run`.
+4. **P2:** CLI test or clearer messaging distinguishing `ABSENT` vs `CURRENT` on `integration sync`.
+
+---
+
+# Hermes Review Section
+
+Reviewer: Hermes (Security)
+Time: 2026-08-12
+Verdict: **Conditional Go**
+
+## Hunt Results (evidence-backed)
+
+### P0 — None
+
+No remotely exploitable path found that first-installs on startup/update, bypasses legacy allowlist / packaged-asset checks, or overwrites foreign skills via the new auto-`yes` paths. `sync_managed_skill()` delegates to `install_integration()`; conflict/recovery states still hit `_require_mutable_state()` fail-closed (`manager.py:898-914`, `1037-1044`). Foreign avatar protection remains intact (`manager.py:969-991`; tests `test_unowned_conflict_is_never_overwritten_or_removed`, `test_forged_legacy_over_foreign_avatar_is_refused` in `tests/test_integrations.py`).
+
+### P1 — Post-update subprocess trusts `PATH` for `dyro` binary
+
+**Category:** A08 Integrity / local execution hijack
+**Location:** `cli.py:3815-3833` (`_refresh_skill_via_new_cli`)
+**Exploitability:** Local; attacker who can prepend to `PATH` (or win a race right after package update) before auto-sync runs
+**Blast radius:** Arbitrary code execution as the user, invoked with fixed args `[dyro, integration, sync, skill, --yes]` — can mutate managed Skill mirror/avatars under that identity
+
+**Evidence:** After `perform_update()` / auto-patch (`cli.py:1618-1619`, `3808-3810`), code resolves the binary via `shutil.which("dyro")` and executes it. Args are list-form (no shell injection — good), but the **binary choice is unconstrained**. A trojan `dyro` on `PATH` is fully trusted.
+
+**Remediation:**
+```python
+# BAD — trusts PATH
+dyro_bin = shutil.which("dyro")
+subprocess.run([dyro_bin, "integration", "sync", "skill", "--yes"], ...)
+
+# GOOD — pin to the interpreter/entry point that just updated
+subprocess.run(
+    [sys.executable, "-m", "dyro.cli", "integration", "sync", "skill", "--yes"],
+    env={**os.environ, "PATH": sanitized_minimal_path},
+    ...
+)
+```
+
+**Condition to ship:** Pin post-update re-exec to the freshly installed entry point (or pass an explicit resolved path from the updater), not bare `which("dyro")`.
+
+### P1 — Startup auto-sync mutates agent homes with `yes=True` and no per-run preview
+
+**Category:** A04 Insecure Design / consent boundary (managed-only)
+**Location:** `cli.py:3849-3872` (`_maybe_sync_managed_skill`), wired from `main()` at `3888-3890`
+**Exploitability:** Local interactive user; runs on every interactive `dyro` / `dyro home` / `dyro start` when state is `OUTDATED`
+**Blast radius:** Atomic mirror upgrade + avatar repair across detected agent homes for **already-managed** installs only (`allow_first_install=False`)
+
+**Evidence:** Gate is correct for scope — `_should_run_daily_update()` limits to `{None, home, start}` + TTY (`3772-3784`); absent Skills are skipped (`manager.py:1035-1036`). Foreign paths still fail-closed or are skipped (`manager.py:987-991`).
+
+**Residual risk:** By product intent, but still privileged mutation without a dry-run/confirm step on each launch. Acceptable only if changelog/docs clearly state “interactive startup auto-repairs managed Skill.”
+
+**Condition to ship:** Document the behavior prominently (partially done in `CHANGELOG.md` / `docs/updates.md`); consider logging a one-line audit trail of changed paths.
+
+### P2 — Auto-patch bundles silent Skill `--yes` sync
+
+**Category:** A04 / consent chaining
+**Location:** `cli.py:3796-3810` → `_refresh_skill_via_new_cli()`
+**Evidence:** User enabling `auto_patch` consents to `perform_update(..., yes=True)`; on success, Skill sync also runs with `--yes` without a separate prompt. Mitigated because subprocess sync path sets `allow_first_install=False` (`cmd_integration_sync`, `cli.py:1557-1564`).
+**Remediation:** Mention in setup copy that auto-patch includes managed-Skill sync; optional env opt-out (e.g. `DYRO_NO_SKILL_SYNC`).
+
+### P2 — Setup skill question nudges install on Enter
+
+**Category:** A04 / consent UX
+**Location:** `cli.py:589-597` (`default="1"`)
+**Evidence:** Empty input selects install. **Mitigated** by later plan preview (`640-647`) and final apply gate `_ask_yes_no(..., default=False)` (`994-996`, `904-906`). Not a bypass, but increases mis-click/Enter-through risk before the hard stop.
+**Remediation:** Default skill choice to `"2"` (defer) or require non-empty confirmation for option 1.
+
+### P2 — Missing adversarial tests for sync fail-closed on conflict states
+
+**Category:** A05 Security Misconfiguration / test gap
+**Location:** `tests/test_integrations.py` (only `ABSENT` skip + `OUTDATED` upgrade covered at `595-611`)
+**Evidence:** `install_integration` refusal for `UNOWNED_CONFLICT` / `DRIFTED` is tested (`161-183`), but **`sync_managed_skill()` is not explicitly tested** to propagate those failures on auto/CLI sync paths.
+**Remediation:** Add tests: `sync_managed_skill(yes=True, allow_first_install=False)` raises/soft-fails on `DRIFTED`, `UNOWNED_CONFLICT`, `RECOVERY_REQUIRED`.
+
+### P2 — Cleared hunts
+
+- **Subprocess injection:** argv lists, no `shell=True`, no user-controlled args (`cli.py:3827-3828`, `manager.py:272-273`).
+- **Startup scope / non-interactive gating:** sync only on interactive `{None, home, start}`; not on `setup`, `integration`, `update`, etc. (`3772-3790`, `3888-3890`).
+- **Legacy allowlist / packaged-asset bypass:** `sync_managed_skill()` → same `_legacy_owned_copy(..., require_current_assets=True)` and avatar allowlist as manual install (`manager.py:453-481`, `954-978`, `1011-1044`).
+- **First install without consent on startup/update:** all automatic paths use `allow_first_install=False`; first install only via setup + final confirm or `integration install --yes`.
+
+## Security Checklist
+
+- [x] No hardcoded secrets in diff
+- [x] Automatic `yes=True` paths cannot first-install absent Skills
+- [x] Foreign-skill overwrite protections preserved in `manager.py`
+- [x] Legacy allowlist / packaged-asset checks not bypassed by sync
+- [x] Subprocess args not injectable (list argv, no shell)
+- [ ] Post-update re-exec pinned to trusted entry point (**P1 open**)
+- [ ] Adversarial tests for sync on conflict/recovery states (**P2 open**)
+- [ ] Dependency audit not run in review environment (须人工核)
+
+**Ship recommendation:** **Conditional Go** — land after PATH-pinned post-update re-exec (P1). P2 items are hardening/docs/tests, not blockers if P1 is fixed or explicitly accepted with a tracked follow-up.
+
+---
+
+# Agy Review Section
+
+Reviewer: Agy
+Time: 2026-08-12
+Verdict: Conditional Go
+
+## Product / UX Findings
+
+### P1 — No-host setup still recommends a known-fail path
+Evidence: `src/dyro/cli.py` `_setup_skill_preference` — when `status.avatars` is empty, option 1 is `尝试安装（无宿主时会失败并提示，可稍后重试）（推荐）` with `default="1"`. Apply then hits manager fail-closed (`没有可挂接的宿主分身；拒绝只安装孤立镜像`) and soft-fails.
+Issue: Copy discloses failure, but “推荐” + Enter-default still steers users into a guaranteed soft-fail on hostless machines. That is not honest recommendation semantics.
+Required fix: If no hosts, remove `（推荐）` from option 1, default to option 2 (“稍后手动安装”), and/or rephrase option 1 as non-recommended “仍要尝试（预期失败）”.
+
+### P1 — Setup completion overclaims after soft-fail
+Evidence: `_apply_setup_personal_preferences` warns and returns on `DyroError`; `_print_setup_completion` still prints `Skill：已请求安装 / 同步` whenever `preferences.install_skill` is true.
+Issue: End-of-setup summary reads as “we took your install request seriously / it is in flight,” not “request failed; Skill absent.”
+Required fix: Completion must reflect outcome: success / skipped-current / failed-soft (with the same remediation tip). Prefer tracking apply result, not the preference bit alone.
+
+### P1 — Plan preview can look actionable when apply cannot succeed
+Evidence: `_render_setup_personal_preferences` summarizes `安装 / 同步控制面 Skill（镜像 + 宿主分身）` while `plan_integration` for ABSENT+no hosts lists `未检测到宿主目录…` plus `（预览）将创建镜像` / manifest; apply refuses orphan mirror.
+Issue: Summary line overpromises “宿主分身”; preview bullets mix blocker with optimistic “将创建” language. Confirming the plan feels like approving a real install.
+Required fix: When no hosts, plan summary must lead with blocker (e.g. “无法安装：未检测到宿主”) and avoid “将创建镜像/分身” wording that implies a successful write path.
+
+### P2 — Soft-fail messaging quality (mostly good; small gaps)
+Good: setup apply soft-fail + `install --dry-run` tip; post-update `_refresh_skill_via_new_cli` best-effort warnings; startup repair soft-fail + `sync --dry-run`.
+Gaps:
+- Post-update “下次启动将重试” is only true for interactive `dyro` / `home` / `start` (same `_should_run_daily_update` gate), and is skipped when `DYRO_NO_UPDATE_CHECK` is set—undocumented coupling.
+- `cmd_integration_sync` prints `无需同步；Skill 未安装或已是当前版本` — collapses two meanings; hurts sync vs install discoverability.
+
+Required fix (P2): Split sync no-op copy (`未安装，请用 install` vs `已是当前版本`); document that `DYRO_NO_UPDATE_CHECK` also skips startup Skill repair, or decouple the gates (see micro-decision 1).
+
+### P2 — Docs vs behavior / daily-update story
+Accurate: `docs/updates.md` Control-plane Skill section matches SSOT (setup opt-in, post-update managed sync via fresh entrypoint, startup OUTDATED repair, no first-install on upgrade/startup). CHANGELOG Unreleased matches. Daily PyPI check story (once/local day, non-blocking, confirm-by-default, patch auto opt-in) remains accurate; Skill hooks are additive.
+Gaps:
+- README locales describe auto sync/repair but mostly omit `dyro integration sync skill` (discoverability of sync vs install weaker than `docs/updates.md`).
+- README “Daily check” narrative unchanged; Skill repair sharing that interactive gate / env opt-out is easy to miss.
+- `README.pt-BR.md`: `repararam` → should be `reparam` (grammar).
+
+Required fix (P2): One README sentence naming `install` (first-time) vs `sync` (managed upgrade-only); note env/gate coupling if kept; fix pt-BR typo.
+
+### P2 — Sync vs install discoverability
+CLI `integration sync` help (`仅升级已托管的 Skill`) is clear; docs/updates comment helps. Setup conflict path only points at `install`, which is correct for first-time/conflict. Main gap is README + sync no-op copy (above).
+
+## Micro-decision votes
+
+1. **Startup Skill sync gate**
+   Vote: Keep command scope to interactive `dyro` / `home` / `start` only (do not expand to arbitrary interactive commands). Prefer decoupling Skill repair from `DYRO_NO_UPDATE_CHECK` (update opt-out should not silently disable Skill repair), or document the coupling explicitly in `docs/updates.md`.
+
+2. **Post-update sync failure vs exit code**
+   Vote: “Retry next launch” is enough. Do not make package update exit non-zero when companion Skill sync fails (best-effort companion; update success remains the primary outcome). Keep visible warning.
+
+3. **`dyro setup --non-interactive --install-skill`**
+   Vote: Out of scope for this change. Keep non-interactive free of Skill side effects; first install stays interactive setup or explicit `dyro integration install skill --yes`.
+
+## Go / No-Go
+
+- Go / No-Go: Conditional Go
+- Blocking for honest UX: P1 recommendation default + completion honesty + no-host plan wording.
+- Not blocking: P2 docs/discoverability polish, sync no-op copy, pt-BR typo.
+
+## Required Fixes (executable)
+
+1. No hosts → do not mark install as recommended; default to defer.
+2. Setup completion reflects install outcome, not preference alone.
+3. No-host plan summary/blocker-first; drop optimistic “将创建…” success framing.
+4. (P2) Clarify sync no-op; README install vs sync; document or decouple `DYRO_NO_UPDATE_CHECK` vs Skill repair; fix pt-BR.
+
+---
+
+# Grok Review Section
+
+Reviewer: Grok
+Time: 2026-08-12
+Verdict: Go
+
+## Scorecard
+
+| # | Claim | Result |
+|---|--------|--------|
+| 1 | `sync_managed_skill(allow_first_install=False)` never installs ABSENT | **PASS** |
+| 2 | `_maybe_sync_managed_skill` only acts on OUTDATED | **PASS** |
+| 3 | Setup can first-install only after plan confirm | **PASS** |
+| 4 | Post-update uses subprocess sync not in-process old assets | **PASS** |
+| 5 | Daily update check still gated to interactive home/start/default | **PASS** |
+
+## Findings (source-verified)
+
+1. **PASS** — `manager.py` `sync_managed_skill`: ABSENT + `not allow_first_install` → `return None` before `install_integration`. Covered by `test_sync_managed_skill_skips_absent_without_first_install`.
+
+2. **PASS** — `cli.py` `_maybe_sync_managed_skill`: early return unless `status.state is IntegrationState.OUTDATED`; sync call uses `allow_first_install=False` (defense in depth).
+
+3. **PASS** — Interactive setup: preference → plan render (dry-run preview with `allow_first_install=True`) → `_ask_yes_no` / `--yes` → `_apply_setup_personal_preferences` → mutating sync. Non-interactive setup never calls skill install. Only mutating `allow_first_install=True` site is post-confirm apply.
+
+4. **PASS** — `_refresh_skill_via_new_cli` uses `subprocess.run([dyro_bin, "integration", "sync", "skill", "--yes"])`; `cmd_integration_sync` sets `allow_first_install=False`. Wired from `cmd_update_now` and patch auto-update success. No in-process `sync_managed_skill` on those paths.
+
+5. **PASS** — `_should_run_daily_update` requires `command in {None, "home", "start"}`, TTY interactive, not dry-run, not `DYRO_NO_UPDATE_CHECK`. Sole call site in `main()`.
+
+## P2 (non-blocking)
+
+- **P2:** `_refresh_skill_via_new_cli` resolves via `shutil.which("dyro")`, not Scripts next to the updated `sys.executable`; wrong PATH shadow could sync via a different binary (still subprocess; soft-fail if missing).
+- **P2:** No direct unit test that `_maybe_sync_managed_skill` no-ops on ABSENT (logic is clear; only OUTDATED path tested).
+
+---
+
+# Final Arbitration
+
+Arbiter: Cursor Root (parent agent)
+Time: 2026-08-12 Asia/Taipei
+Final verdict: **No-Go for land** until P0 closed · **Conditional Go** after P0 + listed P1s
+
+## 1. Final Verdict
+
+- May this Skill lifecycle WIP land as-is: **No-Go**
+- After P0 + required P1s: **Conditional Go**
+- First-install / fail-closed ownership contracts: **hold** (Grok scorecard 1–3/5 + Hermes clear; not reopened)
+- Blocking reason: OpenCode P0 same-session stale overwrite is **source-verified**
+
+## 2. Seat Summary
+
+| Seat | Verdict | Arbiter note |
+| --- | --- | --- |
+| Claude | Conditional Go | Correct on consent gates; missed P0 overwrite chain |
+| OpenCode | Request changes (P0) | **Upheld** — P0 is decisive |
+| Hermes | Conditional Go | No security P0; PATH pin upheld as P1 integrity |
+| Agy | Conditional Go | UX honesty P1s upheld (not merge-blockers once P0 fixed, but must-fix before “honest setup” claim) |
+| Grok | Go | Scorecard PASS upheld for allow_first_install; claim #4 incomplete — did not examine post-refresh in-process follow-up |
+
+## 3. P0 Required Fixes
+
+### P0-F1: Same-session stale Skill overwrite after auto-patch refresh
+
+Evidence:
+- `cli.py` `main()` always runs `_maybe_sync_managed_skill()` after `_maybe_run_daily_update()`
+- Successful auto-patch → `_refresh_skill_via_new_cli()` writes **new** digests via subprocess
+- Still-running old interpreter then evaluates `integration_status` against **old** `_asset_inventory()` → `OUTDATED` → in-process `install_integration` overwrites with stale assets (`manager.py:699-730`)
+
+Decision:
+- After a successful package update + Skill refresh in the same process turn, **must not** run in-process `_maybe_sync_managed_skill()`
+- Minimal fix: `_maybe_run_daily_update()` returns whether refresh already ran (or update succeeded); `main()` skips startup sync when true
+- Acceptable alternate: re-exec into new entry point before any in-process Skill mutation
+
+Acceptance:
+- Unit/integration test: auto-patch success + mocked successful `_refresh_skill_via_new_cli` ⇒ `_maybe_sync_managed_skill` / in-process `sync_managed_skill` **not** invoked
+- Manual mental model: “fresh subprocess sync is last writer in that turn”
+
+## 4. P1 Required Before Unconditional Land
+
+### P1-F1: Setup completion honesty (Claude P1-1 + Agy)
+- Track Skill apply outcome; `_print_setup_completion` must not claim `已请求安装 / 同步` after soft-fail
+
+### P1-F2: Pin post-update Skill sync entry point (Hermes + OpenCode)
+- Do not rely on bare `shutil.which("dyro")` alone
+- Prefer updater-resolved bin, or `sys.executable -m dyro` / Scripts-next-to-prefix after `perform_update` documents the target
+- Note: Hermes’ `sys.executable -m` alone is **insufficient** right after in-place upgrade if the running interpreter still loads the old package from memory; prefer the **new** install’s console script / re-exec. Pinning still beats PATH `which`.
+
+### P1-F3: No-host setup honesty (Agy)
+- No hosts → do not label option 1 `（推荐）`; default to defer
+- Plan summary blocker-first (no optimistic “将创建镜像/分身” as if apply will succeed)
+
+### P1-F4: Regression + boundary tests (OpenCode + Claude)
+- P0 regression test (mandatory)
+- `_refresh_skill_via_new_cli` success / non-zero / timeout / missing binary
+- `cmd_update_now` calls refresh only when `perform_update` returns True
+- At least one CLI test for `integration sync` upgrade-only / ABSENT no-op
+
+## 5. P2 Follow-ups (non-blocking)
+
+- Split `integration sync` no-op copy: ABSENT vs CURRENT
+- Document or decouple `DYRO_NO_UPDATE_CHECK` vs startup Skill repair (Agy/Claude votes: keep command gate; prefer decouple env or document)
+- README install vs sync one-liner; pt-BR `repararam` → `reparam`
+- Conflict-state tests for `sync_managed_skill`
+- Docs note: startup OUTDATED may migrate legacy installs (Claude P2-1)
+
+## 6. Open Micro-Decisions — Arbitration
+
+| # | Decision |
+| --- | --- |
+| 1 | **Keep** startup Skill sync on interactive `dyro` / `home` / `start` only. Prefer **document** `DYRO_NO_UPDATE_CHECK` coupling in this change; optional later decouple is P2. |
+| 2 | Post-update Skill sync failure: **retry next launch**; do **not** fail the package update exit code. |
+| 3 | `--install-skill` for non-interactive setup: **out of scope** this change. |
+
+## 7. Instructions For The Execution Agent
+
+1. Fix **P0-F1** in `cli.py` `main` / `_maybe_run_daily_update` wiring first.
+2. Fix **P1-F2** entry-point resolution in `_refresh_skill_via_new_cli`.
+3. Fix **P1-F1** + **P1-F3** setup UX honesty.
+4. Add **P1-F4** tests; run focused suite: `tests/test_updates.py`, `tests/test_cli.py`, `tests/test_integrations.py`.
+5. Do not touch user WIP plans (`plans/dyro-agent-bridge-*.md`).
+6. Do not bump version / publish; keep CHANGELOG under Unreleased until P0/P1 closed.
+7. Re-open board only if new P0 appears; otherwise mark P0-F1 closed in a short follow-up note under Final Arbitration.
+
+## 8. Requires Human Verification
+
+- Real multi-install PATH layouts (pipx vs uv tool vs venv) after `update now` — 须人工核 for P1-F2 completeness
+- Hostless interactive setup UX after P1-F3 — 须人工核
+
+Final signature: Cursor Root (parent agent)
+
+---
+
+## Follow-up (execution)
+
+Time: 2026-08-12 Asia/Taipei
+
+| Item | Status |
+| --- | --- |
+| P0-F1 same-turn stale overwrite | **closed** — `main()` skips `_maybe_sync_managed_skill` when `_maybe_run_daily_update()` returns True after refresh |
+| P1-F1 setup completion honesty | **closed** — apply returns outcome; completion uses it |
+| P1-F2 pin Skill sync entry point | **closed** — `_fresh_dyro_argv` (Scripts/bin beside `sys.executable`, else `-m dyro`) |
+| P1-F3 no-host setup honesty | **closed** — defer default; blocker-first plan summary; install dry-run no longer pretends orphan mirror create |
+| P1-F4 regression/boundary tests | **closed** — auto-patch skip sync; refresh argv/exit; update now wiring; sync CLI; setup UX |
+| Bare `dyro update` ≡ check | **closed** (separate product ask, same WIP) |
+
+Updated land posture: **Conditional Go → ready for focused re-test / land after green suite** (no remaining arbitration P0).

--- a/docs/updates.md
+++ b/docs/updates.md
@@ -20,6 +20,7 @@ automatic check.
 Use an explicit command to retry or to control the saved preference:
 
 ```bash
+dyro update          # same as: dyro update check
 dyro update check
 dyro update enable
 dyro update disable
@@ -37,7 +38,9 @@ Cancelling setup leaves both project files and update preferences untouched.
 which keeps scripts and CI free of user-level side effects.
 
 Set `DYRO_NO_UPDATE_CHECK=1` for a process-level opt-out without changing the
-saved preference.
+saved preference. The same gate currently also skips the interactive startup
+repair of an outdated managed Skill (they share the daily-update launch
+filter).
 
 ## Installing an update
 
@@ -51,15 +54,23 @@ instructions returned by the network. The requirement is pinned to the version
 that was checked and Dyro verifies the installed distribution version after the
 command succeeds.
 
-After upgrading, optionally attach the control-plane Skill to agent homes:
+## Control-plane Skill
+
+Interactive `dyro setup` can install the Skill during personal preferences
+(preview in the plan, applied only after confirmation). After a successful
+`dyro update now` (or patch auto-update), Dyro best-effort syncs an **already
+managed** Skill via the fresh `dyro` entry point. On interactive
+`dyro` / `dyro home` / `dyro start` launches, an **outdated** managed Skill is
+repaired automatically. First-time install is never forced on upgrade or
+startup; use setup or:
 
 ```bash
 dyro integration install skill --dry-run
 dyro integration install skill --yes
+dyro integration sync skill --yes   # upgrade-only; skips absent installs
 ```
 
-(`codex` is an alias for `skill`.) Preview first; install only writes with
-`--yes`.
+(`codex` is an alias for `skill`.)
 
 Editable source installations are deliberately rejected. Update those through
 their Git checkout so a convenience command cannot replace a development

--- a/src/dyro/cli.py
+++ b/src/dyro/cli.py
@@ -9,6 +9,7 @@ import os
 from pathlib import Path
 import shlex
 import shutil
+import subprocess
 import sys
 import time
 
@@ -102,8 +103,10 @@ from .hub import (
     set_default_workspace,
 )
 from .integrations import (
+    IntegrationState,
     install_integration,
     integration_status,
+    sync_managed_skill,
     uninstall_integration,
 )
 from .onboarding import (
@@ -445,6 +448,7 @@ class SetupPersonalPreferences:
     auto_patch: bool
     default_tool: str | None
     make_default_workspace: bool
+    install_skill: bool
 
 
 def _setup_update_preferences() -> tuple[bool, bool]:
@@ -554,6 +558,47 @@ def _setup_default_workspace(
     return selected == "2"
 
 
+def _setup_skill_preference() -> bool:
+    """Ask whether to install/sync the control-plane Skill during setup."""
+    status = integration_status("skill")
+    if status.state is IntegrationState.CURRENT:
+        print(muted("控制面 Skill 已是当前版本；无需在 setup 中重复安装。"))
+        return False
+    if status.state in {
+        IntegrationState.DRIFTED,
+        IntegrationState.UNOWNED_CONFLICT,
+        IntegrationState.STALE_MANIFEST,
+        IntegrationState.RECOVERY_REQUIRED,
+    }:
+        print(
+            warning(
+                f"控制面 Skill 状态为 {status.state.value}（{status.detail}）；"
+                "setup 不会自动改写，请先手动处理后再运行 "
+                "dyro integration install skill。"
+            )
+        )
+        return False
+    hosts = [row.host for row in status.avatars]
+    if hosts:
+        host_text = "、".join(hosts)
+        prompt = f"控制面 Skill（将挂接到已检测宿主：{host_text}）"
+        option_one = "安装 / 同步到已检测宿主（推荐）"
+        default = "1"
+    else:
+        prompt = "控制面 Skill（当前未检测到 Agent 宿主目录）"
+        option_one = "仍要尝试安装（当前无宿主，预期失败）"
+        default = "2"
+    selected = _ask_setup_choice(
+        prompt,
+        (
+            ("1", option_one),
+            ("2", "稍后手动安装（dyro integration install skill）"),
+        ),
+        default=default,
+    )
+    return selected == "1"
+
+
 def _setup_personal_preferences(
     *,
     root: Path,
@@ -564,11 +609,13 @@ def _setup_personal_preferences(
     check_enabled, auto_patch = _setup_update_preferences()
     default_tool = _setup_default_tool(root, provider_preset)
     make_default_workspace = _setup_default_workspace(registration, args)
+    install_skill = _setup_skill_preference()
     return SetupPersonalPreferences(
         check_enabled=check_enabled,
         auto_patch=auto_patch,
         default_tool=default_tool,
         make_default_workspace=make_default_workspace,
+        install_skill=install_skill,
     )
 
 
@@ -591,9 +638,28 @@ def _render_setup_personal_preferences(
         print("  - 编码工具：个人默认 " + terminal_value(preferences.default_tool))
     else:
         print("  - 编码工具：" + muted("不设置个人默认"))
+    if preferences.install_skill:
+        status = integration_status("skill")
+        if status.state is IntegrationState.ABSENT and not status.avatars:
+            print("  - Skill：无法安装：未检测到 Agent 宿主目录")
+            print(
+                "      · 确认后会 soft-fail；请安装宿主后运行 "
+                "dyro integration install skill"
+            )
+            return
+        plan = sync_managed_skill(yes=False, dry_run=True, allow_first_install=True)
+        if plan is None:
+            print("  - Skill：" + muted("已是当前版本"))
+        else:
+            print("  - Skill：安装 / 同步控制面 Skill（镜像 + 宿主分身）")
+            for change in plan.changes:
+                print("      · " + change)
+    else:
+        print("  - Skill：" + muted("稍后手动安装"))
 
 
-def _apply_setup_personal_preferences(preferences: SetupPersonalPreferences) -> None:
+def _apply_setup_personal_preferences(preferences: SetupPersonalPreferences) -> str:
+    """Apply personal preferences; return Skill outcome for setup completion."""
     if preferences.check_enabled:
         set_update_enabled(True)
         set_auto_patch(preferences.auto_patch)
@@ -601,6 +667,25 @@ def _apply_setup_personal_preferences(preferences: SetupPersonalPreferences) -> 
         set_update_enabled(False)
     if preferences.default_tool is not None:
         set_default_tool(preferences.default_tool)
+    if not preferences.install_skill:
+        return "skipped"
+    try:
+        plan = sync_managed_skill(yes=True, allow_first_install=True)
+    except DyroError as exc:
+        print(
+            warning(
+                f"控制面 Skill 未安装成功：{exc}；"
+                "可稍后运行 dyro integration install skill --dry-run 排查。"
+            )
+        )
+        return "failed"
+    if plan is None:
+        print(muted("控制面 Skill 已是当前版本。"))
+        return "current"
+    print(success("已安装 / 同步控制面 Skill。"))
+    for change in plan.changes:
+        print("  - " + change)
+    return "success"
 
 
 def _setup_provider_preset() -> str | None:
@@ -685,6 +770,8 @@ def _print_setup_completion(
     config: Config,
     registration: WorkspaceRecord | None,
     preferences: SetupPersonalPreferences | None = None,
+    *,
+    skill_outcome: str = "skipped",
 ) -> None:
     print("\n" + success("━━ 设置完成 ━━"))
     print(f"  - Profile：{terminal_value(config.name)}")
@@ -707,6 +794,19 @@ def _print_setup_completion(
         if preferences.default_tool is not None:
             tool = preferences.default_tool or "未设置"
             print(f"  - 编码工具：个人默认 {terminal_value(tool)}")
+        if skill_outcome == "success":
+            print("  - Skill：已安装 / 同步")
+        elif skill_outcome == "current":
+            print("  - Skill：" + muted("已是当前版本"))
+        elif skill_outcome == "failed":
+            print(
+                "  - Skill："
+                + warning(
+                    "安装未成功；可稍后运行 dyro integration install skill --dry-run"
+                )
+            )
+        else:
+            print("  - Skill：" + muted("未在 setup 中安装"))
     print("下一步：" + terminal_value("dyro start"))
 
 
@@ -788,8 +888,10 @@ def _apply_setup_plan(
         _print_doctor_finding(finding)
     if any(finding.startswith("FAIL") for finding in findings):
         raise DyroError("设置已保存，但 doctor 发现问题；请修复后运行 dyro next")
-    _apply_setup_personal_preferences(preferences)
-    _print_setup_completion(config, registration, preferences)
+    skill_outcome = _apply_setup_personal_preferences(preferences)
+    _print_setup_completion(
+        config, registration, preferences, skill_outcome=skill_outcome
+    )
 
 
 def _interactive_setup(args: argparse.Namespace) -> None:
@@ -833,8 +935,10 @@ def _interactive_setup(args: argparse.Namespace) -> None:
             register=registration is not None,
             make_default=preferences.make_default_workspace,
         )
-        _apply_setup_personal_preferences(preferences)
-        _print_setup_completion(config, record, preferences)
+        skill_outcome = _apply_setup_personal_preferences(preferences)
+        _print_setup_completion(
+            config, record, preferences, skill_outcome=skill_outcome
+        )
         return
 
     repositories = (
@@ -1478,6 +1582,22 @@ def cmd_integration_install(args: argparse.Namespace) -> None:
         print("确认计划后，重新运行并添加 --yes 执行。")
 
 
+def cmd_integration_sync(args: argparse.Namespace) -> None:
+    """Upgrade a managed Skill install; never performs a first-time install."""
+    preview = args.dry_run or not args.yes
+    plan = sync_managed_skill(
+        yes=args.yes,
+        dry_run=preview,
+        allow_first_install=False,
+    )
+    if plan is None:
+        print("无需同步；Skill 未安装或已是当前版本。")
+        return
+    _print_integration_plan(plan, dry_run=preview)
+    if not args.yes and not args.dry_run:
+        print("确认计划后，重新运行并添加 --yes 执行。")
+
+
 def cmd_integration_uninstall(args: argparse.Namespace) -> None:
     preview = args.dry_run or not args.yes
     plan = uninstall_integration(args.id, yes=args.yes, dry_run=preview)
@@ -1518,11 +1638,13 @@ def cmd_update_now(args: argparse.Namespace) -> None:
         raise DyroError(
             "非交互环境不会更新 Dyro；请在终端中运行，或审阅计划后显式添加 --yes"
         )
-    perform_update(
+    updated = perform_update(
         result.latest_version,
         yes=args.yes,
         dry_run=args.dry_run,
     )
+    if updated:
+        _refresh_skill_via_new_cli()
 
 
 def _explicit_update_check(*, persist: bool = True):
@@ -3042,6 +3164,25 @@ def build_parser() -> argparse.ArgumentParser:
         help="仅预览安装计划；也兼容全局 --dry-run 放在命令前",
     )
     integration_install_parser.set_defaults(func=cmd_integration_install)
+    integration_sync_parser = integration_sub.add_parser(
+        "sync",
+        help="仅升级已托管的 Skill（不会首次安装）",
+    )
+    integration_sync_parser.add_argument(
+        "id",
+        choices=("skill", "codex"),
+        help="skill 为 canonical id；codex 为兼容别名",
+    )
+    integration_sync_parser.add_argument(
+        "--yes", action="store_true", help="确认执行已预览的同步或升级"
+    )
+    integration_sync_parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        default=argparse.SUPPRESS,
+        help="仅预览同步计划；也兼容全局 --dry-run 放在命令前",
+    )
+    integration_sync_parser.set_defaults(func=cmd_integration_sync)
     integration_uninstall_parser = integration_sub.add_parser(
         "uninstall", help="仅卸载仍匹配 ownership manifest 的资产"
     )
@@ -3056,10 +3197,14 @@ def build_parser() -> argparse.ArgumentParser:
         help="仅预览卸载计划；也兼容全局 --dry-run 放在命令前",
     )
     integration_uninstall_parser.set_defaults(func=cmd_integration_uninstall)
-    update = sub.add_parser("update", help="检测并安全更新 Dyro")
-    update_sub = update.add_subparsers(dest="update_command", required=True)
+    update = sub.add_parser(
+        "update",
+        help="检测并安全更新 Dyro（无子命令时等价于 update check）",
+    )
+    update_sub = update.add_subparsers(dest="update_command", required=False)
+    update.set_defaults(func=cmd_update_check)
     update_sub.add_parser(
-        "check", help="立即检查官方 PyPI 的最新稳定版本"
+        "check", help="立即检查官方 PyPI 的最新稳定版本（等价于 dyro update）"
     ).set_defaults(func=cmd_update_check)
     update_now = update_sub.add_parser("now", help="显示计划并更新到最新稳定版本")
     update_now.add_argument(
@@ -3671,14 +3816,23 @@ def _should_run_daily_update(
     return interactive
 
 
-def _maybe_run_daily_update(*, install=perform_update) -> None:
+def _maybe_run_daily_update(*, install=None) -> bool:
+    """Run the daily update path.
+
+    Returns ``True`` when a successful package update already triggered a
+    best-effort Skill refresh in this process. Callers must then skip
+    in-process Skill sync so stale in-memory assets cannot overwrite the
+    fresh subprocess write.
+    """
+    if install is None:
+        install = perform_update
     try:
         result = check_for_update(__version__)
         if not result.checked or result.error or result.kind == UpdateKind.NONE:
-            return
+            return False
         state = load_update_state()
     except (DyroError, OSError):
-        return
+        return False
     print(f"\n发现 Dyro {result.latest_version}（当前 {result.current_version}）。")
     if state.auto_patch and result.kind == UpdateKind.PATCH:
         print("已开启补丁版本自动更新，正在安全更新……")
@@ -3691,11 +3845,79 @@ def _maybe_run_daily_update(*, install=perform_update) -> None:
         except (DyroError, OSError) as exc:
             print(f"自动更新失败：{exc}")
             print("本次启动继续使用当前版本；稍后可运行 dyro update now 重试。")
-            return
+            return False
         if updated:
             print("自动更新完成；本次启动继续运行，下次将使用新版本。")
-        return
+            _refresh_skill_via_new_cli()
+            return True
+        return False
     print("运行 dyro update now 可一键确认更新；今天不再重复提示。")
+    return False
+
+
+def _fresh_dyro_argv(*cli_args: str) -> list[str]:
+    """Build argv for a new Dyro process bound to this interpreter install."""
+    executable = Path(sys.executable)
+    for candidate in (
+        executable.with_name("dyro"),
+        executable.with_name("dyro.exe"),
+    ):
+        if candidate.is_file() and os.access(candidate, os.X_OK):
+            return [str(candidate), *cli_args]
+    return [sys.executable, "-m", "dyro", *cli_args]
+
+
+def _refresh_skill_via_new_cli() -> None:
+    """Best-effort Skill sync using the freshly installed ``dyro`` entry point."""
+    argv = _fresh_dyro_argv("integration", "sync", "skill", "--yes")
+    print("正在同步已托管的控制面 Skill……")
+    try:
+        completed = subprocess.run(
+            argv,
+            capture_output=True,
+            text=True,
+            timeout=120,
+            check=False,
+        )
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        print(warning(f"Skill 同步未完成：{exc}；下次启动将重试。"))
+        return
+    if completed.returncode != 0:
+        detail = (completed.stderr or completed.stdout or "").strip()
+        message = "Skill 同步未完成"
+        if detail:
+            message += f"：{detail}"
+        print(warning(message + "；下次启动将重试。"))
+        return
+    output = (completed.stdout or "").strip()
+    if output:
+        print(output)
+
+
+def _maybe_sync_managed_skill() -> None:
+    """Auto-repair OUTDATED managed Skill installs on interactive launch."""
+    try:
+        status = integration_status("skill")
+    except (DyroError, OSError, ValidationError):
+        return
+    if status.state is not IntegrationState.OUTDATED:
+        return
+    print("\n检测到控制面 Skill 可升级，正在自动同步……")
+    try:
+        plan = sync_managed_skill(yes=True, allow_first_install=False)
+    except DyroError as exc:
+        print(
+            warning(
+                f"Skill 自动同步未完成：{exc}；"
+                "可运行 dyro integration sync skill --dry-run 查看详情。"
+            )
+        )
+        return
+    if plan is None:
+        return
+    print(success("控制面 Skill 已同步到当前 Dyro 包。"))
+    for change in plan.changes:
+        print("  - " + change)
 
 
 def main(argv: list[str] | None = None) -> None:
@@ -3712,7 +3934,10 @@ def main(argv: list[str] | None = None) -> None:
             raise SystemExit(dispatch_main(experiment[1]))
         args = parser.parse_args(argv)
         if _should_run_daily_update(args):
-            _maybe_run_daily_update()
+            # After a same-turn package update + Skill refresh, skip in-process
+            # sync so stale in-memory assets cannot overwrite the fresh write.
+            if not _maybe_run_daily_update():
+                _maybe_sync_managed_skill()
         if hasattr(args, "func"):
             args.func(args)
         else:

--- a/src/dyro/integrations/__init__.py
+++ b/src/dyro/integrations/__init__.py
@@ -8,6 +8,7 @@ from .manager import (
     install_integration,
     integration_status,
     plan_integration,
+    sync_managed_skill,
     uninstall_integration,
 )
 
@@ -19,5 +20,6 @@ __all__ = [
     "install_integration",
     "integration_status",
     "plan_integration",
+    "sync_managed_skill",
     "uninstall_integration",
 ]

--- a/src/dyro/integrations/manager.py
+++ b/src/dyro/integrations/manager.py
@@ -753,10 +753,9 @@ def plan_integration(
         elif status.state is IntegrationState.ABSENT:
             if not status.avatars:
                 changes = (
-                    "未检测到宿主目录；需先创建或设置 "
+                    "无法安装：未检测到宿主目录；需先创建或设置 "
                     "CODEX_HOME / CLAUDE_HOME / AGENTS_HOME / CURSOR_HOME",
-                    f"（预览）将创建镜像 {status.target}",
-                    f"（预览）将写入 {status.manifest}",
+                    "不会创建孤立镜像或分身",
                 )
             else:
                 changes = (
@@ -1006,6 +1005,42 @@ def _install_avatars(
             if backup.exists() and not original.exists() and not original.is_symlink():
                 os.replace(backup, original)
         raise
+
+
+def sync_managed_skill(
+    *,
+    yes: bool,
+    dry_run: bool = False,
+    allow_first_install: bool = False,
+    dyro_home: Path | None = None,
+    host_homes: Mapping[str, Path] | None = None,
+    codex_home: Path | None = None,
+) -> IntegrationPlan | None:
+    """Install or upgrade the Skill when the local state allows mutation.
+
+    - ``CURRENT``: no-op (``None``)
+    - ``OUTDATED``: upgrade / repair the managed install
+    - ``ABSENT``: first install only when ``allow_first_install`` is true
+    - conflict / recovery states: raise ``DyroError`` (callers may soft-fail)
+    """
+    status = integration_status(
+        CANONICAL_INTEGRATION_ID,
+        dyro_home=dyro_home,
+        host_homes=host_homes,
+        codex_home=codex_home,
+    )
+    if status.state is IntegrationState.CURRENT:
+        return None
+    if status.state is IntegrationState.ABSENT and not allow_first_install:
+        return None
+    return install_integration(
+        CANONICAL_INTEGRATION_ID,
+        yes=yes,
+        dry_run=dry_run,
+        dyro_home=dyro_home,
+        host_homes=host_homes,
+        codex_home=codex_home,
+    )
 
 
 def install_integration(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -5,7 +5,7 @@ import tempfile
 import unittest
 from contextlib import redirect_stderr, redirect_stdout
 from io import StringIO
-from unittest.mock import patch
+from unittest.mock import Mock, patch
 
 from dyro.cli import (
     _print_doctor_finding,
@@ -347,6 +347,7 @@ class CliTests(unittest.TestCase):
             with (
                 patch("dyro.cli._setup_provider_preset", return_value=None),
                 patch("dyro.cli.launcher_tools", return_value=[]),
+                patch("dyro.cli._setup_skill_preference", return_value=False),
                 patch("builtins.input", side_effect=lambda _: next(answers)),
             ):
                 main(["setup", str(root), "--interactive"])
@@ -372,6 +373,7 @@ class CliTests(unittest.TestCase):
             with (
                 patch("dyro.cli._setup_provider_preset", return_value=None),
                 patch("dyro.cli.launcher_tools", return_value=[]),
+                patch("dyro.cli._setup_skill_preference", return_value=False),
                 patch("builtins.input", side_effect=lambda _: next(answers)),
             ):
                 main(["setup", str(root), "--interactive"])
@@ -420,6 +422,7 @@ class CliTests(unittest.TestCase):
             with (
                 patch("dyro.cli._setup_provider_preset", return_value=None),
                 patch("dyro.cli.launcher_tools", return_value=[]),
+                patch("dyro.cli._setup_skill_preference", return_value=False),
                 patch("builtins.input", side_effect=lambda _: next(answers)),
             ):
                 main(["setup", str(repository), "--interactive"])
@@ -455,6 +458,7 @@ class CliTests(unittest.TestCase):
             with (
                 patch("dyro.cli._setup_provider_preset", return_value=None),
                 patch("dyro.cli.launcher_tools", return_value=[]),
+                patch("dyro.cli._setup_skill_preference", return_value=False),
                 patch("builtins.input", side_effect=lambda _: next(answers)),
             ):
                 main(["setup", str(repository), "--interactive"])
@@ -483,6 +487,7 @@ class CliTests(unittest.TestCase):
             with (
                 patch("dyro.cli._setup_provider_preset", return_value="codex"),
                 patch("dyro.cli.launcher_tools", return_value=tools),
+                patch("dyro.cli._setup_skill_preference", return_value=False),
                 patch("builtins.input", side_effect=lambda _: next(answers)),
             ):
                 main(["setup", str(root), "--interactive"])
@@ -534,6 +539,7 @@ class CliTests(unittest.TestCase):
             with (
                 patch("dyro.cli._setup_provider_preset", return_value=None),
                 patch("dyro.cli.launcher_tools", return_value=[]),
+                patch("dyro.cli._setup_skill_preference", return_value=False),
                 patch("builtins.input", side_effect=lambda _: next(answers)),
             ):
                 main(["setup", str(root), "--interactive"])
@@ -555,6 +561,7 @@ class CliTests(unittest.TestCase):
             answers = iter(["", ""])
             with (
                 patch("dyro.cli.launcher_tools", return_value=[]),
+                patch("dyro.cli._setup_skill_preference", return_value=False),
                 patch("builtins.input", side_effect=lambda _: next(answers)),
                 redirect_stdout(output),
             ):
@@ -562,6 +569,94 @@ class CliTests(unittest.TestCase):
 
             self.assertFalse((Path(self.registry_tmp.name) / "updates.json").exists())
             self.assertIn("DRY RUN: 上述个人偏好和全局入口不会写入。", output.getvalue())
+
+    def test_setup_skill_preference_defaults_to_install_when_hosts_exist(
+        self,
+    ) -> None:
+        from dyro.cli import _setup_skill_preference
+        from dyro.integrations import AvatarStatus, IntegrationState, IntegrationStatus
+
+        status = IntegrationStatus(
+            "skill",
+            IntegrationState.ABSENT,
+            Path("/tmp/mirror"),
+            Path("/tmp/manifest"),
+            "未安装",
+            avatars=(
+                AvatarStatus("codex", Path("/tmp/codex"), "missing", "missing"),
+            ),
+        )
+        with (
+            patch("dyro.cli.integration_status", return_value=status),
+            patch("builtins.input", return_value=""),
+        ):
+            self.assertTrue(_setup_skill_preference())
+
+    def test_setup_skill_preference_defaults_to_defer_without_hosts(self) -> None:
+        from dyro.cli import _setup_skill_preference
+        from dyro.integrations import IntegrationState, IntegrationStatus
+
+        status = IntegrationStatus(
+            "skill",
+            IntegrationState.ABSENT,
+            Path("/tmp/mirror"),
+            Path("/tmp/manifest"),
+            "未安装",
+        )
+        with (
+            patch("dyro.cli.integration_status", return_value=status),
+            patch("builtins.input", return_value=""),
+        ):
+            self.assertFalse(_setup_skill_preference())
+
+    def test_apply_setup_personal_preferences_installs_skill_when_requested(
+        self,
+    ) -> None:
+        from dyro.cli import SetupPersonalPreferences, _apply_setup_personal_preferences
+
+        preferences = SetupPersonalPreferences(
+            check_enabled=True,
+            auto_patch=False,
+            default_tool=None,
+            make_default_workspace=False,
+            install_skill=True,
+        )
+        plan = Mock()
+        plan.changes = ("创建镜像",)
+        with (
+            patch("dyro.cli.set_update_enabled") as set_enabled,
+            patch("dyro.cli.set_auto_patch") as set_auto,
+            patch("dyro.cli.sync_managed_skill", return_value=plan) as sync,
+        ):
+            outcome = _apply_setup_personal_preferences(preferences)
+        set_enabled.assert_called_once_with(True)
+        set_auto.assert_called_once_with(False)
+        sync.assert_called_once_with(yes=True, allow_first_install=True)
+        self.assertEqual(outcome, "success")
+
+    def test_print_setup_completion_reflects_skill_failure(self) -> None:
+        from dyro.cli import SetupPersonalPreferences, _print_setup_completion
+
+        preferences = SetupPersonalPreferences(
+            check_enabled=True,
+            auto_patch=False,
+            default_tool=None,
+            make_default_workspace=False,
+            install_skill=True,
+        )
+        with tempfile.TemporaryDirectory(prefix="dyro-cli-") as tmp:
+            root = Path(tmp) / "workspace"
+            main(["init", str(root), "--name", "demo"])
+            output = StringIO()
+            with redirect_stdout(output):
+                _print_setup_completion(
+                    load(root),
+                    None,
+                    preferences,
+                    skill_outcome="failed",
+                )
+            self.assertIn("安装未成功", output.getvalue())
+            self.assertNotIn("已请求安装", output.getvalue())
 
 
 class StartTests(WorkspaceCase):

--- a/tests/test_integrations.py
+++ b/tests/test_integrations.py
@@ -16,6 +16,7 @@ from dyro.integrations import (
     IntegrationState,
     install_integration,
     integration_status,
+    sync_managed_skill,
     uninstall_integration,
 )
 from dyro.integrations import manager
@@ -591,6 +592,24 @@ class IntegrationManagerTests(unittest.TestCase):
         )
         self.assertFalse(self.avatar.is_symlink())
 
+    def test_sync_managed_skill_skips_absent_without_first_install(self) -> None:
+        self.assertIsNone(sync_managed_skill(yes=True, allow_first_install=False))
+        self.assertEqual(integration_status("skill").state, IntegrationState.ABSENT)
+
+    def test_sync_managed_skill_upgrades_outdated(self) -> None:
+        install_integration("skill", yes=True)
+        manifest = json.loads(self.manifest.read_text(encoding="utf-8"))
+        manifest["asset_version"] = manifest["asset_version"] + 1
+        self.manifest.write_text(
+            json.dumps(manifest, ensure_ascii=True, indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
+        self.assertEqual(integration_status("skill").state, IntegrationState.OUTDATED)
+        plan = sync_managed_skill(yes=True, allow_first_install=False)
+        self.assertIsNotNone(plan)
+        assert plan is not None
+        self.assertEqual(plan.status.state, IntegrationState.CURRENT)
+
     def test_plan_surfaces_missing_host_blocker(self) -> None:
         with patch.dict(os.environ):
             for key in ("CODEX_HOME", "CLAUDE_HOME", "AGENTS_HOME", "CURSOR_HOME"):
@@ -602,6 +621,34 @@ class IntegrationManagerTests(unittest.TestCase):
             any("未检测到宿主目录" in change for change in plan.changes),
             msg=plan.changes,
         )
+        self.assertTrue(
+            any("不会创建孤立镜像" in change for change in plan.changes),
+            msg=plan.changes,
+        )
+
+    def test_cli_sync_is_upgrade_only_and_skips_absent(self) -> None:
+        output = StringIO()
+        before = self._tree_snapshot()
+        with redirect_stdout(output):
+            main(["integration", "sync", "skill"])
+            main(["integration", "sync", "skill", "--yes"])
+        self.assertIn("无需同步", output.getvalue())
+        self.assertEqual(self._tree_snapshot(), before)
+
+        install_integration("skill", yes=True)
+        manifest = json.loads(self.manifest.read_text(encoding="utf-8"))
+        manifest["asset_version"] = manifest["asset_version"] + 1
+        self.manifest.write_text(
+            json.dumps(manifest, ensure_ascii=True, indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
+        synced = StringIO()
+        with redirect_stdout(synced):
+            main(["integration", "sync", "skill", "--yes"])
+        text = synced.getvalue()
+        self.assertIn("install skill", text)
+        self.assertIn("current", text)
+        self.assertEqual(integration_status("skill").state, IntegrationState.CURRENT)
 
     def test_cli_status_dry_run_install_and_confirmation_gate(self) -> None:
         output = StringIO()

--- a/tests/test_updates.py
+++ b/tests/test_updates.py
@@ -9,6 +9,7 @@ import json
 import os
 from pathlib import Path
 import subprocess
+import sys
 import tempfile
 import unittest
 from unittest.mock import Mock, patch
@@ -517,12 +518,15 @@ class DailyCliIntegrationTests(unittest.TestCase):
                 "dyro.cli.load_update_state",
                 return_value=UpdateState(auto_patch=True),
             ),
+            patch("dyro.cli._refresh_skill_via_new_cli") as refresh_skill,
             redirect_stdout(output),
         ):
-            _maybe_run_daily_update(install=install)
+            refreshed = _maybe_run_daily_update(install=install)
         install.assert_called_once_with(
             "0.5.6", yes=True, dry_run=False
         )
+        refresh_skill.assert_called_once_with()
+        self.assertTrue(refreshed)
         self.assertIn("自动更新完成", output.getvalue())
 
         output = StringIO()
@@ -533,10 +537,13 @@ class DailyCliIntegrationTests(unittest.TestCase):
                 "dyro.cli.load_update_state",
                 return_value=UpdateState(auto_patch=True),
             ),
+            patch("dyro.cli._refresh_skill_via_new_cli") as refresh_skill,
             redirect_stdout(output),
         ):
-            _maybe_run_daily_update(install=install)
+            refreshed = _maybe_run_daily_update(install=install)
         install.assert_not_called()
+        refresh_skill.assert_not_called()
+        self.assertFalse(refreshed)
         self.assertIn("dyro update now", output.getvalue())
 
     def test_daily_check_failure_never_blocks_or_prints(self) -> None:
@@ -554,7 +561,7 @@ class DailyCliIntegrationTests(unittest.TestCase):
             ),
             redirect_stdout(output),
         ):
-            _maybe_run_daily_update()
+            self.assertFalse(_maybe_run_daily_update())
         self.assertEqual(output.getvalue(), "")
 
     def test_daily_state_io_failure_never_blocks_or_prints(self) -> None:
@@ -565,7 +572,7 @@ class DailyCliIntegrationTests(unittest.TestCase):
             patch("dyro.cli.check_for_update", side_effect=OSError("read-only")),
             redirect_stdout(output),
         ):
-            _maybe_run_daily_update()
+            self.assertFalse(_maybe_run_daily_update())
         self.assertEqual(output.getvalue(), "")
 
     def test_environment_opt_out_accepts_only_truthy_values(self) -> None:
@@ -576,6 +583,156 @@ class DailyCliIntegrationTests(unittest.TestCase):
             self.assertFalse(_should_run_daily_update(args, interactive=True))
         with patch.dict(os.environ, {"DYRO_NO_UPDATE_CHECK": "0"}):
             self.assertTrue(_should_run_daily_update(args, interactive=True))
+
+    def test_startup_syncs_outdated_managed_skill(self) -> None:
+        from dyro.cli import _maybe_sync_managed_skill
+        from dyro.integrations import IntegrationState, IntegrationStatus
+
+        status = IntegrationStatus(
+            "skill",
+            IntegrationState.OUTDATED,
+            Path("/tmp/mirror"),
+            Path("/tmp/manifest"),
+            "outdated",
+        )
+        plan = Mock()
+        plan.changes = ("升级镜像",)
+        output = StringIO()
+        with (
+            patch("dyro.cli.integration_status", return_value=status),
+            patch("dyro.cli.sync_managed_skill", return_value=plan) as sync,
+            redirect_stdout(output),
+        ):
+            _maybe_sync_managed_skill()
+        sync.assert_called_once_with(yes=True, allow_first_install=False)
+        self.assertIn("控制面 Skill 已同步", output.getvalue())
+
+    def test_auto_patch_refresh_skips_same_turn_inprocess_skill_sync(self) -> None:
+        """P0 regression: successful refresh must not be overwritten in-process."""
+        from dyro.cli import main
+
+        patch_result = UpdateResult(
+            checked=True,
+            current_version="0.5.5",
+            latest_version="0.5.6",
+            kind=UpdateKind.PATCH,
+        )
+        with (
+            patch("dyro.cli._should_run_daily_update", return_value=True),
+            patch("dyro.cli.check_for_update", return_value=patch_result),
+            patch(
+                "dyro.cli.load_update_state",
+                return_value=UpdateState(auto_patch=True),
+            ),
+            patch("dyro.cli.perform_update", return_value=True),
+            patch("dyro.cli._refresh_skill_via_new_cli") as refresh,
+            patch("dyro.cli._maybe_sync_managed_skill") as sync,
+            patch("dyro.cli.cmd_home"),
+            redirect_stdout(StringIO()),
+        ):
+            main([])
+        refresh.assert_called_once_with()
+        sync.assert_not_called()
+
+    def test_refresh_skill_uses_install_bound_argv(self) -> None:
+        from dyro.cli import _fresh_dyro_argv, _refresh_skill_via_new_cli
+
+        argv = _fresh_dyro_argv("integration", "sync", "skill", "--yes")
+        self.assertIn("integration", argv)
+        self.assertTrue(
+            Path(argv[0]).name in {"dyro", "dyro.exe"}
+            or argv[:3] == [sys.executable, "-m", "dyro"],
+            msg=argv,
+        )
+
+        completed = Mock(returncode=0, stdout="synced\n", stderr="")
+        output = StringIO()
+        with (
+            patch("dyro.cli._fresh_dyro_argv", return_value=["dyro", "integration", "sync", "skill", "--yes"]),
+            patch("dyro.cli.subprocess.run", return_value=completed) as run,
+            redirect_stdout(output),
+        ):
+            _refresh_skill_via_new_cli()
+        run.assert_called_once()
+        self.assertEqual(
+            run.call_args.args[0],
+            ["dyro", "integration", "sync", "skill", "--yes"],
+        )
+        self.assertIn("synced", output.getvalue())
+
+    def test_refresh_skill_warns_on_nonzero_exit(self) -> None:
+        from dyro.cli import _refresh_skill_via_new_cli
+
+        completed = Mock(returncode=2, stdout="", stderr="boom")
+        output = StringIO()
+        with (
+            patch(
+                "dyro.cli._fresh_dyro_argv",
+                return_value=["dyro", "integration", "sync", "skill", "--yes"],
+            ),
+            patch("dyro.cli.subprocess.run", return_value=completed),
+            redirect_stdout(output),
+        ):
+            _refresh_skill_via_new_cli()
+        self.assertIn("Skill 同步未完成", output.getvalue())
+        self.assertIn("boom", output.getvalue())
+
+    def test_update_now_refreshes_skill_only_when_update_succeeds(self) -> None:
+        from dyro.cli import main
+
+        result = UpdateResult(
+            checked=True,
+            current_version="0.5.5",
+            latest_version="0.5.6",
+            kind=UpdateKind.PATCH,
+        )
+        with tempfile.TemporaryDirectory(prefix="dyro-update-now-refresh-") as tmp:
+            with (
+                patch.dict(os.environ, {"DYRO_HOME": tmp}),
+                patch("dyro.cli.check_for_update", return_value=result),
+                patch("dyro.cli.perform_update", return_value=True) as install,
+                patch("dyro.cli._refresh_skill_via_new_cli") as refresh,
+                redirect_stdout(StringIO()),
+            ):
+                main(["update", "now", "--yes"])
+            install.assert_called_once_with("0.5.6", yes=True, dry_run=False)
+            refresh.assert_called_once_with()
+
+            refresh.reset_mock()
+            with (
+                patch.dict(os.environ, {"DYRO_HOME": tmp}),
+                patch("dyro.cli.check_for_update", return_value=result),
+                patch("dyro.cli.perform_update", return_value=False),
+                patch("dyro.cli._refresh_skill_via_new_cli") as refresh_skip,
+                redirect_stdout(StringIO()),
+            ):
+                main(["update", "now", "--yes"])
+            refresh_skip.assert_not_called()
+
+    def test_bare_update_is_equivalent_to_update_check(self) -> None:
+        from dyro.cli import main
+
+        result = UpdateResult(
+            checked=True,
+            current_version="0.5.5",
+            latest_version="0.5.6",
+            kind=UpdateKind.PATCH,
+        )
+        with tempfile.TemporaryDirectory(prefix="dyro-update-bare-") as tmp:
+            for argv in (["update"], ["update", "check"]):
+                output = StringIO()
+                with (
+                    patch.dict(os.environ, {"DYRO_HOME": tmp}),
+                    patch("dyro.cli.check_for_update", return_value=result) as check,
+                    patch("dyro.cli.perform_update") as install,
+                    redirect_stdout(output),
+                ):
+                    main(argv)
+                check.assert_called_once()
+                install.assert_not_called()
+                text = output.getvalue()
+                self.assertIn("发现 Dyro 0.5.6", text)
+                self.assertIn("dyro update now", text)
 
     def test_update_commands_work_without_a_workspace(self) -> None:
         from dyro.cli import main


### PR DESCRIPTION
## Summary
- Guide control-plane Skill install during interactive `dyro setup` (preview + confirm; honest no-host defaults; completion reflects outcome).
- After package update / patch auto-update, best-effort sync already-managed Skills via an install-bound fresh CLI; repair `OUTDATED` managed Skills on interactive `dyro` / `home` / `start` (never first-install on upgrade/startup).
- Close same-turn stale overwrite after auto-patch refresh; make bare `dyro update` equivalent to `dyro update check`; align localized README install notes.

## Test plan
- [ ] `uv run python -m unittest tests.test_updates.DailyCliIntegrationTests tests.test_integrations.IntegrationManagerTests.test_cli_sync_is_upgrade_only_and_skips_absent tests.test_cli.CliTests.test_setup_skill_preference_defaults_to_defer_without_hosts`
- [ ] Interactive setup with a detected host: Skill preference defaults to install; completion shows success/failure accurately
- [ ] Interactive setup with no agent hosts: Skill preference defaults to defer
- [ ] `dyro update` and `dyro update check` print the same check result
- [ ] With auto-patch on, verify post-update Skill refresh does not get overwritten in the same launch (P0 regression covered by unit test)
- [ ] `dyro integration sync skill --yes` upgrades managed installs and no-ops when absent