### PR TITLE
feat(开发线): spawn、合入父线与从父线同步

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,9 @@
   missing; `dyro host seed` creates missing files only (`--force` overwrites).
 - `line spawn` / `create` write overlay personas at `versions/<line>/` (not
   inside product Git worktrees). Must-track `origin/<line.branch>`.
+- `status` no longer appends a phantom MISSING row after every line; a missing
+  worktree is reported on that repo only. `dyro line spawn|merge|sync` and
+  `dyro host seed` accept `--dry-run` after the verb, not only the global flag.
 
 ## 0.7.7 - 2026-08-20
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 ## Unreleased
 
+- Line manifests may declare an optional `parent` line id (schema 3). Schema 1
+  and 2 files still parse; the writer emits schema 3 only when `parent` is set.
+  `base` remains a Git ref.
+- `dyro line spawn <parent> <child>` creates a durable child line (not a task)
+  from a parent, inheriting repositories (optional `--repos` subset). The child
+  binds like `line create` and does not fetch, push, or track the parent branch.
+- `dyro line merge <child> --into <parent>` merges the child into its direct
+  parent across the child's repos (`--no-ff`, locked, dry-runnable). One repo
+  failure rolls back already-merged repos. `--push` still requires
+  `policy.allow_push`.
+- `dyro line sync <child>` merges the parent into the child the same way.
+  `line list` / `status` show the parent id when set.
+
 ## 0.7.7 - 2026-08-20
 
 - Linked-worktree lines bind to `origin/<line.branch>` when that remote-tracking

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,13 @@
   `policy.allow_push`.
 - `dyro line sync <child>` merges the parent into the child the same way.
   `line list` / `status` show the parent id when set.
+- New `setup` / `join` / `init` workspaces get thin overlay-root `AGENTS.md`
+  and `CLAUDE.md` (same body). They point at host-compiled SKILL.md and
+  `dyro next`; they are not the gate. Installing or upgrading Dyro does not
+  rewrite existing workspaces. `dyro doctor` WARNs when both files are
+  missing; `dyro host seed` creates missing files only (`--force` overwrites).
+- `line spawn` / `create` write overlay personas at `versions/<line>/` (not
+  inside product Git worktrees). Must-track `origin/<line.branch>`.
 
 ## 0.7.7 - 2026-08-20
 

--- a/src/dyro/blueprint.py
+++ b/src/dyro/blueprint.py
@@ -769,6 +769,9 @@ def apply_join_plan(plan: JoinPlan) -> Config:
         _validate_workspace_paths(config, plan)
         for relative in (".dyro/tasks", ".dyro/lines", ".dyro/hotfixes", ".dyro/changes"):
             (plan.root / relative).mkdir(parents=True, exist_ok=True)
+        from .instructions import seed_workspace_overlay
+
+        seed_workspace_overlay(plan.root)
         for repository_id, repository in plan.document.blueprint.repositories.items():
             _clone_anchor(
                 plan.root / repository.path,

--- a/src/dyro/cli.py
+++ b/src/dyro/cli.py
@@ -680,6 +680,9 @@ def cmd_init(args: argparse.Namespace) -> None:
     atomic_write_text(config_file, content)
     for relative in (".dyro/tasks", ".dyro/lines", ".dyro/hotfixes", ".dyro/changes"):
         (root / relative).mkdir(parents=True, exist_ok=True)
+    from .instructions import seed_workspace_overlay
+
+    seed_workspace_overlay(root)
     print(f"已初始化 {root}")
     if args.discover:
         print(
@@ -1235,6 +1238,9 @@ def _apply_setup_plan(
     registration = _register_setup_workspace(
         config, register=register, make_default=make_default
     )
+    from .instructions import seed_workspace_overlay
+
+    seed_workspace_overlay(config.root)
     if plan.needs_bootstrap:
         for message in bootstrap(config, branch=plan.default_base):
             print(message)
@@ -1308,6 +1314,9 @@ def _interactive_setup(args: argparse.Namespace) -> None:
             register=registration is not None,
             make_default=preferences.make_default_workspace,
         )
+        from .instructions import seed_workspace_overlay
+
+        seed_workspace_overlay(config.root)
         skill_outcome = _apply_setup_personal_preferences(preferences)
         _print_setup_completion(
             config, record, preferences, skill_outcome=skill_outcome
@@ -1454,6 +1463,9 @@ def _non_interactive_setup(args: argparse.Namespace) -> None:
         _render_setup_registration_plan(registration)
     if not args.dry_run:
         _ensure_state_directories(config.root)
+        from .instructions import seed_workspace_overlay
+
+        seed_workspace_overlay(config.root)
         registered = _register_setup_workspace(
             config,
             register=not args.no_register,
@@ -2116,6 +2128,27 @@ def cmd_host_doctor(args: argparse.Namespace) -> None:
         print(render_doctor_text(report), end="")
     if not report.ok:
         raise DyroError("宿主投影过期或被手改")
+
+
+def cmd_host_seed(args: argparse.Namespace) -> None:
+    from .instructions import seed_configured_overlays
+
+    config = _config(args)
+    workspace, lines = seed_configured_overlays(
+        config, force=args.force, dry_run=args.dry_run
+    )
+    prefix = "DRY RUN: " if args.dry_run else ""
+    if workspace.written:
+        print(f"{prefix}已写入 overlay {', '.join(workspace.written)}")
+    if workspace.skipped:
+        print(f"{prefix}已跳过 overlay {', '.join(workspace.skipped)}（已存在）")
+    if not workspace.written and not workspace.skipped:
+        print(f"{prefix}overlay 未写入说明文件")
+    for line_id, outcome in lines:
+        if outcome.written:
+            print(f"{prefix}已写入开发线 {line_id} {', '.join(outcome.written)}")
+        if outcome.skipped and args.force:
+            print(f"{prefix}已跳过开发线 {line_id} {', '.join(outcome.skipped)}")
 
 
 def cmd_tool_list(args: argparse.Namespace) -> None:
@@ -4399,6 +4432,16 @@ def build_parser() -> argparse.ArgumentParser:
     )
     host_doctor.add_argument("--format", choices=("text", "json"), default="text")
     host_doctor.set_defaults(func=cmd_host_doctor)
+    host_seed = host_sub.add_parser(
+        "seed",
+        help="在 overlay 根写入缺失的 AGENTS.md 与 CLAUDE.md；已有文件不覆盖",
+    )
+    host_seed.add_argument(
+        "--force",
+        action="store_true",
+        help="覆盖已有 AGENTS.md/CLAUDE.md；必须显式指定",
+    )
+    host_seed.set_defaults(func=cmd_host_seed)
 
     agent_test = agent_sub.add_parser(
         "test", help="仅检查 adapter 可执行文件是否可用，不启动 Agent"

--- a/src/dyro/cli.py
+++ b/src/dyro/cli.py
@@ -238,7 +238,10 @@ from .workspace import (
     get_line,
     is_missing_origin_finding,
     list_lines,
+    merge_line,
+    spawn_line,
     status_rows,
+    sync_line,
 )
 
 
@@ -2632,6 +2635,7 @@ def cmd_line_list(args: argparse.Namespace) -> None:
                 {
                     "kind": line.kind,
                     "id": line.id,
+                    "parent": line.parent,
                     "branch": line.branch,
                     "base": line.base,
                     "repositories": [
@@ -2650,14 +2654,14 @@ def cmd_line_list(args: argparse.Namespace) -> None:
     if not lines:
         print("暂无已登记开发线")
         return
-    print(f"{'KIND':8} {'ID':28} {'BRANCH':30} {'BASE':24} REPOSITORIES")
+    print(f"{'KIND':8} {'ID':28} {'PARENT':24} {'BRANCH':30} {'BASE':24} REPOSITORIES")
     for line in lines:
         repositories = ", ".join(
             f"{repo_id}@{line.base_for(repo_id)}[{line.storage_for(repo_id)}]"
             for repo_id in line.repositories
         )
         print(
-            f"{line.kind:8} {line.id:28} {line.branch:30} {line.base:24} {repositories}"
+            f"{line.kind:8} {line.id:28} {(line.parent or '-'):24} {line.branch:30} {line.base:24} {repositories}"
         )
 
 
@@ -2695,6 +2699,51 @@ def _create_line(args: argparse.Namespace, kind: str) -> None:
 
 def cmd_line_create(args: argparse.Namespace) -> None:
     _create_line(args, "line")
+
+
+def cmd_line_spawn(args: argparse.Namespace) -> None:
+    config = _config(args)
+    _require_yes(args, "派生子开发线")
+    line = spawn_line(
+        config,
+        args.parent,
+        args.child,
+        repositories=_repositories(args.repos),
+        dry_run=args.dry_run,
+    )
+    bases = ", ".join(
+        f"{repo_id}={line.base_for(repo_id)}" for repo_id in line.repositories
+    )
+    print(
+        f"{'DRY RUN: ' if args.dry_run else ''}已从 {line.parent} 派生 {line.kind} {line.id}，"
+        f"分支 {line.branch}，仓库基线：{bases}"
+    )
+
+
+def cmd_line_merge(args: argparse.Namespace) -> None:
+    _require_yes(args, "合并子开发线")
+    config = _config(args)
+    merge_line(
+        config,
+        args.child,
+        args.parent,
+        push=args.push,
+        dry_run=args.dry_run,
+    )
+    print(
+        f"{'DRY RUN: ' if args.dry_run else ''}已将 {args.child} 合并入 {args.parent}"
+        + (" 并推送" if args.push else "")
+    )
+
+
+def cmd_line_sync(args: argparse.Namespace) -> None:
+    _require_yes(args, "同步父开发线")
+    config = _config(args)
+    sync_line(config, args.child, push=args.push, dry_run=args.dry_run)
+    print(
+        f"{'DRY RUN: ' if args.dry_run else ''}已将父线同步到 {args.child}"
+        + (" 并推送" if args.push else "")
+    )
 
 
 def cmd_hotfix_create(args: argparse.Namespace) -> None:
@@ -4636,6 +4685,47 @@ def build_parser() -> argparse.ArgumentParser:
     )
     line_create.add_argument("--yes", action="store_true")
     line_create.set_defaults(func=cmd_line_create)
+    line_spawn = line_sub.add_parser(
+        "spawn", help="从父开发线创建子线（不是任务）；不 fetch、不 push"
+    )
+    line_spawn.add_argument("parent", help="父开发线 ID")
+    line_spawn.add_argument(
+        "child", help="子线短名或完整 ID；短名默认写成 {父ID}_{短名}"
+    )
+    line_spawn.add_argument(
+        "--repos",
+        help="逗号分隔的仓库子集；默认继承父线全部仓库",
+    )
+    line_spawn.add_argument("--yes", action="store_true")
+    line_spawn.set_defaults(func=cmd_line_spawn)
+    line_merge = line_sub.add_parser(
+        "merge", help="将子线 --no-ff 合并回其直接父开发线；不删除子线"
+    )
+    line_merge.add_argument("child", help="子开发线 ID")
+    line_merge.add_argument(
+        "--into",
+        dest="parent",
+        required=True,
+        help="父开发线 ID；必须是该子线的直接父线",
+    )
+    line_merge.add_argument(
+        "--push",
+        action="store_true",
+        help="合并后推送父线分支；需 policy.allow_push",
+    )
+    line_merge.add_argument("--yes", action="store_true")
+    line_merge.set_defaults(func=cmd_line_merge)
+    line_sync = line_sub.add_parser(
+        "sync", help="将父线提交 --no-ff 合并进子线；无线父线则拒绝"
+    )
+    line_sync.add_argument("child", help="子开发线 ID")
+    line_sync.add_argument(
+        "--push",
+        action="store_true",
+        help="同步后推送子线分支；需 policy.allow_push",
+    )
+    line_sync.add_argument("--yes", action="store_true")
+    line_sync.set_defaults(func=cmd_line_sync)
 
     hotfix = sub.add_parser("hotfix", help="生产 Hotfix 开发线")
     hotfix_sub = hotfix.add_subparsers(dest="hotfix_command", required=True)

--- a/src/dyro/cli.py
+++ b/src/dyro/cli.py
@@ -4441,6 +4441,13 @@ def build_parser() -> argparse.ArgumentParser:
         action="store_true",
         help="覆盖已有 AGENTS.md/CLAUDE.md；必须显式指定",
     )
+    host_seed.add_argument(
+        "--dry-run",
+        dest="dry_run",
+        action="store_true",
+        default=argparse.SUPPRESS,
+        help="只打印将写入的路径，不落盘（兼容全局 --dry-run）",
+    )
     host_seed.set_defaults(func=cmd_host_seed)
 
     agent_test = agent_sub.add_parser(
@@ -4739,6 +4746,13 @@ def build_parser() -> argparse.ArgumentParser:
         "--repos",
         help="逗号分隔的仓库子集；默认继承父线全部仓库",
     )
+    line_spawn.add_argument(
+        "--dry-run",
+        dest="dry_run",
+        action="store_true",
+        default=argparse.SUPPRESS,
+        help="只打印计划，不创建子线或工作树（兼容全局 --dry-run）",
+    )
     line_spawn.add_argument("--yes", action="store_true")
     line_spawn.set_defaults(func=cmd_line_spawn)
     line_merge = line_sub.add_parser(
@@ -4756,6 +4770,13 @@ def build_parser() -> argparse.ArgumentParser:
         action="store_true",
         help="合并后推送父线分支；需 policy.allow_push",
     )
+    line_merge.add_argument(
+        "--dry-run",
+        dest="dry_run",
+        action="store_true",
+        default=argparse.SUPPRESS,
+        help="探测合入但不提交（兼容全局 --dry-run）",
+    )
     line_merge.add_argument("--yes", action="store_true")
     line_merge.set_defaults(func=cmd_line_merge)
     line_sync = line_sub.add_parser(
@@ -4766,6 +4787,13 @@ def build_parser() -> argparse.ArgumentParser:
         "--push",
         action="store_true",
         help="同步后推送子线分支；需 policy.allow_push",
+    )
+    line_sync.add_argument(
+        "--dry-run",
+        dest="dry_run",
+        action="store_true",
+        default=argparse.SUPPRESS,
+        help="探测同步但不提交（兼容全局 --dry-run）",
     )
     line_sync.add_argument("--yes", action="store_true")
     line_sync.set_defaults(func=cmd_line_sync)

--- a/src/dyro/instructions.py
+++ b/src/dyro/instructions.py
@@ -1,0 +1,161 @@
+"""Thin overlay instruction files for coding harnesses.
+
+These markdown files are pointers, not policy. Host-compiled SKILL.md and
+``dyro next`` remain the gate. They live on the Dyro overlay (next to
+``dyro.toml``, or at ``versions/<line>/``), never inside product Git checkouts.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+from .errors import DyroError
+from .process import git_read
+from .state import atomic_write_text
+
+
+INSTRUCTION_NAMES = ("AGENTS.md", "CLAUDE.md")
+SEED_COMMAND = "dyro host seed"
+
+
+def render_workspace_overlay() -> str:
+    return """# Dyro overlay
+
+这是 Dyro 工作区 overlay（与 `dyro.toml` 同级），不是产品 Git 仓库。
+
+本文件不是权威。权威入口是：
+- 宿主编译的 SKILL.md（`dyro host compile`）
+- `dyro next`
+
+不要绕过门禁做 `git merge` / `git push`。合入与推送只走 `dyro`（例如 `dyro task merge`、`dyro line merge`；push 还需 `--push` 且 `policy.allow_push`）。
+
+下一步：运行 `dyro next`。
+"""
+
+
+def render_line_persona(*, line_id: str, branch: str) -> str:
+    remote = f"origin/{branch}"
+    return f"""# Dyro 开发线 {line_id}
+
+继承工作区 overlay 约束：这里仍不是产品仓库。权威是 SKILL.md 与 `dyro next`。不要绕过门禁 merge/push。
+
+当前线：
+- id：{line_id}
+- 分支：{branch}
+- 必须跟踪 `{remote}`
+
+下一步：运行 `dyro next`。
+"""
+
+
+@dataclass(frozen=True)
+class SeedOutcome:
+    written: tuple[str, ...]
+    skipped: tuple[str, ...]
+
+
+def missing_workspace_overlay_files(root: Path) -> tuple[str, ...]:
+    return tuple(name for name in INSTRUCTION_NAMES if not (root / name).is_file())
+
+
+def overlay_instruction_warning(root: Path) -> str | None:
+    missing = missing_workspace_overlay_files(root)
+    if not missing:
+        return None
+    joined = " 与 ".join(missing)
+    return f"WARN overlay 缺少 {joined}；运行 {SEED_COMMAND}"
+
+
+def _inside_git_checkout(path: Path) -> bool:
+    result = git_read(path, "rev-parse", "--is-inside-work-tree")
+    return result.code == 0 and result.stdout.strip() == "true"
+
+
+def seed_overlay_files(
+    directory: Path,
+    body: str,
+    *,
+    force: bool = False,
+    dry_run: bool = False,
+    refuse_git: bool = False,
+) -> SeedOutcome:
+    """Write AGENTS.md and CLAUDE.md with the same body. Never overwrite unless force."""
+    if _inside_git_checkout(directory):
+        if refuse_git:
+            raise DyroError(
+                "目标目录是 Git 工作区，拒绝写入 AGENTS.md/CLAUDE.md"
+            )
+        return SeedOutcome((), INSTRUCTION_NAMES)
+    written: list[str] = []
+    skipped: list[str] = []
+    for name in INSTRUCTION_NAMES:
+        path = directory / name
+        if path.exists() and not force:
+            skipped.append(name)
+            continue
+        if path.exists() and not path.is_file():
+            raise DyroError(f"无法写入 overlay 说明：{name} 已存在且不是普通文件")
+        if not dry_run:
+            directory.mkdir(parents=True, exist_ok=True)
+            atomic_write_text(path, body if body.endswith("\n") else body + "\n")
+        written.append(name)
+    return SeedOutcome(tuple(written), tuple(skipped))
+
+
+def seed_workspace_overlay(
+    root: Path,
+    *,
+    force: bool = False,
+    dry_run: bool = False,
+    refuse_git: bool = False,
+) -> SeedOutcome:
+    return seed_overlay_files(
+        root,
+        render_workspace_overlay(),
+        force=force,
+        dry_run=dry_run,
+        refuse_git=refuse_git,
+    )
+
+
+def seed_line_overlay(
+    overlay: Path,
+    *,
+    line_id: str,
+    branch: str,
+    force: bool = False,
+    dry_run: bool = False,
+) -> SeedOutcome:
+    return seed_overlay_files(
+        overlay,
+        render_line_persona(line_id=line_id, branch=branch),
+        force=force,
+        dry_run=dry_run,
+        refuse_git=False,
+    )
+
+
+def seed_configured_overlays(
+    config,
+    *,
+    force: bool = False,
+    dry_run: bool = False,
+) -> tuple[SeedOutcome, tuple[tuple[str, SeedOutcome], ...]]:
+    """Seed workspace overlay files and missing line personas. Existing files stay."""
+    from .workspace import line_root, list_lines
+
+    workspace = seed_workspace_overlay(
+        config.root, force=force, dry_run=dry_run, refuse_git=True
+    )
+    lines: list[tuple[str, SeedOutcome]] = []
+    for line in list_lines(config):
+        outcome = seed_line_overlay(
+            line_root(config, line),
+            line_id=line.id,
+            branch=line.branch,
+            force=force,
+            dry_run=dry_run,
+        )
+        lines.append((line.id, outcome))
+    return workspace, tuple(lines)

--- a/src/dyro/tasks.py
+++ b/src/dyro/tasks.py
@@ -50,7 +50,7 @@ from .provenance import (
     validate_review_binding,
 )
 from .state import append_text, atomic_write_bytes, atomic_write_text, exclusive_lock
-from .workspace import Line, get_line, line_repository_path, repository_path
+from .workspace import Line, get_line, line_repository_path, merge_lock_path, repository_path
 
 
 STATUSES = (
@@ -567,8 +567,7 @@ def _review_lock_path(task: Task) -> Path:
 
 
 def _merge_lock_path(config: Config, line_id: str) -> Path:
-    validate_id(line_id, "开发线 ID")
-    return config.root / ".dyro" / "lines" / f"{line_id}.merge.lock"
+    return merge_lock_path(config, line_id)
 
 
 def _claim(task: Task) -> dict[str, object] | None:
@@ -2880,7 +2879,7 @@ def _merge_task_repositories(
 ) -> None:
     # Serialize merges into the same delivery line across concurrent dyro processes.
     with exclusive_lock(
-        _merge_lock_path(config, task.line), timeout_seconds=MERGE_LOCK_TIMEOUT_SECONDS
+        merge_lock_path(config, task.line), timeout_seconds=MERGE_LOCK_TIMEOUT_SECONDS
     ):
         _merge_task_repositories_locked(config, task, push=push, dry_run=dry_run)
 

--- a/src/dyro/workspace.py
+++ b/src/dyro/workspace.py
@@ -616,6 +616,10 @@ def create_line(
                 detail = "; ".join(recovery_failures)
                 raise DyroError(f"{exc}\n自动清理未完全成功：{detail}") from exc
         raise
+    if not dry_run:
+        from .instructions import seed_line_overlay
+
+        seed_line_overlay(line_root(config, line), line_id=line.id, branch=line.branch)
     return line
 
 
@@ -1185,6 +1189,11 @@ def doctor(config: Config, *, read_budget: ReadBudget | None = None) -> list[str
         findings.append(f"FAIL external Profile requires {requirement}")
     root_git = _is_git_repo(config.root, read_budget=read_budget)
     findings.append(("WARN" if root_git else "PASS") + " workspace root " + ("is a Git repository" if root_git else "is not a Git repository"))
+    from .instructions import overlay_instruction_warning
+
+    overlay_warning = overlay_instruction_warning(config.root)
+    if overlay_warning:
+        findings.append(overlay_warning)
     for repo_id in sorted(config.repositories):
         anchor = repository_path(config, repo_id)
         if _is_git_repo(anchor, read_budget=read_budget):

--- a/src/dyro/workspace.py
+++ b/src/dyro/workspace.py
@@ -1176,9 +1176,9 @@ def status_rows(
                 branch, head, upstream, dirty = _short_status(
                     path, read_budget=read_budget
                 )
-            rows.append((_line_status_scope(line), repo_id, branch, head, upstream, dirty))
-        else:
-            rows.append((_line_status_scope(line), repo_id, "MISSING", "-", "-", -1))
+                rows.append((_line_status_scope(line), repo_id, branch, head, upstream, dirty))
+            else:
+                rows.append((_line_status_scope(line), repo_id, "MISSING", "-", "-", -1))
     return rows
 
 

--- a/src/dyro/workspace.py
+++ b/src/dyro/workspace.py
@@ -17,10 +17,12 @@ from .read_limits import (
     ReadLimitError,
     bounded_directory_names,
 )
-from .state import atomic_write_text
+from .state import atomic_write_text, exclusive_lock
 
 
 STORAGE_MODES = frozenset({"linked-worktree", "anchor-reference"})
+LINE_MANIFEST_SCHEMAS = frozenset({1, 2, 3})
+MERGE_LOCK_TIMEOUT_SECONDS = 1800.0
 
 
 @dataclass(frozen=True)
@@ -32,6 +34,7 @@ class Line:
     repositories: tuple[str, ...]
     repository_bases: Mapping[str, str] = field(default_factory=dict)
     storage_modes: Mapping[str, str] = field(default_factory=dict)
+    parent: str = ""
 
     def base_for(self, repo_id: str) -> str:
         return self.repository_bases.get(repo_id, self.base)
@@ -65,14 +68,17 @@ def _write_line(config: Config, line: Line, *, dry_run: bool = False) -> None:
     repo_items = ", ".join(_toml_string(repo_id) for repo_id in line.repositories)
     bases = tuple((repo_id, line.base_for(repo_id)) for repo_id in line.repositories if line.base_for(repo_id) != line.base)
     storage = tuple((repo_id, line.storage_for(repo_id)) for repo_id in line.repositories if line.storage_for(repo_id) != "linked-worktree")
+    schema_version = 3 if line.parent else 2
     chunks = [
-        "schema_version = 2",
+        f"schema_version = {schema_version}",
         f"id = {_toml_string(line.id)}",
         f"kind = {_toml_string(line.kind)}",
         f"branch = {_toml_string(line.branch)}",
         f"base = {_toml_string(line.base)}",
-        f"repositories = [{repo_items}]",
     ]
+    if line.parent:
+        chunks.append(f"parent = {_toml_string(line.parent)}")
+    chunks.append(f"repositories = [{repo_items}]")
     if bases:
         chunks.extend(("", "[repository_bases]"))
         chunks.extend(f"{_toml_key(repo_id)} = {_toml_string(base)}" for repo_id, base in bases)
@@ -90,7 +96,7 @@ def _parse_line_content(path: Path, content: bytes) -> Line:
         raw = tomllib.loads(content.decode("utf-8"))
     except (UnicodeError, tomllib.TOMLDecodeError, RecursionError) as exc:
         raise ValidationError(f"开发线清单格式错误：{path}: {exc}") from exc
-    if raw.get("schema_version") not in (1, 2):
+    if raw.get("schema_version") not in LINE_MANIFEST_SCHEMAS:
         raise ValidationError(f"不支持的开发线清单版本：{path}")
     line_id = validate_id(str(raw.get("id", "")), "开发线 ID")
     kind = str(raw.get("kind", ""))
@@ -119,7 +125,21 @@ def _parse_line_content(path: Path, content: bytes) -> Line:
         if value not in STORAGE_MODES:
             raise ValidationError(f"开发线清单存储方式无效：{repo_id}={value!r}")
         storage_modes[str(repo_id)] = value
-    return Line(line_id, kind, branch, base, repositories, repository_bases, storage_modes)
+    parent = _parse_parent_field(raw.get("parent", ""), line_id, path)
+    return Line(
+        line_id, kind, branch, base, repositories, repository_bases, storage_modes, parent
+    )
+
+
+def _parse_parent_field(raw: object, line_id: str, path: Path) -> str:
+    if raw in ("", None):
+        return ""
+    if not isinstance(raw, str) or not raw.strip():
+        raise ValidationError(f"开发线清单 parent 必须是开发线 ID：{path}")
+    parent = validate_id(raw.strip(), "父开发线 ID")
+    if parent == line_id:
+        raise ValidationError(f"开发线不能以自身为父线：{path}")
+    return parent
 
 
 def _parse_line(path: Path) -> Line:
@@ -435,6 +455,7 @@ def _build_line(
     repository_bases: Mapping[str, str] | None = None,
     storage_modes: Mapping[str, str] | None = None,
     kind: str = "line",
+    parent: str = "",
 ) -> Line:
     """Validate line arguments and turn them into one immutable creation plan."""
     validate_id(line_id, "开发线 ID")
@@ -462,7 +483,10 @@ def _build_line(
     for repo_id, storage_mode in storage_overrides.items():
         if storage_mode not in STORAGE_MODES:
             raise ValidationError(f"{repo_id} 的存储方式必须是：{', '.join(sorted(STORAGE_MODES))}")
-    return Line(line_id, kind, branch, base, selected, base_overrides, storage_overrides)
+    parent_id = _validate_parent_link(config, line_id, parent)
+    return Line(
+        line_id, kind, branch, base, selected, base_overrides, storage_overrides, parent_id
+    )
 
 
 def _plan_line_creation(
@@ -517,6 +541,7 @@ def preflight_line(
     repository_bases: Mapping[str, str] | None = None,
     storage_modes: Mapping[str, str] | None = None,
     kind: str = "line",
+    parent: str = "",
 ) -> Line:
     """Verify that a line can be created without changing Git state.
 
@@ -533,6 +558,7 @@ def preflight_line(
         repository_bases=repository_bases,
         storage_modes=storage_modes,
         kind=kind,
+        parent=parent,
     )
     _plan_line_creation(config, line)
     return line
@@ -548,6 +574,7 @@ def create_line(
     repository_bases: Mapping[str, str] | None = None,
     storage_modes: Mapping[str, str] | None = None,
     kind: str = "line",
+    parent: str = "",
     dry_run: bool = False,
 ) -> Line:
     """Create isolated linked worktrees from configured repository anchors."""
@@ -560,6 +587,7 @@ def create_line(
         repository_bases=repository_bases,
         storage_modes=storage_modes,
         kind=kind,
+        parent=parent,
     )
     planned = _plan_line_creation(config, line)
 
@@ -589,6 +617,490 @@ def create_line(
                 raise DyroError(f"{exc}\n自动清理未完全成功：{detail}") from exc
         raise
     return line
+
+
+def merge_lock_path(config: Config, line_id: str) -> Path:
+    validate_id(line_id, "开发线 ID")
+    return config.root / ".dyro" / "lines" / f"{line_id}.merge.lock"
+
+
+def _validate_parent_link(config: Config, child_id: str, parent: str) -> str:
+    if not parent:
+        return ""
+    parent_id = validate_id(parent, "父开发线 ID")
+    if parent_id == child_id:
+        raise ValidationError(f"开发线不能以自身为父线：{child_id}")
+    ancestor = get_line(config, parent_id)
+    seen = {child_id, parent_id}
+    current = ancestor.parent
+    while current:
+        if current == child_id or current in seen:
+            raise ValidationError(f"开发线父子关系不能成环：{child_id} -> {parent_id}")
+        seen.add(current)
+        current = get_line(config, current).parent
+    return parent_id
+
+
+def resolve_spawn_child_id(parent_id: str, child: str) -> str:
+    validate_id(parent_id, "父开发线 ID")
+    token = child.strip() if isinstance(child, str) else ""
+    if not token:
+        raise ValidationError("子开发线 ID 不能为空")
+    candidate = token if token.startswith(parent_id) else f"{parent_id}_{token}"
+    return validate_id(candidate, "开发线 ID")
+
+
+def _spawn_base_for(config: Config, parent: Line, repo_id: str) -> str:
+    anchor = repository_path(config, repo_id)
+    remote = _expected_remote_branch(parent.branch)
+    if _ref_exists(anchor, f"refs/remotes/{remote}"):
+        return remote
+    if _rev_parse(anchor, parent.branch):
+        return parent.branch
+    raise DyroError(
+        f"{repo_id} 找不到父线分支 {parent.branch} 或其 origin 跟踪引用"
+    )
+
+
+def spawn_line(
+    config: Config,
+    parent_id: str,
+    child: str,
+    *,
+    repositories: Iterable[str] | None = None,
+    dry_run: bool = False,
+) -> Line:
+    """Create a child line from an existing parent line. No fetch, no push."""
+    parent = get_line(config, parent_id)
+    child_id = resolve_spawn_child_id(parent.id, child)
+    if repositories is None:
+        selected = parent.repositories
+    else:
+        selected = tuple(repositories)
+        if not selected:
+            raise ValidationError("至少选择一个仓库")
+        extra = [repo_id for repo_id in selected if repo_id not in parent.repositories]
+        if extra:
+            raise ValidationError(
+                f"子线仓库必须是父线 {parent.id} 仓库的子集：{', '.join(extra)}"
+            )
+    bases = {repo_id: _spawn_base_for(config, parent, repo_id) for repo_id in selected}
+    default_base = bases[selected[0]]
+    repository_bases = {
+        repo_id: base for repo_id, base in bases.items() if base != default_base
+    }
+    storage_modes = {
+        repo_id: parent.storage_for(repo_id)
+        for repo_id in selected
+        if parent.storage_for(repo_id) != "linked-worktree"
+    }
+    return create_line(
+        config,
+        line_id=child_id,
+        branch=f"feat/{child_id}",
+        base=default_base,
+        repositories=selected,
+        repository_bases=repository_bases,
+        storage_modes=storage_modes,
+        kind="line",
+        parent=parent.id,
+        dry_run=dry_run,
+    )
+
+
+@dataclass(frozen=True)
+class _LineMergePlan:
+    repository: str
+    target: Path
+    source_head: str
+    original_head: str
+
+
+def _line_ledger(config: Config, subject_id: str, phase: str, **fields: object) -> None:
+    from .tasks import ledger
+
+    ledger(config, subject_id, phase, **fields)
+
+
+def _require_push_allowed(config: Config, *, push: bool) -> None:
+    if push and not config.policy.allow_push:
+        raise DyroError(
+            "当前 Profile 禁止 push；请在 dyro.toml 的 policy.allow_push 显式开启"
+        )
+
+
+def _require_line_worktrees(
+    config: Config, line: Line, *, clean: bool, label: str
+) -> None:
+    for repo_id in line.repositories:
+        target = line_repository_path(config, line, repo_id)
+        inside = git(target, "rev-parse", "--is-inside-work-tree")
+        if inside.code != 0 or inside.stdout.strip() != "true":
+            raise DyroError(f"{label} worktree 不存在或不是 Git：{target}")
+        current = require_ok(
+            git(target, "branch", "--show-current"), f"读取 {repo_id} 分支"
+        ).stdout.strip()
+        if current != line.branch:
+            raise DyroError(
+                f"{label}仓库分支错误：{target} 当前 {current or 'DETACHED'}，期望 {line.branch}"
+            )
+        if clean:
+            dirty = require_ok(
+                git(target, "status", "--porcelain=v1", "-uall"), f"读取 {repo_id} 状态"
+            ).stdout.strip()
+            if dirty:
+                raise DyroError(f"{label}仓库不干净，拒绝合并：{target}")
+
+
+def _child_blocking_doctor_findings(config: Config, child: Line) -> list[str]:
+    prefix = f"FAIL {child.kind}:{child.id}/"
+    return [
+        item
+        for item in doctor(config)
+        if item.startswith(prefix) and not is_missing_origin_finding(item)
+    ]
+
+
+def _prepare_line_merge_plans(
+    config: Config,
+    *,
+    target: Line,
+    source: Line,
+    repositories: tuple[str, ...],
+    push: bool,
+    dry_run: bool,
+) -> tuple[_LineMergePlan, ...]:
+    missing = [repo_id for repo_id in repositories if repo_id not in target.repositories]
+    if missing:
+        raise DyroError(
+            f"仓库不在目标开发线 {target.id} 上：{', '.join(missing)}"
+        )
+    missing_source = [
+        repo_id for repo_id in repositories if repo_id not in source.repositories
+    ]
+    if missing_source:
+        raise DyroError(
+            f"仓库不在源开发线 {source.id} 上：{', '.join(missing_source)}"
+        )
+    plans: list[_LineMergePlan] = []
+    for repo_id in repositories:
+        target_path = line_repository_path(config, target, repo_id)
+        source_path = line_repository_path(config, source, repo_id)
+        source_head = require_ok(
+            git(source_path, "rev-parse", "HEAD"), f"读取 {repo_id} 源 HEAD"
+        ).stdout.strip()
+        original_head = require_ok(
+            git(target_path, "rev-parse", "HEAD"), f"读取 {repo_id} 目标 HEAD"
+        ).stdout.strip()
+        plans.append(_LineMergePlan(repo_id, target_path, source_head, original_head))
+    if push:
+        for plan in plans:
+            require_ok(
+                git(
+                    plan.target,
+                    "push",
+                    "--dry-run",
+                    "origin",
+                    target.branch,
+                    dry_run=dry_run,
+                ),
+                f"预检推送 {plan.repository}",
+            )
+    return tuple(plans)
+
+
+def _rollback_line_merges(
+    plans: Iterable[_LineMergePlan], committed_heads: dict[str, str]
+) -> list[str]:
+    failures: list[str] = []
+    for plan in reversed(tuple(plans)):
+        merge_head = git(plan.target, "rev-parse", "--verify", "-q", "MERGE_HEAD")
+        if merge_head.code == 0:
+            result = git(plan.target, "merge", "--abort")
+        else:
+            committed_head = committed_heads.get(plan.repository)
+            if committed_head is None:
+                continue
+            current = git(plan.target, "rev-parse", "HEAD")
+            if current.code != 0:
+                failures.append(f"{plan.repository}: cannot read HEAD during rollback")
+                continue
+            if current.stdout.strip() != committed_head:
+                failures.append(
+                    f"{plan.repository}: HEAD changed concurrently; manual recovery required"
+                )
+                continue
+            result = git(plan.target, "reset", "--keep", plan.original_head)
+        if result.code != 0:
+            failures.append(
+                f"{plan.repository}: {result.stdout.strip() or 'rollback failed'}"
+            )
+    return failures
+
+
+def _abort_line_merge_probes(plans: Iterable[_LineMergePlan]) -> list[str]:
+    return _rollback_line_merges(plans, {})
+
+
+def _record_line_merge_changeset(
+    config: Config, line: Line, repositories: tuple[str, ...]
+) -> str:
+    from datetime import datetime, timezone
+
+    from .changesets import create_changeset
+
+    stamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    changeset_id = f"merge_{line.id}_{stamp}"
+    if len(changeset_id) > 80:
+        changeset_id = f"merge_{stamp}"
+    try:
+        create_changeset(
+            config,
+            changeset_id=changeset_id,
+            line_id=line.id,
+            repositories=repositories,
+        )
+    except DyroError:
+        return ""
+    return changeset_id
+
+
+def _merge_line_repositories(
+    config: Config,
+    *,
+    target: Line,
+    source: Line,
+    repositories: tuple[str, ...],
+    lock_line_id: str,
+    message: str,
+    phase: str,
+    push: bool,
+    dry_run: bool,
+    extra_ledger: Mapping[str, object] | None = None,
+) -> None:
+    with exclusive_lock(
+        merge_lock_path(config, lock_line_id),
+        timeout_seconds=MERGE_LOCK_TIMEOUT_SECONDS,
+    ):
+        _merge_line_repositories_locked(
+            config,
+            target=target,
+            source=source,
+            repositories=repositories,
+            message=message,
+            phase=phase,
+            push=push,
+            dry_run=dry_run,
+            extra_ledger=extra_ledger,
+        )
+
+
+def _merge_line_repositories_locked(
+    config: Config,
+    *,
+    target: Line,
+    source: Line,
+    repositories: tuple[str, ...],
+    message: str,
+    phase: str,
+    push: bool,
+    dry_run: bool,
+    extra_ledger: Mapping[str, object] | None = None,
+) -> None:
+    plans = _prepare_line_merge_plans(
+        config,
+        target=target,
+        source=source,
+        repositories=repositories,
+        push=push,
+        dry_run=dry_run,
+    )
+    fields = dict(extra_ledger or {})
+    probed: list[_LineMergePlan] = []
+    try:
+        for plan in plans:
+            result = git(
+                plan.target,
+                "merge",
+                "--no-ff",
+                "--no-commit",
+                plan.source_head,
+                timeout=300,
+            )
+            probed.append(plan)
+            if result.code != 0:
+                raise DyroError(
+                    f"预检合并 {plan.repository} 存在冲突，拒绝合并"
+                    + (f"\n{result.stdout.strip()}" if result.stdout.strip() else "")
+                )
+        if dry_run:
+            recovery_failures = _abort_line_merge_probes(probed)
+            if recovery_failures:
+                raise DyroError(
+                    "预检合并后清理未完全成功：" + "; ".join(recovery_failures)
+                )
+            return
+    except DyroError as exc:
+        recovery_failures = _abort_line_merge_probes(probed)
+        if not dry_run:
+            _line_ledger(
+                config,
+                source.id,
+                f"{phase}_failed",
+                error=str(exc),
+                recovered=not recovery_failures,
+                recovery_failures=recovery_failures,
+                **fields,
+            )
+        if recovery_failures:
+            raise DyroError(
+                f"{exc}\n自动恢复未完全成功：{'; '.join(recovery_failures)}"
+            ) from exc
+        raise
+
+    committed_heads: dict[str, str] = {}
+    try:
+        for plan in plans:
+            if git(plan.target, "rev-parse", "--verify", "-q", "MERGE_HEAD").code == 0:
+                require_ok(
+                    git(plan.target, "commit", "-m", message, timeout=300),
+                    f"提交 {plan.repository} 合并",
+                )
+                committed_heads[plan.repository] = require_ok(
+                    git(plan.target, "rev-parse", "HEAD"),
+                    f"读取 {plan.repository} 合并提交",
+                ).stdout.strip()
+    except DyroError as exc:
+        recovery_failures = _rollback_line_merges(plans, committed_heads)
+        _line_ledger(
+            config,
+            source.id,
+            f"{phase}_failed",
+            error=str(exc),
+            recovered=not recovery_failures,
+            recovery_failures=recovery_failures,
+            **fields,
+        )
+        if recovery_failures:
+            raise DyroError(
+                f"{exc}\n自动恢复未完全成功：{'; '.join(recovery_failures)}"
+            ) from exc
+        raise
+
+    pushed: list[str] = []
+    if push:
+        for plan in plans:
+            result = git(plan.target, "push", "origin", target.branch)
+            if result.code != 0:
+                _line_ledger(
+                    config,
+                    source.id,
+                    "push_failed",
+                    repository=plan.repository,
+                    pushed_repositories=pushed,
+                    error=result.stdout.strip(),
+                    **fields,
+                )
+                raise DyroError(
+                    f"推送 {plan.repository} 失败；本地合并已保留，已推送仓库：{', '.join(pushed) or '-'}"
+                    f"\n{result.stdout.strip()}"
+                )
+            pushed.append(plan.repository)
+
+    changeset_id = ""
+    if not dry_run:
+        changeset_id = _record_line_merge_changeset(config, target, repositories)
+
+    for plan in plans:
+        result_head = require_ok(
+            git(plan.target, "rev-parse", "HEAD"), f"读取 {plan.repository} 合并结果"
+        ).stdout.strip()
+        _line_ledger(
+            config,
+            source.id,
+            phase,
+            repository=plan.repository,
+            branch=target.branch,
+            source_head=plan.source_head,
+            previous_head=plan.original_head,
+            result_head=result_head,
+            pushed=push,
+            changeset_id=changeset_id,
+            **fields,
+        )
+
+
+def merge_line(
+    config: Config,
+    child_id: str,
+    parent_id: str,
+    *,
+    push: bool = False,
+    dry_run: bool = False,
+) -> None:
+    """Merge a child line into its direct parent. One level only."""
+    _require_push_allowed(config, push=push)
+    child = get_line(config, child_id)
+    parent = get_line(config, parent_id)
+    if not child.parent:
+        raise DyroError(f"开发线 {child.id} 没有父线，无法合并")
+    if child.parent != parent.id:
+        raise DyroError(
+            f"只能将子线合并到其直接父线：{child.id} 的父线是 {child.parent}，不是 {parent.id}"
+        )
+    _require_line_worktrees(config, parent, clean=True, label="父开发线")
+    _require_line_worktrees(config, child, clean=False, label="子开发线")
+    blocking = _child_blocking_doctor_findings(config, child)
+    if blocking:
+        raise DyroError(f"子线 {child.id} 未通过 doctor，拒绝合并：{blocking[0]}")
+    _merge_line_repositories(
+        config,
+        target=parent,
+        source=child,
+        repositories=child.repositories,
+        lock_line_id=parent.id,
+        message=f"merge(line): {child.id} -> {parent.id}",
+        phase="line_merge",
+        push=push,
+        dry_run=dry_run,
+        extra_ledger={"parent": parent.id, "child": child.id},
+    )
+
+
+def sync_line(
+    config: Config,
+    child_id: str,
+    *,
+    push: bool = False,
+    dry_run: bool = False,
+) -> None:
+    """Merge parent commits into a child line. Requires a parent."""
+    _require_push_allowed(config, push=push)
+    child = get_line(config, child_id)
+    if not child.parent:
+        raise DyroError(f"开发线 {child.id} 没有父线，无法同步")
+    parent = get_line(config, child.parent)
+    _require_line_worktrees(config, child, clean=True, label="子开发线")
+    _require_line_worktrees(config, parent, clean=False, label="父开发线")
+    _merge_line_repositories(
+        config,
+        target=child,
+        source=parent,
+        repositories=child.repositories,
+        lock_line_id=child.id,
+        message=f"sync(line): {parent.id} -> {child.id}",
+        phase="line_sync",
+        push=push,
+        dry_run=dry_run,
+        extra_ledger={"parent": parent.id, "child": child.id},
+    )
+
+
+def _line_status_scope(line: Line) -> str:
+    scope = f"{line.kind}:{line.id}"
+    if line.parent:
+        return f"{scope} ({line.parent})"
+    return scope
 
 
 def _short_status(
@@ -660,9 +1172,9 @@ def status_rows(
                 branch, head, upstream, dirty = _short_status(
                     path, read_budget=read_budget
                 )
-                rows.append((f"{line.kind}:{line.id}", repo_id, branch, head, upstream, dirty))
-            else:
-                rows.append((f"{line.kind}:{line.id}", repo_id, "MISSING", "-", "-", -1))
+            rows.append((_line_status_scope(line), repo_id, branch, head, upstream, dirty))
+        else:
+            rows.append((_line_status_scope(line), repo_id, "MISSING", "-", "-", -1))
     return rows
 
 

--- a/tests/test_blueprint.py
+++ b/tests/test_blueprint.py
@@ -201,6 +201,18 @@ class BlueprintJoinTests(unittest.TestCase):
             self.assertEqual(branch, "")
             self.assertEqual(head, expected_head)
             self.assertTrue((target / "versions/feature-a" / config.repositories[repo_id].mount).is_dir())
+            self.assertFalse(
+                (
+                    target
+                    / "versions/feature-a"
+                    / config.repositories[repo_id].mount
+                    / "AGENTS.md"
+                ).exists()
+            )
+        self.assertTrue((target / "AGENTS.md").is_file())
+        self.assertTrue((target / "CLAUDE.md").is_file())
+        self.assertTrue((target / "versions/feature-a/AGENTS.md").is_file())
+        self.assertTrue((target / "versions/feature-a/CLAUDE.md").is_file())
 
     def test_join_dry_run_and_validation_do_not_create_target(self) -> None:
         target = self.parent / "preview"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -14,6 +14,7 @@ from dyro.cli import (
     _route_experiment_surface,
     _setup_default_tool,
     _setup_provider_preset,
+    build_parser,
     main,
 )
 from dyro.changesets import get_changeset
@@ -41,6 +42,23 @@ class CliTests(unittest.TestCase):
     def tearDown(self) -> None:
         self.registry_environment.stop()
         self.registry_tmp.cleanup()
+
+    def test_line_family_and_host_seed_accept_trailing_dry_run(self) -> None:
+        parser = build_parser()
+        merge = parser.parse_args(
+            ["line", "merge", "child", "--into", "parent", "--dry-run"]
+        )
+        self.assertTrue(merge.dry_run)
+        spawn = parser.parse_args(["line", "spawn", "parent", "child", "--dry-run"])
+        self.assertTrue(spawn.dry_run)
+        sync = parser.parse_args(["line", "sync", "child", "--dry-run"])
+        self.assertTrue(sync.dry_run)
+        seed = parser.parse_args(["host", "seed", "--dry-run"])
+        self.assertTrue(seed.dry_run)
+        global_merge = parser.parse_args(
+            ["--dry-run", "line", "merge", "child", "--into", "parent"]
+        )
+        self.assertTrue(global_merge.dry_run)
 
     def test_runtime_is_not_an_experiment_surface(self) -> None:
         routed = _route_experiment_surface(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -110,6 +110,8 @@ class CliTests(unittest.TestCase):
             main(["init", str(root), "--name", "demo"])
             self.assertTrue((root / "dyro.toml").exists())
             self.assertTrue((root / ".dyro/tasks").is_dir())
+            self.assertTrue((root / "AGENTS.md").is_file())
+            self.assertTrue((root / "CLAUDE.md").is_file())
             self.assertEqual(load(root).name, "demo")
 
     def test_workspace_list_json_is_structured_and_identifies_the_default(self) -> None:
@@ -210,6 +212,12 @@ class CliTests(unittest.TestCase):
             self.assertTrue((root / ".dyro/tasks").is_dir())
             self.assertEqual(get_line(config, "dev").branch, "feat/dev")
             self.assertTrue((root / "versions/dev/api").is_dir())
+            self.assertTrue((root / "AGENTS.md").is_file())
+            self.assertTrue((root / "CLAUDE.md").is_file())
+            self.assertTrue((root / "versions/dev/AGENTS.md").is_file())
+            self.assertTrue((root / "versions/dev/CLAUDE.md").is_file())
+            self.assertFalse((root / "versions/dev/api/AGENTS.md").exists())
+            self.assertFalse((repository / "AGENTS.md").exists())
 
             registry = load_registry()
             self.assertEqual(registry.default, "demo")

--- a/tests/test_instructions.py
+++ b/tests/test_instructions.py
@@ -1,0 +1,82 @@
+from dyro.config import load
+from dyro.instructions import seed_configured_overlays, seed_workspace_overlay
+from dyro.workspace import (
+    create_line,
+    doctor,
+    is_missing_origin_finding,
+    line_repository_path,
+    line_root,
+)
+
+from .support import WorkspaceCase
+
+
+class OverlayInstructionTests(WorkspaceCase):
+    def test_old_workspace_doctors_with_warn_not_fail_when_overlay_files_missing(
+        self,
+    ) -> None:
+        config = load(self.root)
+        findings = doctor(config)
+        self.assertTrue(
+            any(
+                item.startswith("WARN overlay 缺少") and "AGENTS.md" in item
+                for item in findings
+            ),
+            findings,
+        )
+        self.assertTrue(any("dyro host seed" in item for item in findings), findings)
+        self.assertFalse(any(item.startswith("FAIL") for item in findings), findings)
+        self.assertFalse((self.root / "AGENTS.md").exists())
+        self.assertFalse((self.root / "CLAUDE.md").exists())
+
+    def test_seed_is_idempotent_and_does_not_overwrite_hand_edited_agents(
+        self,
+    ) -> None:
+        first = seed_workspace_overlay(self.root)
+        self.assertEqual(first.written, ("AGENTS.md", "CLAUDE.md"))
+        self.assertEqual(first.skipped, ())
+        edited = "hand-edited overlay\n"
+        (self.root / "AGENTS.md").write_text(edited, encoding="utf-8")
+        second = seed_workspace_overlay(self.root)
+        self.assertEqual(second.written, ())
+        self.assertEqual(second.skipped, ("AGENTS.md", "CLAUDE.md"))
+        self.assertEqual((self.root / "AGENTS.md").read_text(encoding="utf-8"), edited)
+        findings = doctor(load(self.root))
+        self.assertFalse(
+            any(item.startswith("WARN overlay 缺少") for item in findings), findings
+        )
+        self.assertFalse(any(item.startswith("FAIL") for item in findings), findings)
+
+        force = seed_workspace_overlay(self.root, force=True)
+        self.assertEqual(force.written, ("AGENTS.md", "CLAUDE.md"))
+        self.assertIn(
+            "Dyro overlay", (self.root / "AGENTS.md").read_text(encoding="utf-8")
+        )
+        self.assertEqual(
+            (self.root / "AGENTS.md").read_text(encoding="utf-8"),
+            (self.root / "CLAUDE.md").read_text(encoding="utf-8"),
+        )
+
+    def test_host_seed_writes_line_personas_outside_git_worktrees(self) -> None:
+        config = load(self.root)
+        line = create_line(config, line_id="alpha", branch="feat/alpha", base="main")
+        overlay = line_root(config, line)
+        worktree = line_repository_path(config, line, "api")
+        (overlay / "AGENTS.md").write_text("line-hand-edit\n", encoding="utf-8")
+        workspace, lines = seed_configured_overlays(config)
+        self.assertEqual(workspace.written, ("AGENTS.md", "CLAUDE.md"))
+        self.assertEqual(dict(lines)["alpha"].skipped, ("AGENTS.md", "CLAUDE.md"))
+        self.assertEqual(
+            (overlay / "AGENTS.md").read_text(encoding="utf-8"), "line-hand-edit\n"
+        )
+        self.assertFalse((worktree / "AGENTS.md").exists())
+        self.assertFalse((worktree / "CLAUDE.md").exists())
+        self.assertFalse((self.anchor / "AGENTS.md").exists())
+        findings = doctor(load(self.root))
+        failures = [item for item in findings if item.startswith("FAIL")]
+        self.assertTrue(
+            all(is_missing_origin_finding(item) for item in failures), findings
+        )
+        self.assertFalse(
+            any(item.startswith("WARN overlay 缺少") for item in findings), findings
+        )

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -9,11 +9,15 @@ from dyro.process import Result
 from dyro.workspace import (
     create_line,
     doctor,
+    get_line,
     is_missing_origin_finding,
     line_repository_path,
     list_lines,
+    merge_line,
     preflight_line,
+    spawn_line,
     status_rows,
+    sync_line,
 )
 
 from .support import WorkspaceCase, publish_origin_branch, shell
@@ -377,6 +381,181 @@ class WorkspaceTests(WorkspaceCase):
         shell("git", "checkout", "main", cwd=self.anchor)
         findings = doctor(config)
         self.assertTrue(any("expected feat/reuse-anchor" in item for item in findings), findings)
+
+
+def _commit_text(worktree: Path, filename: str, content: str, message: str) -> str:
+    (worktree / filename).write_text(content, encoding="utf-8")
+    shell("git", "add", filename, cwd=worktree)
+    shell("git", "commit", "-m", message, cwd=worktree)
+    return shell_stdout("git", "rev-parse", "HEAD", cwd=worktree)
+
+
+class LineFamilyTests(WorkspaceCase):
+    def _parent_and_child(self, *, parent_id: str = "onboard", child: str = "tryon"):
+        publish_origin_branch(self.anchor, f"feat/{parent_id}")
+        config = load(self.root)
+        parent = create_line(
+            config, line_id=parent_id, branch=f"feat/{parent_id}", base="main"
+        )
+        spawned = spawn_line(config, parent_id, child)
+        return load(self.root), parent, spawned
+
+    def test_spawn_writes_parent_inherited_repos_and_does_not_track_parent(self) -> None:
+        config, parent, child = self._parent_and_child()
+        self.assertEqual(child.id, "onboard_tryon")
+        self.assertEqual(child.parent, "onboard")
+        self.assertEqual(child.repositories, parent.repositories)
+        self.assertEqual(child.base, "origin/feat/onboard")
+        manifest = (config.lines_state_dir / "onboard_tryon.toml").read_text(
+            encoding="utf-8"
+        )
+        self.assertIn("schema_version = 3", manifest)
+        self.assertIn('parent = "onboard"', manifest)
+        worktree = line_repository_path(config, child, "api")
+        upstream = shell_stdout(
+            "git",
+            "rev-parse",
+            "--abbrev-ref",
+            "--symbolic-full-name",
+            "@{upstream}",
+            cwd=worktree,
+            check=False,
+        )
+        self.assertIn(upstream, ("", "-"))
+        self.assertNotEqual(upstream, "origin/feat/onboard")
+        self.assertNotEqual(upstream, "feat/onboard")
+        full = spawn_line(config, "onboard", "onboard_extra")
+        self.assertEqual(full.id, "onboard_extra")
+        self.assertEqual(full.parent, "onboard")
+        listed = {item.id: item.parent for item in list_lines(config, kind="line")}
+        self.assertEqual(listed["onboard"], "")
+        self.assertEqual(listed["onboard_tryon"], "onboard")
+
+    def test_merge_dry_run_conflict_does_not_mutate(self) -> None:
+        config, parent, child = self._parent_and_child()
+        parent_wt = line_repository_path(config, parent, "api")
+        child_wt = line_repository_path(config, child, "api")
+        parent_head = _commit_text(
+            parent_wt, "README.md", "parent-side\n", "feat: parent edit"
+        )
+        child_head = _commit_text(
+            child_wt, "README.md", "child-side\n", "feat: child edit"
+        )
+        parent_status = shell_stdout(
+            "git", "status", "--porcelain=v1", "-uall", cwd=parent_wt
+        )
+        with self.assertRaisesRegex(DyroError, "冲突"):
+            merge_line(config, child.id, parent.id, dry_run=True)
+        self.assertEqual(
+            shell_stdout("git", "rev-parse", "HEAD", cwd=parent_wt), parent_head
+        )
+        self.assertEqual(
+            shell_stdout("git", "rev-parse", "HEAD", cwd=child_wt), child_head
+        )
+        self.assertEqual(
+            shell_stdout("git", "status", "--porcelain=v1", "-uall", cwd=parent_wt),
+            parent_status,
+        )
+        merge_head = subprocess.run(
+            ["git", "rev-parse", "--verify", "-q", "MERGE_HEAD"],
+            cwd=parent_wt,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+        )
+        self.assertNotEqual(merge_head.returncode, 0)
+
+    def test_merge_success_parent_contains_child_commits(self) -> None:
+        config, parent, child = self._parent_and_child()
+        child_wt = line_repository_path(config, child, "api")
+        parent_wt = line_repository_path(config, parent, "api")
+        child_head = _commit_text(
+            child_wt, "child.txt", "from child\n", "feat: child work"
+        )
+        merge_line(config, child.id, parent.id)
+        contained = subprocess.run(
+            ["git", "merge-base", "--is-ancestor", child_head, "HEAD"],
+            cwd=parent_wt,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+        )
+        self.assertEqual(contained.returncode, 0)
+        ledger = config.ledger_file.read_text(encoding="utf-8")
+        self.assertIn('"phase": "line_merge"', ledger)
+
+    def test_merge_rejects_skip_level_missing_parent_dirty_parent_and_wrong_upstream(
+        self,
+    ) -> None:
+        config, parent, child = self._parent_and_child()
+        grandchild = spawn_line(config, child.id, "fix")
+        with self.assertRaisesRegex(DyroError, "直接父线"):
+            merge_line(config, grandchild.id, parent.id)
+
+        other = create_line(
+            config, line_id="other", branch="feat/other", base="main"
+        )
+        with self.assertRaisesRegex(DyroError, "没有父线"):
+            merge_line(config, other.id, parent.id)
+        with self.assertRaisesRegex(DyroError, "未登记"):
+            merge_line(config, child.id, "missing-parent")
+
+        parent_wt = line_repository_path(config, parent, "api")
+        (parent_wt / "dirty.txt").write_text("pending\n", encoding="utf-8")
+        with self.assertRaisesRegex(DyroError, "不干净"):
+            merge_line(config, child.id, parent.id)
+        (parent_wt / "dirty.txt").unlink()
+
+        child_wt = line_repository_path(config, child, "api")
+        publish_origin_branch(child_wt, child.branch)
+        shell("git", "branch", "--set-upstream-to=origin/feat/onboard", cwd=child_wt)
+        with self.assertRaisesRegex(DyroError, "doctor"):
+            merge_line(config, child.id, parent.id)
+
+    def test_sync_brings_parent_commit_to_child_and_rejects_root(self) -> None:
+        config, parent, child = self._parent_and_child()
+        parent_wt = line_repository_path(config, parent, "api")
+        child_wt = line_repository_path(config, child, "api")
+        parent_head = _commit_text(
+            parent_wt, "from-parent.txt", "synced\n", "feat: parent ahead"
+        )
+        sync_line(config, child.id)
+        contained = subprocess.run(
+            ["git", "merge-base", "--is-ancestor", parent_head, "HEAD"],
+            cwd=child_wt,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+        )
+        self.assertEqual(contained.returncode, 0)
+        ledger = config.ledger_file.read_text(encoding="utf-8")
+        self.assertIn('"phase": "line_sync"', ledger)
+        with self.assertRaisesRegex(DyroError, "没有父线"):
+            sync_line(config, parent.id)
+
+    def test_schema_2_line_files_still_parse(self) -> None:
+        config = load(self.root)
+        config.lines_state_dir.mkdir(parents=True, exist_ok=True)
+        path = config.lines_state_dir / "legacy.toml"
+        path.write_text(
+            'schema_version = 2\n'
+            'id = "legacy"\n'
+            'kind = "line"\n'
+            'branch = "feat/legacy"\n'
+            'base = "main"\n'
+            'repositories = ["api"]\n',
+            encoding="utf-8",
+        )
+        line = get_line(config, "legacy")
+        self.assertEqual(line.parent, "")
+        self.assertEqual(line.branch, "feat/legacy")
+        self.assertEqual(line.repositories, ("api",))
+        root = create_line(config, line_id="rootline", branch="feat/rootline", base="main")
+        written = (config.lines_state_dir / "rootline.toml").read_text(encoding="utf-8")
+        self.assertIn("schema_version = 2", written)
+        self.assertNotIn("parent", written)
+        self.assertEqual(root.parent, "")
+
 
 class MissingOriginFindingTests(unittest.TestCase):
     def test_recognizes_only_missing_origin_doctor_fails(self) -> None:

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -12,6 +12,7 @@ from dyro.workspace import (
     get_line,
     is_missing_origin_finding,
     line_repository_path,
+    line_root,
     list_lines,
     merge_line,
     preflight_line,
@@ -424,6 +425,17 @@ class LineFamilyTests(WorkspaceCase):
         self.assertIn(upstream, ("", "-"))
         self.assertNotEqual(upstream, "origin/feat/onboard")
         self.assertNotEqual(upstream, "feat/onboard")
+        overlay = line_root(config, child)
+        self.assertTrue((overlay / "AGENTS.md").is_file())
+        self.assertTrue((overlay / "CLAUDE.md").is_file())
+        self.assertIn("origin/feat/onboard_tryon", (overlay / "AGENTS.md").read_text())
+        self.assertEqual(
+            (overlay / "AGENTS.md").read_text(encoding="utf-8"),
+            (overlay / "CLAUDE.md").read_text(encoding="utf-8"),
+        )
+        self.assertFalse((worktree / "AGENTS.md").exists())
+        self.assertFalse((worktree / "CLAUDE.md").exists())
+        self.assertFalse((self.anchor / "AGENTS.md").exists())
         full = spawn_line(config, "onboard", "onboard_extra")
         self.assertEqual(full.id, "onboard_extra")
         self.assertEqual(full.parent, "onboard")

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -1,6 +1,7 @@
 from pathlib import Path
 import unittest
 import os
+import shutil
 import subprocess
 
 from dyro.config import load
@@ -567,6 +568,211 @@ class LineFamilyTests(WorkspaceCase):
         self.assertIn("schema_version = 2", written)
         self.assertNotIn("parent", written)
         self.assertEqual(root.parent, "")
+
+    def _enable_web_repo(self):
+        web = self.root / "repositories/web"
+        web.mkdir(parents=True)
+        shell("git", "init", "-b", "main", cwd=web)
+        shell("git", "config", "user.name", "Test User", cwd=web)
+        shell("git", "config", "user.email", "test@example.com", cwd=web)
+        (web / "README.md").write_text("web\n", encoding="utf-8")
+        shell("git", "add", "README.md", cwd=web)
+        shell("git", "commit", "-m", "chore: initial", cwd=web)
+        config_path = self.root / "dyro.toml"
+        config_path.write_text(
+            config_path.read_text(encoding="utf-8")
+            + '\n[repositories.web]\npath = "repositories/web"\nmount = "clients/web"\n',
+            encoding="utf-8",
+        )
+        return load(self.root), web
+
+    def test_status_rows_after_spawn_has_no_phantom_missing(self) -> None:
+        config, parent, child = self._parent_and_child()
+        rows = status_rows(config)
+        self.assertEqual([row for row in rows if row[2] == "MISSING"], [])
+        self.assertEqual(
+            {(row[0], row[1]) for row in rows if row[0].startswith("line:")},
+            {
+                (f"line:{parent.id}", "api"),
+                (f"line:{child.id} ({parent.id})", "api"),
+            },
+        )
+
+    def test_status_rows_reports_missing_worktree(self) -> None:
+        config, parent, child = self._parent_and_child()
+        shutil.rmtree(line_repository_path(config, child, "api"))
+        rows = status_rows(config)
+        child_rows = [row for row in rows if row[0] == f"line:{child.id} ({parent.id})"]
+        self.assertEqual(len(child_rows), 1)
+        self.assertEqual(child_rows[0][1:], ("api", "MISSING", "-", "-", -1))
+        parent_rows = [row for row in rows if row[0] == f"line:{parent.id}"]
+        self.assertEqual(len(parent_rows), 1)
+        self.assertNotEqual(parent_rows[0][2], "MISSING")
+        self.assertEqual(len([row for row in rows if row[2] == "MISSING"]), 1)
+
+    def test_parent_cycle_rejected(self) -> None:
+        config = load(self.root)
+        config.lines_state_dir.mkdir(parents=True, exist_ok=True)
+        (config.lines_state_dir / "cycle_leaf.toml").write_text(
+            "schema_version = 3\n"
+            'id = "cycle_leaf"\n'
+            'kind = "line"\n'
+            'branch = "feat/cycle_leaf"\n'
+            'base = "main"\n'
+            'parent = "cycle_root"\n'
+            'repositories = ["api"]\n',
+            encoding="utf-8",
+        )
+        with self.assertRaisesRegex(DyroError, "成环"):
+            create_line(
+                config,
+                line_id="cycle_root",
+                branch="feat/cycle_root",
+                base="main",
+                parent="cycle_leaf",
+            )
+
+    def test_spawn_repos_subset(self) -> None:
+        config, _web = self._enable_web_repo()
+        publish_origin_branch(self.anchor, "feat/onboard")
+        parent = create_line(
+            config, line_id="onboard", branch="feat/onboard", base="main"
+        )
+        self.assertEqual(parent.repositories, ("api", "web"))
+        child = spawn_line(config, "onboard", "tryon", repositories=["api"])
+        self.assertEqual(child.repositories, ("api",))
+        self.assertTrue(
+            (line_repository_path(config, child, "api") / ".git").exists()
+        )
+        self.assertFalse((self.root / "versions/onboard_tryon/clients/web").exists())
+
+    def test_merge_push_refused_when_allow_push_false(self) -> None:
+        config, parent, child = self._parent_and_child()
+        self.assertFalse(config.policy.allow_push)
+        with self.assertRaisesRegex(DyroError, "禁止 push"):
+            merge_line(config, child.id, parent.id, push=True)
+
+    def test_merge_successful_dry_run_does_not_mutate(self) -> None:
+        config, parent, child = self._parent_and_child()
+        child_wt = line_repository_path(config, child, "api")
+        parent_wt = line_repository_path(config, parent, "api")
+        child_head = _commit_text(
+            child_wt, "child.txt", "from child\n", "feat: child work"
+        )
+        parent_head = shell_stdout("git", "rev-parse", "HEAD", cwd=parent_wt)
+        parent_status = shell_stdout(
+            "git", "status", "--porcelain=v1", "-uall", cwd=parent_wt
+        )
+        merge_line(config, child.id, parent.id, dry_run=True)
+        self.assertEqual(
+            shell_stdout("git", "rev-parse", "HEAD", cwd=parent_wt), parent_head
+        )
+        self.assertEqual(
+            shell_stdout("git", "rev-parse", "HEAD", cwd=child_wt), child_head
+        )
+        self.assertEqual(
+            shell_stdout("git", "status", "--porcelain=v1", "-uall", cwd=parent_wt),
+            parent_status,
+        )
+        merge_head = subprocess.run(
+            ["git", "rev-parse", "--verify", "-q", "MERGE_HEAD"],
+            cwd=parent_wt,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+        )
+        self.assertNotEqual(merge_head.returncode, 0)
+        if config.ledger_file.exists():
+            self.assertNotIn(
+                '"phase": "line_merge"',
+                config.ledger_file.read_text(encoding="utf-8"),
+            )
+
+    def test_sync_dry_run_does_not_mutate(self) -> None:
+        config, parent, child = self._parent_and_child()
+        parent_wt = line_repository_path(config, parent, "api")
+        child_wt = line_repository_path(config, child, "api")
+        parent_head = _commit_text(
+            parent_wt, "from-parent.txt", "synced\n", "feat: parent ahead"
+        )
+        child_head = shell_stdout("git", "rev-parse", "HEAD", cwd=child_wt)
+        child_status = shell_stdout(
+            "git", "status", "--porcelain=v1", "-uall", cwd=child_wt
+        )
+        sync_line(config, child.id, dry_run=True)
+        self.assertEqual(
+            shell_stdout("git", "rev-parse", "HEAD", cwd=child_wt), child_head
+        )
+        self.assertEqual(
+            shell_stdout("git", "rev-parse", "HEAD", cwd=parent_wt), parent_head
+        )
+        self.assertEqual(
+            shell_stdout("git", "status", "--porcelain=v1", "-uall", cwd=child_wt),
+            child_status,
+        )
+        if config.ledger_file.exists():
+            self.assertNotIn(
+                '"phase": "line_sync"',
+                config.ledger_file.read_text(encoding="utf-8"),
+            )
+
+    def test_merge_rolls_back_committed_first_repo_when_later_commit_fails(self) -> None:
+        config, _web = self._enable_web_repo()
+        publish_origin_branch(self.anchor, "feat/onboard")
+        parent = create_line(
+            config, line_id="onboard", branch="feat/onboard", base="main"
+        )
+        child = spawn_line(config, "onboard", "tryon")
+        self.assertEqual(child.repositories, ("api", "web"))
+        parent_api = line_repository_path(config, parent, "api")
+        parent_web = line_repository_path(config, parent, "web")
+        _commit_text(
+            line_repository_path(config, child, "api"),
+            "child-api.txt",
+            "from child\n",
+            "feat: child api",
+        )
+        _commit_text(
+            line_repository_path(config, child, "web"),
+            "child-web.txt",
+            "from child\n",
+            "feat: child web",
+        )
+        parent_api_head = shell_stdout("git", "rev-parse", "HEAD", cwd=parent_api)
+        parent_web_head = shell_stdout("git", "rev-parse", "HEAD", cwd=parent_web)
+
+        from dyro import workspace as workspace_mod
+
+        original_git = workspace_mod.git
+
+        def flaky_git(repo: Path, *args: str, dry_run: bool = False, timeout: int = 180):
+            if not dry_run and args[:1] == ("commit",) and "clients/web" in str(repo):
+                return Result(
+                    ("git", "-C", str(repo), *args), 1, "simulated commit failure"
+                )
+            return original_git(repo, *args, dry_run=dry_run, timeout=timeout)
+
+        workspace_mod.git = flaky_git  # type: ignore[assignment]
+        try:
+            with self.assertRaisesRegex(DyroError, "提交 web 合并"):
+                merge_line(config, child.id, parent.id)
+        finally:
+            workspace_mod.git = original_git  # type: ignore[assignment]
+
+        self.assertEqual(
+            shell_stdout("git", "rev-parse", "HEAD", cwd=parent_api), parent_api_head
+        )
+        self.assertEqual(
+            shell_stdout("git", "rev-parse", "HEAD", cwd=parent_web), parent_web_head
+        )
+        self.assertEqual(
+            shell_stdout("git", "status", "--porcelain=v1", "-uall", cwd=parent_api),
+            "",
+        )
+        self.assertEqual(
+            shell_stdout("git", "status", "--porcelain=v1", "-uall", cwd=parent_web),
+            "",
+        )
 
 
 class MissingOriginFindingTests(unittest.TestCase):


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Operators can spawn durable child **lines** (not tasks), merge a child back into its direct parent, and sync parent commits into a child. All three are multi-repo, take the same line merge lock as `task merge`, are dry-runnable, and do not push unless `--push` and `policy.allow_push`.

New workspaces also get thin overlay-root `AGENTS.md` + `CLAUDE.md`. Existing workspaces are not rewritten on upgrade.

Public version stays **0.7.7**.

## Line family

- Optional `parent = "<line-id>"` on line manifests (schema 3). Schema 1 and 2 files still parse. Writer emits schema 3 only when `parent` is set. `base` remains a Git ref. Cycles and self-parent are rejected.
- `dyro line spawn <parent> <child>` creates a sibling child line: inherited repos (optional `--repos` subset), branch `feat/<id>`, base `origin/<parent.branch>` when that ref exists else the parent’s local branch. Reuses `create_line` origin-bind / `--no-track`. No fetch, no push. `dyro line create` stays for root/unparented lines.
- `dyro line merge <child> --into <parent>` `--no-ff` merges `child.branch` into the parent line worktrees. One-level parent only. Preflight: both worktrees exist and match branch names; parent clean; child doctor allows only missing-origin FAILs; per-repo conflict probe before mutating. Failure rolls back already-merged repos. Records a ChangeSet of parent HEADs when cheap, plus ledger `line_merge`.
- `dyro line sync <child>` merges the parent into the child (`--no-ff`; already-contained is a no-op). Locks the child line. Ledger `line_sync`. Refuses a line with no parent.
- `dyro line list` / status show the parent id when set. CLI `--help` is in Chinese.

## Overlay instruction files

These markdown files are **not** the authority. Host-compiled SKILL.md and `dyro next` remain the gate. The files tell a coding harness: this is a Dyro overlay, use `dyro next`, do not git merge/push around gates.

- Written at the workspace overlay root (next to `dyro.toml`), never into `repositories/*` or line Git worktrees.
- `setup` / `join` / `init` generate both files if absent. Same body for `AGENTS.md` and `CLAUDE.md`. Chinese, short.
- Installing or upgrading Dyro does not rewrite existing workspaces. `dyro doctor` WARNs (not FAIL) when they are missing. `dyro host seed` creates missing files only; `--force` overwrites and must be explicit.
- `line spawn` / `create` write a short persona at `versions/<line>/AGENTS.md` and `CLAUDE.md` (line id, branch, must track `origin/<line.branch>`). Overlay-only.

## Tests

Git-fixture unit tests cover spawn parent/repos/upstream, merge dry-run conflict (no mutation), merge success, skip-level / missing parent / dirty parent / wrong-upstream child, sync, no-parent sync, and schema 2 parse.

Overlay tests cover setup/join/init writing both files, seed idempotence (no overwrite of a hand-edited `AGENTS.md`), doctor WARN without FAIL, spawn personas outside product Git worktrees, and old workspaces still doctor-passing except the WARN.

## Out of scope

No version bump. No task-merge semantic changes. No family-tree UI. No `AGENT.md` singular.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4d0d3379-dd41-4496-bdfe-00e4d7392ead?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4d0d3379-dd41-4496-bdfe-00e4d7392ead&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

