### PR TITLE
chore(发布): 准备 0.6.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## 0.6.4 - 2026-08-12
+
 - Guide control-plane Skill install during interactive `dyro setup` (preview in
   the plan; apply only after confirmation; soft-fail if no host is ready).
 - After a successful package update (`dyro update now` or patch auto-update),

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "dyro"
-version = "0.6.3"
+version = "0.6.4"
 description = "DyroEngineeringFlow: local-first automation and delivery control for multi-repository teams"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/uv.lock
+++ b/uv.lock
@@ -286,7 +286,7 @@ wheels = [
 
 [[package]]
 name = "dyro"
-version = "0.6.3"
+version = "0.6.4"
 source = { editable = "." }
 dependencies = [
     { name = "cryptography" },


### PR DESCRIPTION
## Summary
- Bump `dyro` to **0.6.4** (`pyproject.toml` / `uv.lock`).
- Move Skill lifecycle / bare `dyro update` notes from Unreleased to dated `## 0.6.4 - 2026-08-12`.

## Test plan
- [x] `uv lock --check`
- [x] Focused release-metadata + Skill lifecycle unit tests
- [ ] CI green on PR
- [ ] After merge: tag `v0.6.4`, publish GitHub Release (triggers PyPI Trusted Publishing; needs `pypi` Environment approval)