### PR TITLE
chore(发布): 准备 0.6.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## 0.6.7 - 2026-08-13
+
 - Make bare `dyro update` check, confirm, and install (same path as
   `update now`). `update check` remains check-only; `--yes` skips the
   confirmation on both `update` and `update now`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "dyro"
-version = "0.6.6"
+version = "0.6.7"
 description = "DyroEngineeringFlow: local-first automation and delivery control for multi-repository teams"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/uv.lock
+++ b/uv.lock
@@ -286,7 +286,7 @@ wheels = [
 
 [[package]]
 name = "dyro"
-version = "0.6.6"
+version = "0.6.7"
 source = { editable = "." }
 dependencies = [
     { name = "cryptography" },


### PR DESCRIPTION
## 摘要

- 将版本号从 0.6.6 提升到 0.6.7
- 把 Unreleased 中的 `dyro update` 确认安装改动写入 `## 0.6.7 - 2026-08-13`

依赖已合并的 #26。本 PR 不含 tag、GitHub Release 或 PyPI 发布。