### PR TITLE
chore(发布): 准备 0.6.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## 0.6.5 - 2026-08-13
+
 - Expand the packaged `dyro-control-plane` Skill into a host-neutral,
   intent-routed read-only control surface for workspace health, lines, Change
   Sets, integrations, and Objective attention/graph/tick/plan observations.
@@ -22,9 +24,9 @@
   checking Task integration evidence and Git ancestry inside the same budget;
   reject unsafe bootstrap targets before `next` can hand off a mutation.
 - Minimize Agent-visible local metadata: workspace and Skill integration JSON
-  and health diagnostics omit absolute paths by default, expose them only through explicit
-  `--include-paths`, and let the Skill skip global discovery when an alias is
-  already known.
+  and health diagnostics omit absolute paths by default, expose them only
+  through explicit `--include-paths`, and let the Skill skip global discovery
+  when an alias is already known.
 - Let Enter confirm the already-previewed feature worktree plan while keeping
   `b` as the explicit route back to baseline selection.
 - Exclude generated Python bytecode from source and wheel distributions, even

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "dyro"
-version = "0.6.4"
+version = "0.6.5"
 description = "DyroEngineeringFlow: local-first automation and delivery control for multi-repository teams"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/uv.lock
+++ b/uv.lock
@@ -286,7 +286,7 @@ wheels = [
 
 [[package]]
 name = "dyro"
-version = "0.6.4"
+version = "0.6.5"
 source = { editable = "." }
 dependencies = [
     { name = "cryptography" },


### PR DESCRIPTION
## 发布准备

- 将项目与锁文件版本更新为 0.6.5
- 将 Unreleased 内容固化为 2026-08-13 的 0.6.5 changelog

## 门禁

- 功能合并 main 精确 SHA 4cbf49d 的 push CI：8/8 通过
- 发布版本与 dated changelog 测试通过
- uv lock、全仓 Ruff、git diff check 通过
- 0.6.5 wheel 与 sdist 构建、twine strict check 通过
- 制品不含 pycache、pyc、pyo；打包 Skill 隐私扫描通过