### PR TITLE
chore(发布): 准备 0.6.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## 0.6.6 - 2026-08-13
+
 - Launch any installed coding tool from `dyro start` / `open`, not only a
   Codex Profile adapter; `agent add --preset` now covers the catalogued
   launchable tools.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "dyro"
-version = "0.6.5"
+version = "0.6.6"
 description = "DyroEngineeringFlow: local-first automation and delivery control for multi-repository teams"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/uv.lock
+++ b/uv.lock
@@ -286,7 +286,7 @@ wheels = [
 
 [[package]]
 name = "dyro"
-version = "0.6.5"
+version = "0.6.6"
 source = { editable = "." }
 dependencies = [
     { name = "cryptography" },


### PR DESCRIPTION
## 摘要

- 将版本号从 0.6.5 提升到 0.6.6
- 把 Unreleased 中的启动面多工具改动写入 `## 0.6.6 - 2026-08-13`

依赖已合并的 #24。本 PR 不含 tag、GitHub Release 或 PyPI 发布。