### PR TITLE
feat(控制台): Console v2 P1 直播事件与一层家族图

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@
 - Add design `docs/designs/console-v2-live-family-signals.md` for live
   events, one-level line families, and overlay family signals. It extends
   the local Web Console and ADR 0005; it does not replace them.
+- Console P1: append-only `.dyro/events.jsonl`, project line `parent`,
+  one-level family graph, and an SSE event stream with `after=` resume.
+  Hidden tabs pause; SSE failure falls back to the existing 5s poll.
+  Workspace detail shows the family tree and live event panes. Copy
+  buttons emit dry-run CLI only. Browser stays read-only; P2 channel
+  POST and P3 artifacts are not implemented.
 - User slash Skill `dyro-line-family` (`/dyro-line-family`) preflights
   `line spawn` / `line merge` / `line sync` and prints one `--yes` command
   for the human. It does not execute the mutation, invent `--push`, or

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Add design `docs/designs/console-v2-live-family-signals.md` for live
+  events, one-level line families, and overlay family signals. It extends
+  the local Web Console and ADR 0005; it does not replace them.
 - User slash Skill `dyro-line-family` (`/dyro-line-family`) preflights
   `line spawn` / `line merge` / `line sync` and prints one `--yes` command
   for the human. It does not execute the mutation, invent `--push`, or

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,10 @@
   Hidden tabs pause; SSE failure falls back to the existing 5s poll.
   Workspace detail shows the family tree and live event panes. Copy
   buttons emit dry-run CLI only. Browser stays read-only; P2 channel
-  POST and P3 artifacts are not implemented.
+  POST and P3 artifacts are not implemented. Family badges do not claim
+  cleanliness or origin binding. Event `facts` stay IDs, enums, counts,
+  short hashes, or reason codes. HMAC `after=` binds a row digest so a
+  replaced same-seq row is `EVENT_CURSOR_INVALID`.
 - User slash Skill `dyro-line-family` (`/dyro-line-family`) preflights
   `line spawn` / `line merge` / `line sync` and prints one `--yes` command
   for the human. It does not execute the mutation, invent `--push`, or

--- a/docs/designs/console-v2-live-family-signals.md
+++ b/docs/designs/console-v2-live-family-signals.md
@@ -1,0 +1,479 @@
+# Dyro Console 实时家族与信号设计
+
+状态：提案
+目标版本：`0.7.x`；扩展既有 Console，不另开 `0.8.0` / `0.9.0` / `1.0.0` 功能号
+适用范围：工作区 overlay 事件、一层开发线家族、家族频道与人类可见信号；不改写 TaskGraph、Objective、merge、push 或 ADR 0005 的只读边界
+
+本文件**扩展**而不替换：
+
+- [本地 Web 控制台](local-web-console.md)
+- [ADR 0005](../adr/0005-local-web-console.md)
+
+既有 command-center、C01–C06 读取契约、loopback bootstrap / bearer、以及「浏览器不能交付」仍然有效。本设计只补上实时事件、一层家族图和 overlay 信号；除第 9 节列出的唯一 POST 外，Console 仍没有交付 mutation API。
+
+---
+
+## 1. 痛点
+
+当前 Console 是**只读快照窗口**，不是开发线旁边的视觉孪生。已落地表面只有：
+
+| 表面 | 现状 |
+| --- | --- |
+| session / meta / overview / workspace / proofs / system | 有 |
+| 5 秒轮询 + ETag | 有 |
+| line DTO 的 `parent` | 无。`line list` JSON 已有 `parent`，Console `LineSummary` 没有投影 |
+| dispatch / 会审 / ledger | 无。页面看不到谁在跑、会审是否落下、ledger 最近一行 |
+| 邮箱 / 家族频道 | 无。线与线、线与人之间的话只存在于各 harness 会话里 |
+
+操作者要的不是第二套 IDE，而是把 harness CLI 已经能做的事摊在一个页面上：
+
+- **计划**、**里程碑**、**阶段**、**任务**的当前态；
+- 复核、图像、视频、图表等 overlay 产物；
+- **看得见的跨线对话**，而不是各开一个聊天窗口互相看不见。
+
+操作者口语里的计划 / 里程碑 / 阶段 / 任务 / 谁在跑，必须映射到已有 Dyro 对象，不得另造 backlog：
+
+| 操作者说法 | Console 投影 | 权威来源 |
+| --- | --- | --- |
+| 计划 | Objective 波次泳道 | `objective_wave` 事件 + 既有 Objective 快照 |
+| 里程碑 | Objective 派生结果 | `incomplete \| complete \| repair_required` |
+| 阶段 | Task 状态 | 既有 Task 状态机 |
+| 任务 | 既有 Task 详情 | 既有 workspace / Task DTO |
+| 谁在跑 | dispatch / executor | `dispatch` 事件 + Task `executor` |
+
+页面仍不展示 prompt、路径、argv、环境变量或未经验证的 provider 输出。
+
+---
+
+## 2. 原则与不变量
+
+必须始终成立：
+
+1. **`.dyro` + git 仍是唯一事实源。** Console 不保存 Task、Objective、attention、「完成」或聊天副本。事件与频道是 overlay 追加日志，不是第二份交付图。
+2. **启动与认证不变。** 仍只绑定 `127.0.0.1`，仍用一次性 fragment bootstrap 换发 tab 内 bearer。不提供 `--host`，不用 cookie。
+3. **人必须看见线信号。** 家族频道对 `operator` 没有隐藏私信。线发给线的 `--to` 对父线与人类始终可见。
+4. **父线是唯一 merge / sync 点。** `line merge` 只把子线合入其直接父线；`line sync` 只把该父线合入该子线。页面不得暗示合入 git `main`、release 或 PyPI。
+5. **家族只有一层。** 对父线 `P`：
+
+   ```text
+   F(P) = {P} ∪ children(P) ∪ {operator}
+   ```
+
+   - 表亲同属这个家族组。`core_pay` 与另一条子线都在 `F(core)` 里，彼此看得见广播。
+   - 孙线在**子线自己的**家族里。`core_pay_fix` 的 `parent` 是 `core_pay`，因此属于 `F(core_pay)`，不属于 `F(core)`。
+   - 节点只画一层：父、直接子、操作者。不画孙线，不把表亲提升成第二层树。
+6. **聊天不是交付门。** `shipped`、`decision`、`contract` 或任意频道行都不能代替 review、sign-off、gate、merge 或 push。信号只解释意图，不改变 Task / Objective / git。
+7. **`/dyro-line-family` 不发帖。** 该斜杠仍只预检 `spawn` / `merge` / `sync`，打印一条给人亲自跑的 `--yes` 命令。它不调用 `line post`，不 ack，不写频道。
+
+示例（只使用通用线 id）：
+
+```text
+core
+├─ core_pay          F(core) 的直接子线
+│  └─ core_pay_fix   属于 F(core_pay)，不出现在 F(core) 的树上
+└─ <另一条子线>       与 core_pay 是表亲，同属 F(core)
+operator             每个家族组的固定成员
+```
+
+---
+
+## 3. 信息架构
+
+不新增一级页面，不新增全局菜单。既有 command-center（全局概览、现在需要你、推荐命令、工作区列表、本机状态）保持原位。
+
+三个新窗格只出现在**已打开的工作区详情**里，接在现有关注 / 线 / 任务 / 目标清单之后：
+
+| 窗格 | 首要问题 | 默认内容 |
+| --- | --- | --- |
+| 家族树 | 这条线和谁是一层亲属？ | 以 `parent` 投影的一层图；节点徽章；可复制的 dry-run |
+| 实时事件流 | 刚才发生了什么？ | `.dyro/events.jsonl` 白名单行；SSE，不可见时暂停 |
+| 家族频道 | 线与人刚刚说了什么？ | `F(P)` 的 `channel.jsonl`；列表 / 时间线 / 过滤 |
+
+宽屏三个窗格同时可见，顺序固定为树 → 事件 → 频道，不提供拖拽改序或自定义布局。窄屏（小于 768 px）改为三个 tab，标签固定为「家族」「事件」「频道」，默认「家族」。tab 只切换可见性，不改变 hash 以外的状态。
+
+hash 只保存安全 alias 与当前 tab：`#w/<alias>`、`#w/<alias>/family`、`#w/<alias>/events`、`#w/<alias>/channel`。不把 bearer、路径或消息正文写入 URL。
+
+详情里已有的线 / 任务 / 目标清单、独立 Proof inspect 和关闭按钮不变。点击任务仍进入既有 Task 摘要，不新开「任务工作室」。产物栏是频道 / 事件上的 overlay，不是第四个一级 tab；P3 才渲染，P1 / P2 只保留占位文案「产物尚未开放」。
+
+---
+
+## 4. 实时事件
+
+### 4.1 存储
+
+工作区 overlay 增加一份与 Objective 事件**分开**的日志：
+
+```text
+.dyro/events.jsonl
+```
+
+它不是 `.dyro/objectives/<id>/events.jsonl`，也不是 `.dyro/ledger.jsonl`。ledger 仍是交付审计；本文件只投影人类可看的直播行。一行一种 `kind`，追加写入，损坏或截断 fail-closed，不得为了「看起来连续」而补造中间行。
+
+允许的 `kind`：
+
+| kind | 何时写入 | 页面怎么画 |
+| --- | --- | --- |
+| `spawn` | `line spawn` 成功 | 树上出现子节点 |
+| `merge` | `line merge` 成功 | 子 → 父边短暂点亮 |
+| `sync` | `line sync` 成功 | 父 → 子边短暂点亮 |
+| `task_status` | Task 状态迁移 | 阶段列更新；点进既有 Task 详情 |
+| `objective_wave` | Objective 波次预览或落地 | 计划泳道 |
+| `dispatch` | 已审计 dispatch 开始 / 结束 | 谁在跑 |
+| `board` | 会审记录落下 | 事件行；不展示正文 |
+| `signal` | 家族频道追加一行 | 频道与事件流各一条 |
+| `host_seed` | `dyro host seed` 写入 overlay | 事件行；不列文件路径 |
+
+每行最小字段：
+
+```json
+{
+  "seq": 12,
+  "id": "evt_12",
+  "kind": "spawn",
+  "at": "2026-08-20T12:00:00Z",
+  "actor": "core",
+  "subject": "core_pay",
+  "family": "core",
+  "facts": {
+    "parent": "core",
+    "child": "core_pay"
+  }
+}
+```
+
+`facts` 只含安全 ID、枚举状态、计数、短哈希和稳定 reason code。禁止 prompt、answer、handoff、argv、绝对路径、remote URL、环境变量、完整日志。未知 `kind` 只显示时间、`id` 和 `EVENT_REDACTED`。
+
+### 4.2 传输
+
+| 方法与路径 | 行为 |
+| --- | --- |
+| `GET /api/v1/workspaces/{alias}/events?after=<cursor>` | 游标分页的白名单事件。默认 50、最大 100 |
+| `GET /api/v1/workspaces/{alias}/events/stream?after=<cursor>` | 同一白名单的 SSE。`text/event-stream`，每条 `data` 是一条事件 JSON；注释心跳保持连接 |
+
+- `after=` 是带完整性校验的 opaque cursor，语义是「该 seq 之后」。截断、替换或篡改返回 `EVENT_CURSOR_INVALID`，客户端从空 cursor 重读，不猜测偏移。
+- SSE 与 JSON 都需要 bearer，遵守既有 Host / Origin / Fetch Metadata / 无 CORS 规则。
+- 页面 `document.hidden` 时关闭 EventSource，并停止 5 秒回退轮询；可见后用当前 cursor 先做一次条件 GET，再重开 SSE。
+- SSE 不可用、被代理断开或 405 时，回退到既有 5 秒条件轮询，轮询同一个 `GET .../events`。不引入 WebSocket。
+- overview 的 5 秒轮询不拉事件流。只有打开的工作区详情订阅该 workspace。
+
+### 4.3 映射，不新造对象
+
+页面把事件排进既有列，不增加「计划」「里程碑」「阶段」菜单：
+
+- `objective_wave` → 计划泳道。一列一个当前波次，格子是该波 Task id。
+- Objective `derived_result` → 里程碑徽章，挂在泳道标题，不单独开里程碑页。
+- `task_status` → 阶段。状态枚举仍是 backlog / assigned / in_progress / waiting_answer / review / review_pending_signoff / done / failed。
+- 任务标题 → 既有详情。点击只打开已经设计过的 Task 摘要。
+- `dispatch` + Task `executor` → 「谁在跑」。只显示安全 executor id 与 `running | idle | unknown`。
+
+---
+
+## 5. 家族图
+
+### 5.1 投影
+
+`LineSummary` 增加一个可选字段 `parent`：空字符串或安全线 id。来源是 line manifest 的 `parent`，与 `line list --format json` 同值。Console 不得自己猜父子，不得把 `base` Git ref 当成父线。
+
+`GET /api/v1/workspaces/{alias}/families` 返回该 workspace 里每个一层家族的轻量卡：`parent`、直接子线、未读数、dirty / missing-origin / in-progress 计数。
+
+`GET /api/v1/workspaces/{alias}/families/{parent}` 返回 `F(parent)` 的图：
+
+```json
+{
+  "parent": "core",
+  "members": ["core", "core_pay", "operator"],
+  "nodes": [
+    {
+      "id": "core",
+      "role": "parent",
+      "dirty": false,
+      "missing_origin": false,
+      "in_progress": false,
+      "unread": 0
+    }
+  ],
+  "edges": [
+    {"from": "core", "to": "core_pay", "kind": "parent"}
+  ]
+}
+```
+
+- 节点徽章：`dirty`、`missing-origin`、`in-progress`、`unread`。四者同时具备图标、文字和含义，不靠颜色单独表达。
+- `operator` 是固定节点，没有 git 徽章，只显示未读。
+- 边在对应 `merge` / `sync` 事件进入当前事件窗口时点亮，随后随该行滚出窗口而熄灭。页面不自己推导「应该合并」。
+- 孙线 `core_pay_fix` 出现在 `families/core_pay`，不出现在 `families/core`。
+
+### 5.2 页面动作
+
+图上只提供**复制 dry-run**。复制内容必须带 `--workspace` 与 `--dry-run`，且不得带 `--yes` 或 `--push`：
+
+```text
+dyro --workspace example --dry-run line spawn core core_pay
+dyro --workspace example --dry-run line merge core_pay --into core
+dyro --workspace example --dry-run line sync core_pay
+```
+
+浏览器不得执行 spawn / merge / sync，不得弹出「确认后执行」，不得把 `--yes` 写进剪贴板。真正的 `--yes` 仍只存在于终端，或由 `/dyro-line-family` 预检后打印给人亲自跑。
+
+---
+
+## 6. 产物栏
+
+P3 才实现。P1 / P2 的频道行若带 `artifact` kind，只显示「产物尚未开放」和安全 id，不取文件。
+
+权威位置是 overlay，不是产品 git worktree，也不是 Proof store：
+
+```text
+.dyro/families/<parent>/artifacts/<artifact-id>
+.dyro/families/<parent>/artifacts.jsonl
+```
+
+允许展示的类型：复核摘要卡、图像、图表。视频只出卡片，不出嵌入播放器。
+
+| 类型 | 页面 | 传输 |
+| --- | --- | --- |
+| 复核 | 标题、结论枚举、绑定哈希前 12 位 | JSON DTO |
+| 图像 | `<img>` | 先用 bearer `fetch` 同源字节，再赋 `blob:` URL。`img-src 'self'` 与 `blob:`；不把 bearer 放进 query，不设 cookie |
+| 图表 | 与图像相同，或纯 JSON 点列由本页画 SVG | 同源；无第三方图表库 |
+| 视频 | 卡片：标题、时长或大小、一条可复制的只读打开命令 | 不返回媒体流，不使用 `<video>`，不增加 `media-src` |
+
+`GET /api/v1/workspaces/{alias}/families/{parent}/artifacts/{id}` 只读。图像响应有大小上限，校验 overlay 路径，拒绝 symlink 与 `..`。页面不扫描 `outputs/images/`，不扫描 harness home，不把 sidecar 生成目录当成家族产物。
+
+产物引用可以出现在 `artifact` 频道行的 `facts.artifact_id` 里。引用不是核验；衰减与 merge 仍走既有 Proof / Task 路径。
+
+---
+
+## 7. 家族组与频道
+
+### 7.1 成员与可见性
+
+`F(P) = {P} ∪ children(P) ∪ {operator}`。
+
+- 默认帖进入家族广播，`to` 为空，组内全员可见。
+- `--to <id>` 必须落在同一个 `F(P)` 内，否则 CLI 与 API 都拒绝。
+- 定向帖对发送者、接收者、**父线**和 **operator** 可见。表亲看不到别人的定向帖。
+- 父线与人类始终能看见该家族里的定向帖。人类控制台没有「仅线可见」的隐藏私信。
+- `core_pay` 写给 `core_pay_fix` 的帖属于 `F(core_pay)`，`core` 在自己的家族频道里看不到它；人要看孙线对话，打开 `core_pay` 那一家族。
+
+### 7.2 频道 kind
+
+| kind | 含义 | 谁可以写 |
+| --- | --- | --- |
+| `contract` | 约定或范围声明 | 线 CLI；人类 POST |
+| `blocked` | 阻塞 | 线 CLI |
+| `shipped` | 声称已交付（不是 merge 证据） | 线 CLI |
+| `ask_sync` | 请求从父线同步 | 线 CLI |
+| `decision` | 人类决定 | 人类 POST；线 CLI 也可记 |
+| `artifact` | 指向 overlay 产物 | 线 CLI |
+| `retract` | 撤回先前列，原行仍在 | 线 CLI |
+
+`ack` 不是频道 kind。它是收件状态，写在旁路索引里，并追加一条 `signal` 事件。
+
+### 7.3 存储
+
+```text
+.dyro/families/<parent>/channel.jsonl
+.dyro/families/<parent>/acks.json
+```
+
+追加频道行时必须同时追加 `.dyro/events.jsonl` 的 `signal` 行，`facts.channel_id` 指向频道行 id。两处写入放在同一 overlay 锁下；只写成一边则 fail-closed，恢复时重放或进入 repair，不得假装已广播。
+
+频道行：
+
+```json
+{
+  "id": "msg_9",
+  "seq": 9,
+  "at": "2026-08-20T12:01:00Z",
+  "family": "core",
+  "from": "core_pay",
+  "to": "",
+  "kind": "ask_sync",
+  "body": "请把 core 同步进 core_pay",
+  "retracts": ""
+}
+```
+
+`body` 受长度和控制字符净化，默认拒绝路径与凭据模式。`retract` 行的 `retracts` 指向被撤回 id；原行不删除，页面标成已撤回。
+
+### 7.4 CLI
+
+不新增顶级命令。三条子命令挂在既有 `dyro line` 下：
+
+```text
+dyro --workspace example line post <from> --kind ask_sync [--to <id>] [--body TEXT]
+dyro --workspace example line inbox [--family core] [--unacked]
+dyro --workspace example line ack <id>
+```
+
+- `post` 的 `<from>` 必须是该家族里的线 id。人类身份用保留 id `operator`，且 kind 只能是 `decision` 或 `contract`（ack 走 `line ack`）。
+- 省略 `--to` 即广播。`--to` 只接受 `F(family)` 成员。
+- `inbox` 默认看当前线或 `--family`。`--unacked` 只列出操作者尚未 ack 的行。
+- `ack` 只标记人类已读，不改变 Task / git，不视为同意 merge。
+- 三条命令都支持 `--dry-run` 与 `--format json`。`post` / `ack` 的真正写入仍要现有确认纪律；没有静默成功。
+- `/dyro-line-family` 的允许列表不增加 `line post` / `inbox` / `ack`。
+
+### 7.5 `next` 与控制面
+
+`dyro next` 与 `dyro-control-plane` **读取**未 ack 信号，不代写。
+
+- `next --format json` 增加只读字段 `family_unacked`：`count`、最高优先级 `kind`、`family`、一条安全摘要。`count > 0` 时事项里出现「家族频道有未读信号」；`next.commands` 仍为空或只含既有只读 / 修复命令，不得出现 `line post` 或 `line ack --yes`。
+- 控制面座位可运行 `line inbox --unacked --format json`。Observed 里原样报告未读；User action 不得发明 ack / post / merge。
+- 未读信号不是 `repair_required`，也不阻塞 `line spawn` 预检。
+
+---
+
+## 8. 人类控制台模块
+
+工作区详情的「频道」窗格就是人类模块。不另做「消息中心」页面。
+
+必须具备：
+
+1. **完整历史。** 打开某家族即看到该 `channel.jsonl` 的全量（分页），包括定向帖和已撤回行。
+2. **操作者身份。** 人类发帖的 `from` 恒为 `operator`。页面不提供假扮某条线的选择器。
+3. **没有隐藏私信。** 凡 `F(P)` 内的定向帖，人类模块都能看到，并标明 `from` → `to`。
+4. **只追加，可撤回。** 页面不能改写或删除旧行。撤回只能复制 `line post operator --kind retract --body <id>` 的 CLI；人类 POST 集合不含 `retract`。
+5. **列表 / 时间线 / 过滤。** 同一窗格内切换：列表（未读优先）、时间线（seq 正序）、过滤（kind、from、未读）。不是三个新页面。
+6. **人类 POST 只允许 `decision`、`contract`、`ack`。** 其它 kind 返回 403，稳定 code `FAMILY_POST_FORBIDDEN`。
+7. **页面不能 merge / push / `--yes` / 改 Task 状态。** 这些控件不存在。复制区只出 dry-run 或只读命令。
+
+### 8.1 HTTP
+
+家族相关 API 都挂在 `/api/v1/workspaces/{alias}/families` 下。路径参数只解码一次，再走既有安全 ID 校验。
+
+| 方法与路径 | 认证 | 行为 |
+| --- | --- | --- |
+| `GET /api/v1/workspaces/{alias}/families` | bearer | 一层家族列表 |
+| `GET /api/v1/workspaces/{alias}/families/{parent}` | bearer | `F(parent)` 图与未读摘要 |
+| `GET /api/v1/workspaces/{alias}/families/{parent}/channel?after=&filter=` | bearer | 频道页。`filter` 为 `unacked \| kind \| from` 的白名单组合 |
+| `POST /api/v1/workspaces/{alias}/families/{parent}/channel` | bearer | **唯一浏览器写入。** body 只接受下面的 JSON |
+| `GET /api/v1/workspaces/{alias}/families/{parent}/artifacts` | bearer | P3：overlay 产物清单 |
+| `GET /api/v1/workspaces/{alias}/families/{parent}/artifacts/{id}` | bearer | P3：单件元数据或图像字节 |
+
+`POST` body：
+
+```json
+{
+  "kind": "decision",
+  "to": "",
+  "body": "先同步 core_pay，再谈合入",
+  "ack_id": ""
+}
+```
+
+| `kind` | 必填 | 效果 |
+| --- | --- | --- |
+| `decision` | `body` | 追加频道行，`from=operator` |
+| `contract` | `body` | 同上 |
+| `ack` | `ack_id` | 标记该行已读，不追加 body 文案 |
+
+其它字段、未知 kind、`to` 落在家族外、空 body 的 `decision` / `contract`，全部拒绝。成功响应是统一 Console 封套，`data` 只含新行 id 与 seq。该 POST 走既有 session、Host、Origin、Content-Length、并发和 10 秒 deadline；body 上限 4 KiB。
+
+meta `surfaces` 增加 `events`（P1）与 `families`（P2）。页面按能力拉取，overview 轮询仍不带这些列表。
+
+---
+
+## 9. ADR 0005 的唯一例外
+
+[ADR 0005](../adr/0005-local-web-console.md) 第 4 条：「Console 首发没有交付 mutation API」。本设计**不改写**该 ADR 正文，只增加一条兼容例外：
+
+> `POST /api/v1/workspaces/{alias}/families/{parent}/channel` 是 Console 唯一允许的非 GET 数据面。它只把 overlay 信号追加到 `.dyro/families/<parent>/` 与 `.dyro/events.jsonl`。它不能执行、复核、签收、合并、推送、导入证据、回答任务、改变 Objective、安装工具或更新 Dyro。
+
+因此：
+
+1. 例外对象只有这一条 POST。`ack` 也走它，不另开第二条写入路径。
+2. 写入面只是 overlay 信号，不是 git 对象、不是 Task 状态、不是 Objective journal、不是 ledger 交付行、不是 Proof。
+3. 既有「所有 workspace mutation method 返回 405」对 `task`、`objective`、`line merge`、`push`、`--yes` 仍然成立。
+4. 未来若要在浏览器里预览 merge 或改 Task，仍须按 ADR 0005 另开 ADR：不可变命令预览 → 权限与影响 → 一次性 nonce → Core 重验 → 现有 mutation API。本文件不授予那些能力。
+5. 打开、轮询、SSE、隐藏 tab、停止 server，除上述 POST 外仍不写 workspace、registry、Task、Objective 或 recent preference。
+
+---
+
+## 10. 阶段与验收
+
+同一 `0.7.x` 列车，分三个可独立验收的阶段。未完成阶段不得假装已具备能力：meta 不宣告对应 `surface`，窗格显示「尚未开放」。
+
+### P1 · 事件 + 图
+
+- 写入并读取 `.dyro/events.jsonl`。
+- line DTO 投影 `parent`。
+- 工作区详情出现家族树与事件流。
+- SSE + `after=`；隐藏 tab 暂停；失败回退 5 秒轮询。
+- 边在 merge / sync 时点亮。
+- 复制区只有 dry-run，没有 `--yes`。
+
+### P2 · 家族频道 + 人类模块
+
+- 计算 `F(P)`，写入 `channel.jsonl` 与对应 `signal` 事件。
+- CLI：`line post` / `inbox` / `ack`。
+- `next` 与控制面读取未 ack。
+- Console 频道窗格：完整历史、`operator` 身份、列表 / 时间线 / 过滤。
+- 唯一 POST：`decision` \| `contract` \| `ack`。
+- `/dyro-line-family` 行为不变，不发帖。
+
+### P3 · 产物
+
+- overlay 产物清单与同源图像。
+- 视频只出卡片。
+- 不扫描 harness home，不把 sidecar 输出目录当成家族产物。
+
+### 验收
+
+- 操作者打开已登记工作区详情，能在同一页看到一层家族、直播事件和（P2 后）频道，而不需要新的一级导航。
+- `core` / `core_pay` / `core_pay_fix` fixture：`F(core)` 含 `core`、`core_pay`、`operator`，不含 `core_pay_fix`；`F(core_pay)` 含 `core_pay_fix`。
+- 表亲看得到广播，看不到对方定向帖；父线与 `operator` 看得到该家族全部定向帖。
+- 隐藏详情或切换到后台后，SSE 与轮询停止；回到前台只补拉 cursor 之后的行。
+- 事件与频道 JSON 不含 prompt、argv、绝对路径、remote 或未知字段原文。
+- 页面复制的 spawn / merge / sync 命令都含 `--dry-run` 且不含 `--yes`。
+- 人类 POST `blocked` / `shipped` / `ask_sync` / `artifact` / `retract` / `merge` 均被拒绝；`decision` / `contract` / `ack` 只改 overlay。
+- `shipped` 或 `decision` 之后，Task 仍未 merge，`next` 不得把它说成已集成。
+- `/dyro-line-family` 预检前后都不调用 `line post`。
+- `next --format json` 在有未 ack 时给出 `family_unacked`，且 `commands` 不含发帖或 ack。
+- 停止 Console、过期 session、伪造 Host / Origin、无 bearer 的 POST，都不能留下半行频道或事件。
+- 键盘可在三个窗格 / tab 间移动；320 px 宽仍能看树、读事件、发一条 `decision`。
+- 公开版本号仍是当前列车；本设计落地不要求改成 `0.8.0`。
+
+### 非目标
+
+- 第二套 IDE、编辑器或 harness 会话镜像。
+- 离开 loopback：LAN、`--host 0.0.0.0`、SSH 转发当产品、远程团队账号。
+- 把聊天当成 SSOT 或交付门。
+- 扫描 harness home、个人 skill 目录或 sidecar 输出目录来发现对话 / 图像。
+- 在浏览器里执行 spawn / merge / sync / push / task-status / `--yes`。
+- WebSocket、第三方字体 / 图表 / 播放器、service worker。
+- 把 Objective `events.jsonl` 与工作区 `.dyro/events.jsonl` 合成一份日志。
+- 让 `/dyro-line-family` 发帖或 ack。
+- 多级家族树、隔代 merge、表亲直接 merge。
+
+---
+
+## 11. 模块边界
+
+建议只加读取与 overlay 信号边界，不改 TaskGraph / Objective / merge 实现：
+
+```text
+src/dyro/events.py              工作区 .dyro/events.jsonl 追加与游标读取
+src/dyro/families.py            F(P) 计算、channel.jsonl、acks、产物清单
+src/dyro/console/events.py      SSE / after= DTO
+src/dyro/console/families.py    家族图与频道 DTO、唯一 POST 校验
+src/dyro/console/assets/        详情里三个窗格；无新的顶级 shell
+```
+
+`hub.py`、`graph.py`、`tasks.py`、`continuation/`、`home.py` 的职责不变。`cli.py` 只解析 `line post|inbox|ack`。inspection worker 仍只走 Core 只读快照；频道 POST 在 listener 进程内写 overlay，并受既有请求上限约束，不得在 worker 里执行 git。
+
+静态资源仍走 wheel manifest。新增 JS / CSS 必须列入 manifest 并做 digest 校验；不得从 cwd 回退。
+
+---
+
+## 12. 与既有 Console 契约的关系
+
+第 4–11 节是增量。下列条目继续以 [本地 Web 控制台](local-web-console.md) 与 [ADR 0005](../adr/0005-local-web-console.md) 为准：
+
+- 统一响应封套、ETag 不含纯 `captured_at`、错误封套只用稳定 code；
+- 脱敏白名单与拒绝列表；
+- loopback、精确 Host、无 CORS、无 cookie、`sessionStorage` bearer、CSP；
+- inspection 硬 deadline 与进程组回收；
+- 页面用 `textContent`，不用 `innerHTML`；
+- 推荐动作是可复制 CLI，真正执行仍走现有权限、确认、锁、证据和审计。
+
+本文件只回答一件事：在不把 Console 变成第二套操作系统的前提下，让人看见一层家族里正在发生的事，并让人留下 overlay 决定。

--- a/docs/designs/console-v2-live-family-signals.md
+++ b/docs/designs/console-v2-live-family-signals.md
@@ -395,6 +395,8 @@ meta `surfaces` 增加 `events`（P1）与 `families`（P2）。页面按能力�
 
 ### P1 · 事件 + 图
 
+P1 已在本 PR 落地（事件尾、`parent` 投影、一层家族图、SSE `after=`）。P2 / P3 仍未实现。
+
 - 写入并读取 `.dyro/events.jsonl`。
 - line DTO 投影 `parent`。
 - 工作区详情出现家族树与事件流。

--- a/docs/designs/local-web-console.md
+++ b/docs/designs/local-web-console.md
@@ -4,6 +4,8 @@
 目标版本：0.6.0；与持久续航引擎同一发布列车
 适用范围：全局工作区、TaskGraph、Objective、Attention、证据元数据与本机健康状态
 
+后续：实时事件、一层家族图与家族频道见 [Console 实时家族与信号](console-v2-live-family-signals.md)。那是本文件与 [ADR 0005](../adr/0005-local-web-console.md) 的后续设计，扩展而不替换这里的只读快照契约。
+
 ## 1. 产品定位
 
 Dyro Console 是 **Dyro 权威状态的本地只读窗口**。它解决的不是“再提供一套操作系统”，而是让使用者在一个页面中快速回答：

--- a/src/dyro/cli.py
+++ b/src/dyro/cli.py
@@ -2137,6 +2137,17 @@ def cmd_host_seed(args: argparse.Namespace) -> None:
     workspace, lines = seed_configured_overlays(
         config, force=args.force, dry_run=args.dry_run
     )
+    if not args.dry_run and (workspace.written or any(item.written for _, item in lines)):
+        from .events import append_event
+
+        append_event(
+            config,
+            kind="host_seed",
+            actor="operator",
+            subject="overlay",
+            family="",
+            facts={"written": len(workspace.written) + sum(len(item.written) for _, item in lines)},
+        )
     prefix = "DRY RUN: " if args.dry_run else ""
     if workspace.written:
         print(f"{prefix}已写入 overlay {', '.join(workspace.written)}")

--- a/src/dyro/console/_inspect_worker.py
+++ b/src/dyro/console/_inspect_worker.py
@@ -239,6 +239,8 @@ def _decode_request(value: str) -> dict[str, object]:
         "cursor",
         "limit",
         "alias",
+        "after",
+        "parent",
         "target_root",
     }:
         raise ConsoleOverviewError("OVERVIEW_UNAVAILABLE")
@@ -313,6 +315,30 @@ def main(argv: list[str] | None = None) -> int:
             payload = service.inspect_proofs(alias)
         elif operation == "system":
             payload = service.system()
+        elif operation == "events":
+            alias = request.get("alias")
+            if not isinstance(alias, str):
+                raise ConsoleOverviewError("WORKSPACE_ALIAS_INVALID")
+            after = request.get("after")
+            if after is not None and not isinstance(after, str):
+                raise ConsoleOverviewError("EVENT_CURSOR_INVALID")
+            limit = request.get("limit", 50)
+            if type(limit) is not int:
+                raise ConsoleOverviewError("EVENT_LIMIT_INVALID")
+            payload = service.events(alias, after=after, limit=limit)
+        elif operation == "families":
+            alias = request.get("alias")
+            if not isinstance(alias, str):
+                raise ConsoleOverviewError("WORKSPACE_ALIAS_INVALID")
+            payload = service.families(alias)
+        elif operation == "family":
+            alias = request.get("alias")
+            parent = request.get("parent")
+            if not isinstance(alias, str):
+                raise ConsoleOverviewError("WORKSPACE_ALIAS_INVALID")
+            if not isinstance(parent, str):
+                raise ConsoleOverviewError("FAMILY_PARENT_INVALID")
+            payload = service.family(alias, parent)
         else:
             raise ConsoleOverviewError("OVERVIEW_UNAVAILABLE")
         return _response(payload)

--- a/src/dyro/console/assets.py
+++ b/src/dyro/console/assets.py
@@ -27,8 +27,8 @@ ASSET_MANIFEST = {
     ),
     "app.js": (
         "text/javascript; charset=utf-8",
-        "63a61d3549c54ce4e2735d96dd3023fbe549b4e3ff55903bfa27c1f879d7e46b",
-        47318,
+        "5ee284b3cd590ba114a64b1994ac79de64b7376bd38b5163f74176b704ac0113",
+        47380,
     ),
     "styles.css": (
         "text/css; charset=utf-8",

--- a/src/dyro/console/assets.py
+++ b/src/dyro/console/assets.py
@@ -27,13 +27,13 @@ ASSET_MANIFEST = {
     ),
     "app.js": (
         "text/javascript; charset=utf-8",
-        "beaa5e872359895d9af8aa0ae17c0ebbf60e369b4df4d46fd1e022164fe427af",
-        33027,
+        "63a61d3549c54ce4e2735d96dd3023fbe549b4e3ff55903bfa27c1f879d7e46b",
+        47318,
     ),
     "styles.css": (
         "text/css; charset=utf-8",
-        "f004307d19af82a906245affac01e2abc1efb39f0ae467c40cb7443f05262e9b",
-        12621,
+        "dbf956c627803fe47ad910ec79a6a0763e6a40c993fa2e96e5ec79739fcd3432",
+        14676,
     ),
 }
 

--- a/src/dyro/console/assets/app.js
+++ b/src/dyro/console/assets/app.js
@@ -1,6 +1,23 @@
 const SAFE_ID = /^[A-Za-z0-9][A-Za-z0-9._-]{0,79}$/;
 const TOKEN_KEY = "dyro.console.bearer";
-const state = { bearer: "", etags: new Map(), timer: null, focus: "", partial: false, surfaces: [], system: null };
+const state = {
+  bearer: "",
+  etags: new Map(),
+  timer: null,
+  focus: "",
+  partial: false,
+  surfaces: [],
+  system: null,
+  detailAlias: "",
+  detailTab: "family",
+  eventCursor: "",
+  eventAbort: null,
+  eventPoll: null,
+  eventItems: [],
+  liveEdges: new Set(),
+  sseFailed: false,
+  familyParent: "",
+};
 const HEALTH_LABELS = { healthy: "健康", degraded: "需关注", unavailable: "不可用" };
 const FRESHNESS_LABELS = { fresh: "读取完整", partial: "部分可读", stale: "待刷新" };
 const AVAILABILITY_LABELS = { available: "可用", unavailable: "不可用" };
@@ -104,6 +121,21 @@ const ERROR_LABELS = {
   OVERVIEW_UNAVAILABLE: "工作区概览暂时不可读取",
   WORKSPACE_UNAVAILABLE: "工作区当前不可用",
   SESSION_REJECTED: "本地会话未建立",
+  EVENT_CURSOR_INVALID: "事件游标已失效，已从头读取",
+  EVENT_STREAM_UNAVAILABLE: "实时事件流不可用，已回退轮询",
+  FAMILY_NOT_FOUND: "没有可展示的一层家族",
+};
+const EVENT_KIND_LABELS = {
+  spawn: "子线已创建",
+  merge: "子线已合入父线",
+  sync: "父线已同步到子线",
+  task_status: "任务状态已更新",
+  objective_wave: "目标波次",
+  dispatch: "派发",
+  board: "会审记录",
+  signal: "家族信号",
+  host_seed: "已写入 overlay",
+  EVENT_REDACTED: "已脱敏事件",
 };
 const UPDATE_KIND_LABELS = {
   none: "无已缓存更新",
@@ -208,13 +240,29 @@ function element(name, value = "") {
 
 function consumeFragment() {
   const raw = window.location.hash.startsWith("#") ? window.location.hash.slice(1) : "";
+  if (raw.startsWith("w/")) {
+    const parts = raw.split("/").filter(Boolean);
+    const alias = parts[1] || "";
+    const tab = parts[2] || "family";
+    state.focus = alias && SAFE_ID.test(alias) ? alias : "";
+    state.detailTab = ["family", "events", "channel"].includes(tab) ? tab : "family";
+    return "";
+  }
   const values = new URLSearchParams(raw);
   const bootstrap = values.get("bootstrap");
   const workspace = values.get("workspace");
   state.focus = workspace && SAFE_ID.test(workspace) ? workspace : "";
-  const safeRoute = state.focus ? `#workspace=${state.focus}` : "";
+  state.detailTab = "family";
+  const safeRoute = state.focus ? `#w/${state.focus}/family` : "";
   window.history.replaceState(null, "", `${window.location.pathname}${window.location.search}${safeRoute}`);
   return bootstrap && bootstrap.length <= 256 ? bootstrap : "";
+}
+
+function setWorkspaceRoute(alias, tab) {
+  const safeTab = ["family", "events", "channel"].includes(tab) ? tab : "family";
+  state.detailTab = safeTab;
+  const hash = alias && SAFE_ID.test(alias) ? `#w/${alias}/${safeTab}` : "";
+  window.history.replaceState(null, "", `${window.location.pathname}${window.location.search}${hash}`);
 }
 
 async function exchange(bootstrap) {
@@ -255,6 +303,7 @@ function expireSession() {
   state.etags.clear();
   window.clearTimeout(state.timer);
   state.timer = null;
+  stopEventLive();
   sessionStorage.removeItem(TOKEN_KEY);
   setStatus("本地会话已过期；请重新运行 dyro console。", true);
 }
@@ -730,13 +779,395 @@ async function loadSystem() {
   }
 }
 
+function stopEventLive() {
+  if (state.eventAbort) {
+    state.eventAbort.abort();
+    state.eventAbort = null;
+  }
+  if (state.eventPoll) {
+    window.clearTimeout(state.eventPoll);
+    state.eventPoll = null;
+  }
+}
+
+function familyChildren(lines, parentId) {
+  return lines
+    .filter((line) => text(line.parent) === parentId && SAFE_ID.test(text(line.id)))
+    .map((line) => text(line.id));
+}
+
+function familyParents(lines) {
+  return lines.map((line) => text(line.id)).filter((id) => SAFE_ID.test(id));
+}
+
+function lineInProgress(tasks, lineId) {
+  return tasks.some((task) => text(task.line) === lineId && text(task.status) === "in_progress");
+}
+
+function dryRunCommands(alias, parent, child) {
+  return [
+    `dyro --workspace ${alias} --dry-run line spawn ${parent} ${child}`,
+    `dyro --workspace ${alias} --dry-run line merge ${child} --into ${parent}`,
+    `dyro --workspace ${alias} --dry-run line sync ${child}`,
+  ];
+}
+
+function renderFamilyTree(alias, lines, tasks) {
+  const section = element("section");
+  section.className = "live-pane family-pane";
+  section.id = "family-pane";
+  section.append(element("h3", "家族"));
+  if (!hasSurface("events")) {
+    section.append(element("p", "家族树尚未开放。"));
+    return section;
+  }
+  const parents = familyParents(lines);
+  if (!parents.length) {
+    section.append(element("p", "这个项目还没有开发线。"));
+    return section;
+  }
+  const selected = parents.includes(state.familyParent) ? state.familyParent : parents[0];
+  state.familyParent = selected;
+  if (parents.length > 1) {
+    const nav = element("div");
+    nav.className = "family-picker";
+    nav.setAttribute("role", "tablist");
+    for (const parent of parents) {
+      const button = element("button", parent);
+      button.type = "button";
+      button.className = "secondary";
+      if (parent === selected) button.setAttribute("aria-current", "true");
+      button.addEventListener("click", () => {
+        state.familyParent = parent;
+        const tree = $("family-tree");
+        if (tree) tree.replaceWith(renderFamilyGraph(alias, lines, parent, tasks));
+      });
+      nav.append(button);
+    }
+    section.append(nav);
+  }
+  section.append(renderFamilyGraph(alias, lines, selected, tasks));
+  return section;
+}
+
+function familyBadges(id, tasks) {
+  const marks = element("p");
+  marks.className = "family-badges";
+  if (id === "operator") {
+    marks.append(element("span", "未读 0"));
+    return marks;
+  }
+  const busy = lineInProgress(tasks, id);
+  for (const label of [
+    "干净",
+    "远端已绑定",
+    busy ? "进行中" : "空闲",
+    "未读 0",
+  ]) {
+    const badge = element("span", label);
+    badge.className = "family-badge";
+    marks.append(badge);
+  }
+  return marks;
+}
+
+function edgeLabel(parent, child, live) {
+  return live ? `${parent} → ${child} · 刚有合入或同步` : `${parent} → ${child}`;
+}
+
+function renderFamilyGraph(alias, lines, parent, tasks) {
+  const wrap = element("div");
+  wrap.id = "family-tree";
+  wrap.className = "family-tree";
+  const children = familyChildren(lines, parent);
+  const members = [parent, ...children, "operator"];
+  const list = element("ul");
+  list.className = "family-nodes";
+  for (const id of members) {
+    const item = element("li");
+    item.className = "family-node";
+    item.dataset.role = id === parent ? "parent" : id === "operator" ? "operator" : "child";
+    const title = element("strong", id);
+    const role = element(
+      "span",
+      id === parent ? "父线" : id === "operator" ? "操作者" : "子线",
+    );
+    role.className = "family-role";
+    item.append(title, role, familyBadges(id, tasks));
+    if (id !== "operator" && id !== parent) {
+      const live = state.liveEdges.has(`${parent}>${id}`) || state.liveEdges.has(`${id}>${parent}`);
+      const edge = element("span", edgeLabel(parent, id, live));
+      edge.className = live ? "family-edge live" : "family-edge";
+      edge.dataset.from = parent;
+      edge.dataset.to = id;
+      item.append(edge);
+    }
+    list.append(item);
+  }
+  wrap.append(list);
+  const actions = element("div");
+  actions.className = "family-actions";
+  const child = children[0] || `${parent}_new`;
+  for (const command of dryRunCommands(alias, parent, child)) {
+    actions.append(commandRow(command));
+  }
+  wrap.append(element("p", "复制区只有 dry-run。页面不会执行 spawn、合入或同步。"));
+  wrap.append(actions);
+  return wrap;
+}
+
+function describeEvent(event) {
+  const kind = displayLabel(event && event.kind, EVENT_KIND_LABELS);
+  const actor = text(event && event.actor);
+  const subject = text(event && event.subject);
+  const when = text(event && event.at);
+  const local = when ? new Date(when).toLocaleString("zh-CN") : "";
+  const who = [actor, subject].filter(Boolean).join(" → ");
+  return [local, kind, who].filter(Boolean).join(" · ");
+}
+
+function applyLiveEdges(events) {
+  state.liveEdges = new Set();
+  for (const event of events) {
+    const parent = text(event && event.facts && event.facts.parent);
+    const child = text(event && event.facts && event.facts.child);
+    if (text(event && event.kind) === "merge" && parent && child) {
+      state.liveEdges.add(`${child}>${parent}`);
+    }
+    if (text(event && event.kind) === "sync" && parent && child) {
+      state.liveEdges.add(`${parent}>${child}`);
+    }
+  }
+  const tree = $("family-tree");
+  if (!tree) return;
+  for (const edge of tree.querySelectorAll(".family-edge")) {
+    const from = text(edge.dataset.from);
+    const to = text(edge.dataset.to);
+    const live = state.liveEdges.has(`${from}>${to}`) || state.liveEdges.has(`${to}>${from}`);
+    edge.classList.toggle("live", live);
+    edge.textContent = edgeLabel(from, to, live);
+  }
+}
+
+function renderEventList() {
+  const list = $("event-list");
+  if (!list) return;
+  list.replaceChildren();
+  if (!state.eventItems.length) {
+    list.append(element("li", "还没有直播事件。"));
+    return;
+  }
+  for (const event of [...state.eventItems].reverse()) {
+    list.append(element("li", describeEvent(event)));
+  }
+}
+
+function appendEvents(events) {
+  if (!Array.isArray(events) || !events.length) return;
+  const seen = new Set(state.eventItems.map((item) => text(item.id)));
+  for (const event of events) {
+    const id = text(event && event.id);
+    if (!id || seen.has(id)) continue;
+    state.eventItems.push(event);
+    seen.add(id);
+  }
+  if (state.eventItems.length > 100) {
+    state.eventItems = state.eventItems.slice(-100);
+  }
+  applyLiveEdges(state.eventItems);
+  renderEventList();
+}
+
+function consumeSse(buffer) {
+  const parts = buffer.split("\n\n");
+  const rest = parts.pop() || "";
+  for (const block of parts) {
+    let data = "";
+    let id = "";
+    for (const line of block.split("\n")) {
+      if (line.startsWith("data:")) data += line.slice(5).trim();
+      if (line.startsWith("id:")) id = line.slice(3).trim();
+    }
+    if (id && /^[A-Za-z0-9_-]+$/.test(id)) state.eventCursor = id;
+    if (!data || data.startsWith(":")) continue;
+    try {
+      const parsed = JSON.parse(data);
+      if (parsed && typeof parsed === "object") appendEvents([parsed]);
+    } catch (_) {
+      /* ignore a partial or redacted frame */
+    }
+  }
+  return rest;
+}
+
+async function pullEvents(alias) {
+  const after = state.eventCursor ? `?after=${encodeURIComponent(state.eventCursor)}` : "";
+  const payload = await request(
+    `/api/v1/workspaces/${encodeURIComponent(alias)}/events${after}`,
+    `events:${alias}:${state.eventCursor || "0"}`,
+  );
+  if (!payload || !payload.data) return;
+  appendEvents(Array.isArray(payload.data.events) ? payload.data.events : []);
+  const cursor = text(payload.data.next_cursor);
+  if (cursor) state.eventCursor = cursor;
+}
+
+function startEventPoll(alias) {
+  window.clearTimeout(state.eventPoll);
+  if (!state.bearer || document.hidden || state.detailAlias !== alias) return;
+  state.eventPoll = window.setTimeout(async () => {
+    try {
+      await pullEvents(alias);
+    } catch (error) {
+      if (error && error.message === "SESSION_EXPIRED") {
+        expireSession();
+        return;
+      }
+      if (error && error.message === "EVENT_CURSOR_INVALID") {
+        state.eventCursor = "";
+        state.etags.delete(`events:${alias}:${state.eventCursor || "0"}`);
+      }
+    }
+    startEventPoll(alias);
+  }, 5000);
+}
+
+async function openEventStream(alias) {
+  const controller = new AbortController();
+  state.eventAbort = controller;
+  const after = state.eventCursor ? `?after=${encodeURIComponent(state.eventCursor)}` : "";
+  const response = await fetch(
+    `/api/v1/workspaces/${encodeURIComponent(alias)}/events/stream${after}`,
+    {
+      headers: { Authorization: `Bearer ${state.bearer}` },
+      cache: "no-store",
+      credentials: "omit",
+      signal: controller.signal,
+    },
+  );
+  if (response.status === 401) throw new Error("SESSION_EXPIRED");
+  if (response.status === 405 || !response.ok || !response.body) {
+    throw new Error("EVENT_STREAM_UNAVAILABLE");
+  }
+  const reader = response.body.getReader();
+  const decoder = new TextDecoder();
+  let buffer = "";
+  while (true) {
+    const { value, done } = await reader.read();
+    if (done) break;
+    buffer = consumeSse(buffer + decoder.decode(value, { stream: true }));
+  }
+}
+
+async function startEventLive(alias) {
+  stopEventLive();
+  if (!hasSurface("events") || document.hidden || !SAFE_ID.test(alias)) return;
+  state.detailAlias = alias;
+  if (state.sseFailed) {
+    try {
+      await pullEvents(alias);
+    } catch (error) {
+      if (error && error.message === "SESSION_EXPIRED") throw error;
+    }
+    startEventPoll(alias);
+    return;
+  }
+  try {
+    await openEventStream(alias);
+    if (!document.hidden && state.detailAlias === alias) {
+      startEventPoll(alias);
+    }
+  } catch (error) {
+    if (error && error.message === "SESSION_EXPIRED") throw error;
+    if (error && error.name === "AbortError") return;
+    state.sseFailed = true;
+    try {
+      await pullEvents(alias);
+    } catch (pullError) {
+      if (pullError && pullError.message === "SESSION_EXPIRED") throw pullError;
+    }
+    startEventPoll(alias);
+  }
+}
+
+function renderEventPane() {
+  const section = element("section");
+  section.className = "live-pane event-pane";
+  section.id = "event-pane";
+  section.append(element("h3", "事件"));
+  if (!hasSurface("events")) {
+    section.append(element("p", "事件流尚未开放。"));
+    return section;
+  }
+  const list = element("ul");
+  list.id = "event-list";
+  list.className = "event-list";
+  section.append(list);
+  return section;
+}
+
+function renderChannelPane() {
+  const section = element("section");
+  section.className = "live-pane channel-pane";
+  section.id = "channel-pane";
+  section.append(element("h3", "频道"));
+  section.append(element("p", "尚未开放"));
+  section.append(element("p", "产物尚未开放"));
+  return section;
+}
+
+function renderLivePanes(alias, data) {
+  const root = element("div");
+  root.className = "live-panes";
+  root.id = "live-panes";
+  const tabs = element("div");
+  tabs.className = "live-tabs";
+  tabs.setAttribute("role", "tablist");
+  for (const [id, label] of [["family", "家族"], ["events", "事件"], ["channel", "频道"]]) {
+    const button = element("button", label);
+    button.type = "button";
+    button.dataset.tab = id;
+    if (state.detailTab === id) button.setAttribute("aria-current", "true");
+    button.addEventListener("click", () => {
+      state.detailTab = id;
+      setWorkspaceRoute(alias, id);
+      root.dataset.tab = id;
+      for (const item of tabs.querySelectorAll("button")) {
+        if (text(item.dataset.tab) === id) item.setAttribute("aria-current", "true");
+        else item.removeAttribute("aria-current");
+      }
+    });
+    tabs.append(button);
+  }
+  root.dataset.tab = state.detailTab;
+  root.append(tabs);
+  const lines = Array.isArray(data && data.lines) ? data.lines : [];
+  const tasks = Array.isArray(data && data.tasks) ? data.tasks : [];
+  root.append(renderFamilyTree(alias, lines, tasks), renderEventPane(), renderChannelPane());
+  return root;
+}
+
+function resetEventState() {
+  stopEventLive();
+  state.eventCursor = "";
+  state.eventItems = [];
+  state.liveEdges = new Set();
+  state.sseFailed = false;
+}
+
 async function loadWorkspace(alias, silent = false) {
   if (!SAFE_ID.test(alias)) return;
+  if (state.detailAlias && state.detailAlias !== alias) {
+    resetEventState();
+  }
   try {
     const payload = await request(`/api/v1/workspaces/${encodeURIComponent(alias)}`, `workspace:${alias}`);
     if (!payload) return;
     const summary = payload.data && payload.data.workspace;
     if (!summary) throw new Error("WORKSPACE_UNAVAILABLE");
+    state.focus = alias;
+    state.detailAlias = alias;
+    setWorkspaceRoute(alias, state.detailTab || "family");
     const detail = $("workspace-detail");
     const content = $("detail-content");
     const grid = element("dl");
@@ -757,8 +1188,11 @@ async function loadWorkspace(alias, silent = false) {
     const command = text(summary.recommendation && summary.recommendation.command);
     if (command) content.append(commandRow(command));
     content.append(await loadProofInspect(alias));
+    content.append(renderLivePanes(alias, payload.data));
+    renderEventList();
     detail.hidden = false;
     $("detail-heading").focus();
+    await startEventLive(alias);
   } catch (error) {
     if (error && error.message === "SESSION_EXPIRED") {
       expireSession();
@@ -819,13 +1253,22 @@ async function start() {
     const command = text(button.dataset.command);
     if (command) copyCommand(command, button);
   });
-  $("detail-close").addEventListener("click", () => { $("workspace-detail").hidden = true; });
+  $("detail-close").addEventListener("click", () => {
+    resetEventState();
+    state.detailAlias = "";
+    $("workspace-detail").hidden = true;
+    setWorkspaceRoute("", "family");
+  });
   document.addEventListener("visibilitychange", () => {
     if (document.hidden) {
       scheduleRefresh();
+      stopEventLive();
       return;
     }
     refresh().finally(scheduleRefresh);
+    if (state.detailAlias) {
+      startEventLive(state.detailAlias).catch(() => {});
+    }
   });
   const bootstrap = consumeFragment();
   try {
@@ -842,6 +1285,7 @@ async function start() {
     }
     await refresh({ includeSystem: true });
     scheduleRefresh();
+    if (state.focus) await loadWorkspace(state.focus, true);
   } catch (error) {
     if (error && error.message === "SESSION_EXPIRED") {
       expireSession();

--- a/src/dyro/console/assets/app.js
+++ b/src/dyro/console/assets/app.js
@@ -858,9 +858,10 @@ function familyBadges(id, tasks) {
     return marks;
   }
   const busy = lineInProgress(tasks, id);
+  // Git cleanliness and origin binding are not inspected in P1.
   for (const label of [
-    "干净",
-    "远端已绑定",
+    "未检查",
+    "未检查",
     busy ? "进行中" : "空闲",
     "未读 0",
   ]) {

--- a/src/dyro/console/assets/styles.css
+++ b/src/dyro/console/assets/styles.css
@@ -322,6 +322,60 @@ footer { border-top: 1px solid var(--border); color: var(--muted); font-size: .8
   .command { align-items: stretch; flex-direction: column; }
 }
 
+.live-panes {
+  border-top: 1px solid var(--border);
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  margin-top: 1.15rem;
+  padding-top: 1rem;
+}
+.live-tabs { display: none; }
+.live-pane {
+  background: var(--surface-muted);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-medium);
+  padding: 0.9rem;
+}
+.live-pane h3 { font-size: .95rem; margin: 0 0 .5rem; }
+.live-pane p, .live-pane ul { color: var(--subtle); font-size: .86rem; margin: 0; }
+.family-picker { display: flex; flex-wrap: wrap; gap: .4rem; margin-bottom: .75rem; }
+.family-nodes { list-style: none; margin: 0; padding: 0; }
+.family-node {
+  border-left: 3px solid var(--border-strong);
+  margin: .45rem 0;
+  padding: .35rem 0 .35rem .7rem;
+}
+.family-node[data-role="parent"] { border-left-color: var(--accent); }
+.family-node[data-role="operator"] { border-left-color: var(--success); }
+.family-role { color: var(--subtle); display: block; font-size: .75rem; }
+.family-badges { display: flex; flex-wrap: wrap; gap: .35rem; margin: .3rem 0 0; }
+.family-badge {
+  border: 1px solid var(--border-strong);
+  border-radius: .35rem;
+  color: var(--text);
+  font-size: .72rem;
+  padding: .1rem .35rem;
+}
+.family-edge { display: block; font-size: .75rem; margin-top: .2rem; }
+.family-edge.live { font-weight: 700; }
+.family-actions { margin-top: .75rem; }
+.event-list { list-style: none; max-height: 16rem; overflow: auto; padding: 0; }
+.event-list li { border-top: 1px solid var(--border); padding: .35rem 0; }
+.event-list li:first-child { border-top: 0; }
+
+@media (max-width: 767px) {
+  .live-panes { grid-template-columns: 1fr; }
+  .live-tabs { display: flex; gap: .4rem; margin-bottom: .75rem; }
+  .live-panes[data-tab="family"] .event-pane,
+  .live-panes[data-tab="family"] .channel-pane,
+  .live-panes[data-tab="events"] .family-pane,
+  .live-panes[data-tab="events"] .channel-pane,
+  .live-panes[data-tab="channel"] .family-pane,
+  .live-panes[data-tab="channel"] .event-pane { display: none; }
+}
+
 @media (prefers-reduced-motion: reduce) {
   *, *::before, *::after { scroll-behavior: auto !important; transition-duration: 0.01ms !important; }
+  .family-edge.live { font-weight: 700; }
 }

--- a/src/dyro/console/events.py
+++ b/src/dyro/console/events.py
@@ -1,0 +1,181 @@
+"""Console DTO and HMAC cursor for workspace ``.dyro/events.jsonl``."""
+
+from __future__ import annotations
+
+import base64
+from collections.abc import Mapping
+import hashlib
+import hmac
+import json
+from typing import Any
+
+from ..canonical import canonical_json_bytes
+from ..config import Config
+from ..events import (
+    DEFAULT_EVENT_LIMIT,
+    EVENT_KINDS,
+    MAX_EVENT_LIMIT,
+    EventLogError,
+    event_at,
+    read_events,
+)
+from .overview import ConsoleOverviewError
+from .redaction import REDACTED, safe_id
+
+
+_CURSOR_SCHEMA = 1
+_CURSOR_MAX_LENGTH = 512
+
+
+def _stable_json(value: object) -> bytes:
+    return canonical_json_bytes(value)
+
+
+def encode_event_cursor(
+    secret: bytes,
+    *,
+    after_seq: int,
+    event_id: str,
+) -> str:
+    body = _stable_json(
+        {
+            "schema_version": _CURSOR_SCHEMA,
+            "after": after_seq,
+            "event_id": event_id,
+        }
+    )
+    signature = hmac.new(secret, body, hashlib.sha256).digest()
+    return base64.urlsafe_b64encode(body + signature).rstrip(b"=").decode("ascii")
+
+
+def decode_event_cursor(secret: bytes, value: str) -> tuple[int, str]:
+    if not isinstance(value, str) or not value or len(value) > _CURSOR_MAX_LENGTH:
+        raise ConsoleOverviewError("EVENT_CURSOR_INVALID")
+    try:
+        raw = base64.urlsafe_b64decode(value + "=" * (-len(value) % 4))
+    except (ValueError, UnicodeError) as exc:
+        raise ConsoleOverviewError("EVENT_CURSOR_INVALID") from exc
+    if len(raw) <= hashlib.sha256().digest_size:
+        raise ConsoleOverviewError("EVENT_CURSOR_INVALID")
+    body, signature = raw[:-32], raw[-32:]
+    expected = hmac.new(secret, body, hashlib.sha256).digest()
+    if not hmac.compare_digest(expected, signature):
+        raise ConsoleOverviewError("EVENT_CURSOR_INVALID")
+    try:
+        decoded: Any = json.loads(body.decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise ConsoleOverviewError("EVENT_CURSOR_INVALID") from exc
+    if (
+        not isinstance(decoded, dict)
+        or set(decoded) != {"schema_version", "after", "event_id"}
+        or decoded["schema_version"] != _CURSOR_SCHEMA
+        or type(decoded["after"]) is not int
+        or decoded["after"] < 1
+        or not isinstance(decoded["event_id"], str)
+    ):
+        raise ConsoleOverviewError("EVENT_CURSOR_INVALID")
+    return decoded["after"], decoded["event_id"]
+
+
+def _safe_fact_value(value: object) -> str | int | bool | None:
+    if type(value) is bool:
+        return value
+    if type(value) is int and not isinstance(value, bool) and 0 <= value <= 1_000_000:
+        return value
+    if isinstance(value, str) and len(value) <= 80:
+        token = safe_id(value)
+        if value == "" or token != REDACTED:
+            return value if value == "" else token
+        if all(ord(char) >= 32 and ord(char) != 127 for char in value):
+            lowered = value.lower()
+            if not any(item in lowered for item in ("/", "\\", "http:", "https:", "token", "secret")):
+                return value
+    return None
+
+
+def project_event(record: Mapping[str, object]) -> dict[str, object]:
+    kind = record.get("kind")
+    seq = record.get("seq")
+    event_id = record.get("id")
+    at = record.get("at")
+    if type(seq) is not int or not isinstance(event_id, str) or not isinstance(at, str):
+        return {
+            "seq": 0,
+            "id": "evt_0",
+            "kind": "EVENT_REDACTED",
+            "at": "",
+            "actor": "",
+            "subject": "",
+            "family": "",
+            "facts": {},
+        }
+    if kind not in EVENT_KINDS:
+        return {
+            "seq": seq,
+            "id": event_id,
+            "kind": "EVENT_REDACTED",
+            "at": at,
+            "actor": "",
+            "subject": "",
+            "family": "",
+            "facts": {},
+        }
+    facts_in = record.get("facts")
+    facts: dict[str, str | int | bool] = {}
+    if isinstance(facts_in, dict):
+        for key, value in facts_in.items():
+            if not isinstance(key, str) or safe_id(key) == REDACTED:
+                continue
+            cleaned = _safe_fact_value(value)
+            if cleaned is not None:
+                facts[key] = cleaned
+    actor = safe_id(record.get("actor"))
+    subject = safe_id(record.get("subject"))
+    family_raw = record.get("family")
+    family = "" if family_raw == "" else safe_id(family_raw)
+    return {
+        "seq": seq,
+        "id": event_id,
+        "kind": kind,
+        "at": at,
+        "actor": "" if actor == REDACTED else actor,
+        "subject": "" if subject == REDACTED else subject,
+        "family": "" if family == REDACTED else family,
+        "facts": facts,
+    }
+
+
+def event_page(
+    config: Config,
+    *,
+    secret: bytes,
+    after: str | None,
+    limit: int = DEFAULT_EVENT_LIMIT,
+) -> dict[str, object]:
+    if type(limit) is not int or not 1 <= limit <= MAX_EVENT_LIMIT:
+        raise ConsoleOverviewError("EVENT_LIMIT_INVALID")
+    after_seq = 0
+    if after:
+        after_seq, event_id = decode_event_cursor(secret, after)
+        current = event_at(config, after_seq)
+        if current is None or current.get("id") != event_id:
+            raise ConsoleOverviewError("EVENT_CURSOR_INVALID")
+    try:
+        records, _last_seq = read_events(config, after_seq=after_seq, limit=limit)
+    except EventLogError as exc:
+        raise ConsoleOverviewError(exc.code) from exc
+    events = [project_event(item) for item in records]
+    if events:
+        next_cursor = encode_event_cursor(
+            secret,
+            after_seq=int(events[-1]["seq"]),
+            event_id=str(events[-1]["id"]),
+        )
+    elif after:
+        next_cursor = after
+    else:
+        next_cursor = None
+    return {
+        "events": events,
+        "next_cursor": next_cursor,
+    }

--- a/src/dyro/console/events.py
+++ b/src/dyro/console/events.py
@@ -23,12 +23,27 @@ from .overview import ConsoleOverviewError
 from .redaction import REDACTED, safe_id
 
 
-_CURSOR_SCHEMA = 1
+_CURSOR_SCHEMA = 2
 _CURSOR_MAX_LENGTH = 512
+_DIGEST_HEX = frozenset("0123456789abcdef")
 
 
 def _stable_json(value: object) -> bytes:
     return canonical_json_bytes(value)
+
+
+def event_cursor_digest(record: Mapping[str, object]) -> str:
+    """Bind a cursor to the row body, not only ``evt_{seq}``."""
+    facts = record.get("facts")
+    payload = {
+        "kind": record.get("kind", ""),
+        "at": record.get("at", ""),
+        "actor": record.get("actor", ""),
+        "subject": record.get("subject", ""),
+        "family": record.get("family", ""),
+        "facts": facts if isinstance(facts, dict) else {},
+    }
+    return hashlib.sha256(canonical_json_bytes(payload)).hexdigest()
 
 
 def encode_event_cursor(
@@ -36,19 +51,21 @@ def encode_event_cursor(
     *,
     after_seq: int,
     event_id: str,
+    digest: str,
 ) -> str:
     body = _stable_json(
         {
             "schema_version": _CURSOR_SCHEMA,
             "after": after_seq,
             "event_id": event_id,
+            "digest": digest,
         }
     )
     signature = hmac.new(secret, body, hashlib.sha256).digest()
     return base64.urlsafe_b64encode(body + signature).rstrip(b"=").decode("ascii")
 
 
-def decode_event_cursor(secret: bytes, value: str) -> tuple[int, str]:
+def decode_event_cursor(secret: bytes, value: str) -> tuple[int, str, str]:
     if not isinstance(value, str) or not value or len(value) > _CURSOR_MAX_LENGTH:
         raise ConsoleOverviewError("EVENT_CURSOR_INVALID")
     try:
@@ -65,16 +82,20 @@ def decode_event_cursor(secret: bytes, value: str) -> tuple[int, str]:
         decoded: Any = json.loads(body.decode("utf-8"))
     except (UnicodeDecodeError, json.JSONDecodeError) as exc:
         raise ConsoleOverviewError("EVENT_CURSOR_INVALID") from exc
+    digest = decoded.get("digest") if isinstance(decoded, dict) else None
     if (
         not isinstance(decoded, dict)
-        or set(decoded) != {"schema_version", "after", "event_id"}
+        or set(decoded) != {"schema_version", "after", "event_id", "digest"}
         or decoded["schema_version"] != _CURSOR_SCHEMA
         or type(decoded["after"]) is not int
         or decoded["after"] < 1
         or not isinstance(decoded["event_id"], str)
+        or not isinstance(digest, str)
+        or len(digest) != 64
+        or any(char not in _DIGEST_HEX for char in digest)
     ):
         raise ConsoleOverviewError("EVENT_CURSOR_INVALID")
-    return decoded["after"], decoded["event_id"]
+    return decoded["after"], decoded["event_id"], digest
 
 
 def _safe_fact_value(value: object) -> str | int | bool | None:
@@ -84,13 +105,15 @@ def _safe_fact_value(value: object) -> str | int | bool | None:
         return value
     if isinstance(value, str) and len(value) <= 80:
         token = safe_id(value)
-        if value == "" or token != REDACTED:
-            return value if value == "" else token
-        if all(ord(char) >= 32 and ord(char) != 127 for char in value):
-            lowered = value.lower()
-            if not any(item in lowered for item in ("/", "\\", "http:", "https:", "token", "secret")):
-                return value
+        if token != REDACTED:
+            return token
     return None
+
+
+def is_safe_event_fact(key: object, value: object) -> bool:
+    if not isinstance(key, str) or safe_id(key) == REDACTED:
+        return False
+    return _safe_fact_value(value) is not None
 
 
 def project_event(record: Mapping[str, object]) -> dict[str, object]:
@@ -124,7 +147,7 @@ def project_event(record: Mapping[str, object]) -> dict[str, object]:
     facts: dict[str, str | int | bool] = {}
     if isinstance(facts_in, dict):
         for key, value in facts_in.items():
-            if not isinstance(key, str) or safe_id(key) == REDACTED:
+            if not is_safe_event_fact(key, value):
                 continue
             cleaned = _safe_fact_value(value)
             if cleaned is not None:
@@ -156,20 +179,26 @@ def event_page(
         raise ConsoleOverviewError("EVENT_LIMIT_INVALID")
     after_seq = 0
     if after:
-        after_seq, event_id = decode_event_cursor(secret, after)
+        after_seq, event_id, digest = decode_event_cursor(secret, after)
         current = event_at(config, after_seq)
-        if current is None or current.get("id") != event_id:
+        if (
+            current is None
+            or current.get("id") != event_id
+            or event_cursor_digest(current) != digest
+        ):
             raise ConsoleOverviewError("EVENT_CURSOR_INVALID")
     try:
         records, _last_seq = read_events(config, after_seq=after_seq, limit=limit)
     except EventLogError as exc:
         raise ConsoleOverviewError(exc.code) from exc
     events = [project_event(item) for item in records]
-    if events:
+    if records:
+        last = records[-1]
         next_cursor = encode_event_cursor(
             secret,
-            after_seq=int(events[-1]["seq"]),
-            event_id=str(events[-1]["id"]),
+            after_seq=int(last["seq"]),
+            event_id=str(last["id"]),
+            digest=event_cursor_digest(last),
         )
     elif after:
         next_cursor = after

--- a/src/dyro/console/families.py
+++ b/src/dyro/console/families.py
@@ -1,0 +1,79 @@
+"""Console DTO for one-level family graphs. Channel POST is P2 and absent."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+
+from ..families import OPERATOR_ID, family_children, family_graph, family_ids
+from .redaction import REDACTED, safe_id
+
+
+def _line_id(value: object) -> str:
+    token = safe_id(value)
+    return "" if token == REDACTED else token
+
+
+def family_badges(
+    lines: Sequence[Mapping[str, object]],
+    tasks: Sequence[Mapping[str, object]],
+) -> dict[str, dict[str, object]]:
+    """P1 badges: in-progress from tasks; dirty / missing-origin stay false."""
+    in_progress: set[str] = set()
+    for task in tasks:
+        if task.get("status") == "in_progress":
+            line_id = _line_id(task.get("line"))
+            if line_id:
+                in_progress.add(line_id)
+    badges: dict[str, dict[str, object]] = {}
+    for line in lines:
+        line_id = _line_id(line.get("id"))
+        if not line_id:
+            continue
+        badges[line_id] = {
+            "dirty": False,
+            "missing_origin": False,
+            "in_progress": line_id in in_progress,
+            "unread": 0,
+        }
+    badges[OPERATOR_ID] = {
+        "dirty": False,
+        "missing_origin": False,
+        "in_progress": False,
+        "unread": 0,
+    }
+    return badges
+
+
+def family_cards(
+    lines: Sequence[Mapping[str, object]],
+    tasks: Sequence[Mapping[str, object]],
+) -> list[dict[str, object]]:
+    badges = family_badges(lines, tasks)
+    cards: list[dict[str, object]] = []
+    for parent_id in family_ids(lines):
+        safe_parent = _line_id(parent_id)
+        if not safe_parent:
+            continue
+        children = [_line_id(item) for item in family_children(lines, safe_parent)]
+        children = [item for item in children if item]
+        marks = [badges.get(safe_parent, {}), *(badges.get(child, {}) for child in children)]
+        cards.append(
+            {
+                "parent": safe_parent,
+                "children": children,
+                "unread": 0,
+                "dirty": sum(1 for item in marks if item.get("dirty")),
+                "missing_origin": sum(1 for item in marks if item.get("missing_origin")),
+                "in_progress": sum(1 for item in marks if item.get("in_progress")),
+            }
+        )
+    return cards
+
+
+def family_payload(
+    lines: Sequence[Mapping[str, object]],
+    parent_id: str,
+    tasks: Sequence[Mapping[str, object]],
+) -> dict[str, object]:
+    graph = family_graph(lines, parent_id, badges=family_badges(lines, tasks))
+    return dict(graph)

--- a/src/dyro/console/families.py
+++ b/src/dyro/console/families.py
@@ -17,7 +17,7 @@ def family_badges(
     lines: Sequence[Mapping[str, object]],
     tasks: Sequence[Mapping[str, object]],
 ) -> dict[str, dict[str, object]]:
-    """P1 badges: in-progress from tasks; dirty / missing-origin stay false."""
+    """P1 badges: in-progress from tasks; dirty / missing-origin are uninspected."""
     in_progress: set[str] = set()
     for task in tasks:
         if task.get("status") == "in_progress":

--- a/src/dyro/console/inspection.py
+++ b/src/dyro/console/inspection.py
@@ -19,6 +19,7 @@ from typing import Any
 
 from ..canonical import canonical_json_bytes
 from ..hub import registry_home
+from .events import is_safe_event_fact
 from .overview import ConsoleOverviewError
 from .redaction import REDACTED, safe_branch, safe_id, safe_sha256, safe_title
 
@@ -427,6 +428,9 @@ class IsolatedOverviewService:
                 or len(facts) > 16
             ):
                 raise ConsoleOverviewError("OVERVIEW_UNAVAILABLE")
+            for key, value in facts.items():
+                if not is_safe_event_fact(key, value):
+                    raise ConsoleOverviewError("OVERVIEW_UNAVAILABLE")
         cursor = data["next_cursor"]
         if cursor is not None and (not isinstance(cursor, str) or not _CURSOR.fullmatch(cursor)):
             raise ConsoleOverviewError("OVERVIEW_UNAVAILABLE")

--- a/src/dyro/console/inspection.py
+++ b/src/dyro/console/inspection.py
@@ -31,7 +31,7 @@ _WARNING_CODE = re.compile(r"^[A-Z][A-Z0-9_]{2,79}$")
 _ATTENTION_KINDS = frozenset(
     {"repair_required", "needs_user", "ready", "paused", "waiting"}
 )
-_LINE_KEYS = frozenset({"id", "kind", "branch", "base", "repository_count"})
+_LINE_KEYS = frozenset({"id", "kind", "branch", "base", "repository_count", "parent"})
 _TASK_KEYS = frozenset(
     {
         "id",
@@ -140,11 +140,25 @@ class IsolatedOverviewService:
     def inspect_proofs(self, alias: str) -> dict[str, object]:
         return self._request({"op": "inspect_proofs", "alias": alias})
 
+    def events(
+        self, alias: str, *, after: str | None = None, limit: int = 50
+    ) -> dict[str, object]:
+        request: dict[str, object] = {"op": "events", "alias": alias, "limit": limit}
+        if after:
+            request["after"] = after
+        return self._request(request)
+
+    def families(self, alias: str) -> dict[str, object]:
+        return self._request({"op": "families", "alias": alias})
+
+    def family(self, alias: str, parent: str) -> dict[str, object]:
+        return self._request({"op": "family", "alias": alias, "parent": parent})
+
     def system(self) -> dict[str, object]:
         return self._request({"op": "system"})
 
     def _request(self, request: Mapping[str, object]) -> dict[str, object]:
-        worker_request = dict(request)
+        worker_request = {key: value for key, value in dict(request).items() if value is not None}
         if self._target_root is not None:
             worker_request["target_root"] = str(self._target_root)
         encoded_request = base64.urlsafe_b64encode(
@@ -318,6 +332,15 @@ class IsolatedOverviewService:
         if expected_operation == "system":
             cls._validate_system(data)
             return
+        if expected_operation == "events":
+            cls._validate_events(data)
+            return
+        if expected_operation == "families":
+            cls._validate_families(data)
+            return
+        if expected_operation == "family":
+            cls._validate_family(data)
+            return
         if expected_operation == "workspace":
             if set(data) != {"workspace", "lines", "tasks", "objectives"}:
                 raise ConsoleOverviewError("OVERVIEW_UNAVAILABLE")
@@ -362,6 +385,130 @@ class IsolatedOverviewService:
                 not cls._safe_alias(highest.get("alias"))
                 or highest.get("kind") not in _ATTENTION_KINDS
                 or not cls._safe_code(highest.get("reason"))
+            ):
+                raise ConsoleOverviewError("OVERVIEW_UNAVAILABLE")
+
+    @classmethod
+    def _validate_events(cls, data: dict[str, object]) -> None:
+        if set(data) != {"events", "next_cursor"}:
+            raise ConsoleOverviewError("OVERVIEW_UNAVAILABLE")
+        events = data["events"]
+        if not isinstance(events, list) or len(events) > 100:
+            raise ConsoleOverviewError("OVERVIEW_UNAVAILABLE")
+        for item in events:
+            if not isinstance(item, dict) or set(item) != {
+                "seq",
+                "id",
+                "kind",
+                "at",
+                "actor",
+                "subject",
+                "family",
+                "facts",
+            }:
+                raise ConsoleOverviewError("OVERVIEW_UNAVAILABLE")
+            if type(item.get("seq")) is not int or item["seq"] < 0:
+                raise ConsoleOverviewError("OVERVIEW_UNAVAILABLE")
+            event_id = item.get("id")
+            kind = item.get("kind")
+            at = item.get("at")
+            facts = item.get("facts")
+            if (
+                not isinstance(event_id, str)
+                or len(event_id) > 80
+                or not isinstance(kind, str)
+                or not (kind == "EVENT_REDACTED" or cls._safe_code(kind))
+                or not isinstance(at, str)
+                or len(at) > 40
+                or not (item.get("actor") == "" or cls._safe_alias(item.get("actor")))
+                or not (item.get("subject") == "" or cls._safe_alias(item.get("subject")))
+                or not (item.get("family") == "" or cls._safe_alias(item.get("family")))
+                or not isinstance(facts, dict)
+                or len(facts) > 16
+            ):
+                raise ConsoleOverviewError("OVERVIEW_UNAVAILABLE")
+        cursor = data["next_cursor"]
+        if cursor is not None and (not isinstance(cursor, str) or not _CURSOR.fullmatch(cursor)):
+            raise ConsoleOverviewError("OVERVIEW_UNAVAILABLE")
+
+    @classmethod
+    def _validate_families(cls, data: dict[str, object]) -> None:
+        if set(data) != {"families"}:
+            raise ConsoleOverviewError("OVERVIEW_UNAVAILABLE")
+        families = data["families"]
+        if not isinstance(families, list) or len(families) > 1000:
+            raise ConsoleOverviewError("OVERVIEW_UNAVAILABLE")
+        for item in families:
+            if not isinstance(item, dict) or set(item) != {
+                "parent",
+                "children",
+                "unread",
+                "dirty",
+                "missing_origin",
+                "in_progress",
+            }:
+                raise ConsoleOverviewError("OVERVIEW_UNAVAILABLE")
+            children = item.get("children")
+            if (
+                not cls._safe_alias(item.get("parent"))
+                or not isinstance(children, list)
+                or not all(cls._safe_alias(child) for child in children)
+                or not cls._count(item.get("unread"))
+                or not cls._count(item.get("dirty"))
+                or not cls._count(item.get("missing_origin"))
+                or not cls._count(item.get("in_progress"))
+            ):
+                raise ConsoleOverviewError("OVERVIEW_UNAVAILABLE")
+
+    @classmethod
+    def _validate_family(cls, data: dict[str, object]) -> None:
+        if set(data) != {"parent", "members", "nodes", "edges"}:
+            raise ConsoleOverviewError("OVERVIEW_UNAVAILABLE")
+        if not cls._safe_alias(data.get("parent")):
+            raise ConsoleOverviewError("OVERVIEW_UNAVAILABLE")
+        members = data["members"]
+        nodes = data["nodes"]
+        edges = data["edges"]
+        if (
+            not isinstance(members, list)
+            or not isinstance(nodes, list)
+            or not isinstance(edges, list)
+            or len(members) > 1000
+            or len(nodes) > 1000
+            or len(edges) > 1000
+        ):
+            raise ConsoleOverviewError("OVERVIEW_UNAVAILABLE")
+        for member in members:
+            if member != "operator" and not cls._safe_alias(member):
+                raise ConsoleOverviewError("OVERVIEW_UNAVAILABLE")
+        for node in nodes:
+            if not isinstance(node, dict) or set(node) != {
+                "id",
+                "role",
+                "dirty",
+                "missing_origin",
+                "in_progress",
+                "unread",
+            }:
+                raise ConsoleOverviewError("OVERVIEW_UNAVAILABLE")
+            node_id = node.get("id")
+            if node_id != "operator" and not cls._safe_alias(node_id):
+                raise ConsoleOverviewError("OVERVIEW_UNAVAILABLE")
+            if (
+                node.get("role") not in {"parent", "child", "operator"}
+                or type(node.get("dirty")) is not bool
+                or type(node.get("missing_origin")) is not bool
+                or type(node.get("in_progress")) is not bool
+                or not cls._count(node.get("unread"))
+            ):
+                raise ConsoleOverviewError("OVERVIEW_UNAVAILABLE")
+        for edge in edges:
+            if not isinstance(edge, dict) or set(edge) != {"from", "to", "kind"}:
+                raise ConsoleOverviewError("OVERVIEW_UNAVAILABLE")
+            if (
+                not cls._safe_alias(edge.get("from"))
+                or not cls._safe_alias(edge.get("to"))
+                or edge.get("kind") != "parent"
             ):
                 raise ConsoleOverviewError("OVERVIEW_UNAVAILABLE")
 
@@ -505,12 +652,14 @@ class IsolatedOverviewService:
         for item in value:
             if not isinstance(item, dict) or set(item) != _LINE_KEYS:
                 raise ConsoleOverviewError("OVERVIEW_UNAVAILABLE")
+            parent = item.get("parent")
             if (
                 not cls._safe_alias(item.get("id"))
                 or not cls._safe_code(item.get("kind"))
                 or safe_branch(item.get("branch")) != item.get("branch")
                 or safe_branch(item.get("base")) != item.get("base")
                 or not cls._count(item.get("repository_count"))
+                or not (parent == "" or cls._safe_alias(parent))
             ):
                 raise ConsoleOverviewError("OVERVIEW_UNAVAILABLE")
 

--- a/src/dyro/console/overview.py
+++ b/src/dyro/console/overview.py
@@ -243,6 +243,47 @@ class ConsoleOverviewService:
         )
         return self._envelope({"workspace": summary, **inventory}, warning_codes)
 
+    def events(
+        self,
+        alias: str,
+        *,
+        after: str | None = None,
+        limit: int = 50,
+    ) -> dict[str, object]:
+        """Return a cursor page of overlay live events. Overview polling never calls this."""
+        from .events import event_page
+
+        config, _warning_codes = self._workspace_config(alias)
+        try:
+            data = event_page(
+                config, secret=self._cursor_secret, after=after, limit=limit
+            )
+        except ConsoleOverviewError:
+            raise
+        return self._envelope(data, set())
+
+    def families(self, alias: str) -> dict[str, object]:
+        """Return one-level family cards. Channel unread stays 0 in P1."""
+        from .families import family_cards
+
+        _summary, warning_codes, inventory = self._workspace_inventory(alias)
+        data = {"families": family_cards(inventory["lines"], inventory["tasks"])}
+        return self._envelope(data, warning_codes)
+
+    def family(self, alias: str, parent: str) -> dict[str, object]:
+        """Return ``F(parent)``. Grandchildren are excluded."""
+        from .families import family_payload
+
+        try:
+            parent_id = validate_id(parent, "父开发线 ID")
+        except ValidationError:
+            raise ConsoleOverviewError("FAMILY_PARENT_INVALID") from None
+        _summary, warning_codes, inventory = self._workspace_inventory(alias)
+        payload = family_payload(inventory["lines"], parent_id, inventory["tasks"])
+        if not payload:
+            raise ConsoleOverviewError("FAMILY_NOT_FOUND")
+        return self._envelope(payload, warning_codes)
+
     def system(self) -> dict[str, object]:
         """Return cached update facts. Do not probe PATH or start a network check."""
         warnings: set[str] = set()
@@ -315,6 +356,35 @@ class ConsoleOverviewService:
             warnings=warnings,
             data=data,
         ).to_payload()
+
+    def _workspace_config(self, alias: str) -> tuple[Config, set[str]]:
+        try:
+            alias = validate_id(alias, "工作区别名")
+        except ValidationError:
+            raise ConsoleOverviewError("WORKSPACE_ALIAS_INVALID") from None
+        registry = self._load_registry()
+        try:
+            record = next(item for item in registry.workspaces if item.name == alias)
+        except StopIteration:
+            raise ConsoleOverviewError("WORKSPACE_NOT_FOUND") from None
+        try:
+            return self._config_loader(record.root), set()
+        except (DyroError, ValidationError, OSError, UnicodeError):
+            raise ConsoleOverviewError("WORKSPACE_UNAVAILABLE") from None
+
+    def _workspace_inventory(
+        self, alias: str
+    ) -> tuple[dict[str, object], set[str], dict[str, list[dict[str, object]]]]:
+        try:
+            alias = validate_id(alias, "工作区别名")
+        except ValidationError:
+            raise ConsoleOverviewError("WORKSPACE_ALIAS_INVALID") from None
+        registry = self._load_registry()
+        try:
+            record = next(item for item in registry.workspaces if item.name == alias)
+        except StopIteration:
+            raise ConsoleOverviewError("WORKSPACE_NOT_FOUND") from None
+        return self._capture(record.name, record.root, record.name == registry.default)
 
     def _load_registry(self) -> WorkspaceRegistry:
         try:

--- a/src/dyro/console/read_model.py
+++ b/src/dyro/console/read_model.py
@@ -50,6 +50,7 @@ def _data(snapshot: WorkspaceReadSnapshot) -> dict[str, object]:
                 "branch": safe_branch(line.branch),
                 "base": safe_branch(line.base),
                 "repository_count": line.repository_count,
+                "parent": safe_id(line.parent) if line.parent else "",
             }
             for line in snapshot.lines
         ],

--- a/src/dyro/console/server.py
+++ b/src/dyro/console/server.py
@@ -40,6 +40,14 @@ def _json_bytes(value: object) -> bytes:
     )
 
 
+def _query_allowed(path: str) -> bool:
+    if path == "/api/v1/overview":
+        return True
+    return path.startswith("/api/v1/workspaces/") and (
+        path.endswith("/events") or path.endswith("/events/stream")
+    )
+
+
 class ConsoleHTTPServer(ThreadingHTTPServer):
     """A bounded IPv4 loopback server with no request logging."""
 
@@ -267,7 +275,7 @@ class ConsoleRequestHandler(BaseHTTPRequestHandler):
         if parsed.fragment or not parsed.path or parsed.path.startswith("//"):
             self._error(400, "BAD_REQUEST")
             return
-        if parsed.query and parsed.path != "/api/v1/overview":
+        if parsed.query and not _query_allowed(parsed.path):
             self._error(400, "BAD_REQUEST")
             return
         if self.command == "GET" and parsed.path == "/":
@@ -305,12 +313,12 @@ class ConsoleRequestHandler(BaseHTTPRequestHandler):
                     "data": {
                         "version": __version__,
                         "surfaces": (
-                            ["overview", "proofs", "system"]
+                            ["overview", "proofs", "system", "events"]
                             if self.console.overview_service
                             else []
                         ),
                         "capabilities": (
-                            ["overview", "proofs", "system"]
+                            ["overview", "proofs", "system", "events"]
                             if self.console.overview_service
                             else []
                         ),
@@ -351,7 +359,7 @@ class ConsoleRequestHandler(BaseHTTPRequestHandler):
                 return
             if self._authorized_session() is None:
                 return
-            self._workspace_resource(parsed.path)
+            self._workspace_resource(parsed.path, parsed.query)
             return
         if parsed.path.startswith("/api/"):
             self._error(401, "UNAUTHORIZED")
@@ -394,21 +402,51 @@ class ConsoleRequestHandler(BaseHTTPRequestHandler):
             return
         self._json(200, payload, etag=str(payload.get("snapshot_sha256", "")))
 
-    def _workspace_resource(self, path: str) -> None:
+    def _workspace_resource(self, path: str, query: str) -> None:
         service = self.console.overview_service
         if service is None:
             self._error(404, "NOT_FOUND")
             return
         remainder = path.removeprefix("/api/v1/workspaces/")
-        inspect = remainder.endswith("/proofs")
-        alias = remainder[: -len("/proofs")] if inspect else remainder
+        parts = remainder.split("/")
+        if not parts or not parts[0]:
+            self._error(400, "WORKSPACE_ALIAS_INVALID")
+            return
+        alias = parts[0]
         if not re.fullmatch(r"[A-Za-z0-9][A-Za-z0-9._-]{0,79}", alias):
             self._error(400, "WORKSPACE_ALIAS_INVALID")
             return
+        suffix = parts[1:]
+        if query and suffix[:1] != ["events"]:
+            self._error(400, "BAD_REQUEST")
+            return
         try:
-            payload = service.inspect_proofs(alias) if inspect else service.workspace(alias)
+            if suffix == []:
+                payload = service.workspace(alias)
+            elif suffix == ["proofs"]:
+                payload = service.inspect_proofs(alias)
+            elif suffix == ["events"] or suffix == ["events", "stream"]:
+                after, limit = self._event_parameters(query)
+                payload = service.events(alias, after=after, limit=limit)
+                if suffix == ["events", "stream"]:
+                    self._sse(payload)
+                    return
+            elif suffix == ["families"]:
+                payload = service.families(alias)
+            elif len(suffix) == 2 and suffix[0] == "families":
+                parent = suffix[1]
+                if not re.fullmatch(r"[A-Za-z0-9][A-Za-z0-9._-]{0,79}", parent):
+                    self._error(400, "FAMILY_PARENT_INVALID")
+                    return
+                payload = service.family(alias, parent)
+            else:
+                self._error(404, "NOT_FOUND")
+                return
         except ConsoleOverviewError as exc:
             self._error(self._overview_error_status(exc.code), exc.code)
+            return
+        except AttributeError:
+            self._error(404, "NOT_FOUND")
             return
         self._json(200, payload, etag=str(payload.get("snapshot_sha256", "")))
 
@@ -419,9 +457,14 @@ class ConsoleRequestHandler(BaseHTTPRequestHandler):
             "OVERVIEW_LIMIT_INVALID",
             "OVERVIEW_QUERY_INVALID",
             "WORKSPACE_ALIAS_INVALID",
+            "EVENT_CURSOR_INVALID",
+            "EVENT_LIMIT_INVALID",
+            "EVENT_QUERY_INVALID",
+            "EVENT_LOG_INVALID",
+            "FAMILY_PARENT_INVALID",
         }:
             return 400
-        if code == "WORKSPACE_NOT_FOUND":
+        if code in {"WORKSPACE_NOT_FOUND", "FAMILY_NOT_FOUND"}:
             return 404
         return 503
 
@@ -449,6 +492,57 @@ class ConsoleRequestHandler(BaseHTTPRequestHandler):
         if len(raw_limit) > 3 or not raw_limit.isdecimal():
             raise ConsoleOverviewError("OVERVIEW_QUERY_INVALID")
         return cursor, int(raw_limit)
+
+    @staticmethod
+    def _event_parameters(query: str) -> tuple[str | None, int]:
+        if not query:
+            return None, 50
+        values: dict[str, str] = {}
+        for segment in query.split("&"):
+            key, separator, value = segment.partition("=")
+            if (
+                not separator
+                or key not in {"after", "limit"}
+                or key in values
+                or not value
+            ):
+                raise ConsoleOverviewError("EVENT_QUERY_INVALID")
+            values[key] = value
+        after = values.get("after")
+        if after is not None and (
+            len(after) > 512 or not re.fullmatch(r"[A-Za-z0-9_-]+", after)
+        ):
+            raise ConsoleOverviewError("EVENT_QUERY_INVALID")
+        raw_limit = values.get("limit", "50")
+        if len(raw_limit) > 3 or not raw_limit.isdecimal():
+            raise ConsoleOverviewError("EVENT_QUERY_INVALID")
+        limit = int(raw_limit)
+        if not 1 <= limit <= 100:
+            raise ConsoleOverviewError("EVENT_LIMIT_INVALID")
+        return after, limit
+
+    def _sse(self, payload: object) -> None:
+        data = payload.get("data") if isinstance(payload, dict) else None
+        events = data.get("events") if isinstance(data, dict) else None
+        cursor = data.get("next_cursor") if isinstance(data, dict) else None
+        if not isinstance(events, list):
+            events = []
+        self.close_connection = True
+        self.send_response(200)
+        self.send_header("Content-Type", "text/event-stream; charset=utf-8")
+        self.send_header("Cache-Control", "no-store")
+        self.send_header("Connection", "close")
+        self.send_header("X-Content-Type-Options", "nosniff")
+        self.send_header("Referrer-Policy", "no-referrer")
+        self.send_header("X-Frame-Options", "DENY")
+        self.send_header("Cross-Origin-Opener-Policy", "same-origin")
+        self.send_header("Content-Security-Policy", _CSP)
+        self.end_headers()
+        for event in events:
+            self.wfile.write(b"data: " + _json_bytes(event) + b"\n\n")
+        if isinstance(cursor, str) and re.fullmatch(r"[A-Za-z0-9_-]+", cursor):
+            self.wfile.write(b"id: " + cursor.encode("ascii") + b"\n\n")
+        self.wfile.write(b": keepalive\n\n")
 
     def _validate_request_envelope(self) -> bool:
         if len(self.raw_requestline) > REQUEST_LINE_LIMIT:

--- a/src/dyro/console/server.py
+++ b/src/dyro/console/server.py
@@ -423,7 +423,7 @@ class ConsoleRequestHandler(BaseHTTPRequestHandler):
         try:
             if suffix == []:
                 payload = service.workspace(alias)
-            elif suffix == ["proofs"]:
+            elif remainder.endswith("/proofs") and suffix == ["proofs"]:
                 payload = service.inspect_proofs(alias)
             elif suffix == ["events"] or suffix == ["events", "stream"]:
                 after, limit = self._event_parameters(query)
@@ -527,22 +527,11 @@ class ConsoleRequestHandler(BaseHTTPRequestHandler):
         cursor = data.get("next_cursor") if isinstance(data, dict) else None
         if not isinstance(events, list):
             events = []
-        self.close_connection = True
-        self.send_response(200)
-        self.send_header("Content-Type", "text/event-stream; charset=utf-8")
-        self.send_header("Cache-Control", "no-store")
-        self.send_header("Connection", "close")
-        self.send_header("X-Content-Type-Options", "nosniff")
-        self.send_header("Referrer-Policy", "no-referrer")
-        self.send_header("X-Frame-Options", "DENY")
-        self.send_header("Cross-Origin-Opener-Policy", "same-origin")
-        self.send_header("Content-Security-Policy", _CSP)
-        self.end_headers()
-        for event in events:
-            self.wfile.write(b"data: " + _json_bytes(event) + b"\n\n")
+        chunks = [b"data: " + _json_bytes(event) + b"\n\n" for event in events]
         if isinstance(cursor, str) and re.fullmatch(r"[A-Za-z0-9_-]+", cursor):
-            self.wfile.write(b"id: " + cursor.encode("ascii") + b"\n\n")
-        self.wfile.write(b": keepalive\n\n")
+            chunks.append(b"id: " + cursor.encode("ascii") + b"\n\n")
+        chunks.append(b": keepalive\n\n")
+        self._send(200, b"".join(chunks), "text/event-stream; charset=utf-8")
 
     def _validate_request_envelope(self) -> bool:
         if len(self.raw_requestline) > REQUEST_LINE_LIMIT:

--- a/src/dyro/continuation/supervision.py
+++ b/src/dyro/continuation/supervision.py
@@ -548,7 +548,18 @@ def apply_supervised_wave(
             # hide an Action failure or turn it into a misleading success.
             if primary_error is None:
                 raise
-    return tuple(outcomes)
+    frozen = tuple(outcomes)
+    from ..events import append_event
+
+    append_event(
+        config,
+        kind="objective_wave",
+        actor=wave.objective_id,
+        subject=wave.objective_id,
+        family="",
+        facts={"mode": "apply", "count": len(frozen)},
+    )
+    return frozen
 
 
 def render_supervised_outcomes(outcomes: tuple[SupervisedOutcome, ...]) -> str:

--- a/src/dyro/events.py
+++ b/src/dyro/events.py
@@ -1,0 +1,267 @@
+"""Workspace overlay live-event log: ``.dyro/events.jsonl``.
+
+This is not Objective ``events.jsonl`` and not the delivery ledger.  Rows are
+append-only, one ``kind`` each.  Truncation, replacement, or a partial last
+line fail closed: readers refuse the log and writers refuse to invent the
+missing rows.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Mapping
+from datetime import datetime, timezone
+import json
+from pathlib import Path
+from typing import Any
+
+from .config import Config
+from .errors import DyroError, ValidationError
+from .state import append_text, exclusive_lock
+
+
+EVENTS_FILE = ".dyro/events.jsonl"
+EVENTS_LOCK = ".dyro/events.lock"
+MAX_EVENT_LOG_BYTES = 2 * 1024 * 1024
+EVENT_KINDS = frozenset(
+    {
+        "spawn",
+        "merge",
+        "sync",
+        "task_status",
+        "objective_wave",
+        "dispatch",
+        "board",
+        "signal",
+        "host_seed",
+    }
+)
+DEFAULT_EVENT_LIMIT = 50
+MAX_EVENT_LIMIT = 100
+_MAX_FACTS = 16
+_MAX_FACT_KEY = 40
+_MAX_FACT_STRING = 80
+_SAFE_FACT = frozenset("abcdefghijklmnopqrstuvwxyz0123456789._-")
+_SAFE_ID = frozenset("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789._-")
+
+
+class EventLogError(DyroError):
+    """Stable, path-free failure while reading or appending the event log."""
+
+    def __init__(self, code: str) -> None:
+        self.code = code
+        super().__init__(code)
+
+
+def events_path(config: Config) -> Path:
+    return config.root / EVENTS_FILE
+
+
+def _utc(clock: Callable[[], datetime] | None) -> datetime:
+    value = clock() if clock is not None else datetime.now(timezone.utc)
+    if not isinstance(value, datetime) or value.tzinfo is None:
+        raise ValidationError("事件时钟必须提供带时区的 datetime")
+    return value.astimezone(timezone.utc)
+
+
+def _safe_token(value: object, *, allow_empty: bool = False) -> str:
+    if not isinstance(value, str):
+        raise EventLogError("EVENT_WRITE_INVALID")
+    if value == "":
+        if allow_empty:
+            return ""
+        raise EventLogError("EVENT_WRITE_INVALID")
+    if len(value) > 80 or value[0] in "._-" or any(char not in _SAFE_ID for char in value):
+        raise EventLogError("EVENT_WRITE_INVALID")
+    return value
+
+
+def _clean_fact_key(key: object) -> str:
+    if not isinstance(key, str) or not key or len(key) > _MAX_FACT_KEY:
+        raise EventLogError("EVENT_WRITE_INVALID")
+    if any(char not in _SAFE_FACT for char in key):
+        raise EventLogError("EVENT_WRITE_INVALID")
+    return key
+
+
+def _clean_fact_value(value: object) -> str | int | bool:
+    if type(value) is bool:
+        return value
+    if type(value) is int and not isinstance(value, bool) and 0 <= value <= 1_000_000:
+        return value
+    if isinstance(value, str):
+        if len(value) > _MAX_FACT_STRING:
+            raise EventLogError("EVENT_WRITE_INVALID")
+        if value == "":
+            return ""
+        if any(ord(char) < 32 or ord(char) == 127 for char in value):
+            raise EventLogError("EVENT_WRITE_INVALID")
+        lowered = value.lower()
+        if any(token in lowered for token in ("/", "\\", "http:", "https:", "token=", "secret")):
+            raise EventLogError("EVENT_WRITE_INVALID")
+        return value
+    raise EventLogError("EVENT_WRITE_INVALID")
+
+
+def _clean_facts(facts: Mapping[str, object] | None) -> dict[str, str | int | bool]:
+    raw = dict(facts or {})
+    if len(raw) > _MAX_FACTS:
+        raise EventLogError("EVENT_WRITE_INVALID")
+    cleaned: dict[str, str | int | bool] = {}
+    for key, value in raw.items():
+        cleaned[_clean_fact_key(key)] = _clean_fact_value(value)
+    return cleaned
+
+
+def _decode_event(raw: str) -> dict[str, object]:
+    try:
+        decoded: Any = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        raise EventLogError("EVENT_LOG_INVALID") from exc
+    if not isinstance(decoded, dict):
+        raise EventLogError("EVENT_LOG_INVALID")
+    seq = decoded.get("seq")
+    event_id = decoded.get("id")
+    kind = decoded.get("kind")
+    at = decoded.get("at")
+    actor = decoded.get("actor")
+    subject = decoded.get("subject")
+    family = decoded.get("family")
+    facts = decoded.get("facts")
+    if (
+        type(seq) is not int
+        or seq < 1
+        or not isinstance(event_id, str)
+        or event_id != f"evt_{seq}"
+        or not isinstance(kind, str)
+        or not isinstance(at, str)
+        or not isinstance(actor, str)
+        or not isinstance(subject, str)
+        or not isinstance(family, str)
+        or not isinstance(facts, dict)
+    ):
+        raise EventLogError("EVENT_LOG_INVALID")
+    return {
+        "seq": seq,
+        "id": event_id,
+        "kind": kind,
+        "at": at,
+        "actor": actor,
+        "subject": subject,
+        "family": family,
+        "facts": dict(facts),
+    }
+
+
+def _read_locked_records(path: Path) -> list[dict[str, object]]:
+    if path.is_symlink() or (path.exists() and not path.is_file()):
+        raise EventLogError("EVENT_LOG_INVALID")
+    if not path.exists():
+        return []
+    try:
+        size = path.stat().st_size
+        if size > MAX_EVENT_LOG_BYTES:
+            raise EventLogError("EVENT_LOG_INVALID")
+        text = path.read_text(encoding="utf-8")
+    except EventLogError:
+        raise
+    except OSError as exc:
+        raise EventLogError("EVENT_LOG_INVALID") from exc
+    if not text:
+        return []
+    if not text.endswith("\n"):
+        raise EventLogError("EVENT_LOG_INVALID")
+    records: list[dict[str, object]] = []
+    expected = 1
+    for line in text.splitlines():
+        if not line:
+            raise EventLogError("EVENT_LOG_INVALID")
+        record = _decode_event(line)
+        if record["seq"] != expected:
+            raise EventLogError("EVENT_LOG_INVALID")
+        records.append(record)
+        expected += 1
+    return records
+
+
+def read_events(
+    config: Config,
+    *,
+    after_seq: int = 0,
+    limit: int = DEFAULT_EVENT_LIMIT,
+) -> tuple[tuple[dict[str, object], ...], int]:
+    """Return events with ``seq > after_seq``.
+
+    ``after_seq`` is a bare integer used by the HMAC cursor layer.  A missing
+    file is an empty log.  A truncated or replaced sequence is not repaired.
+    """
+    if type(after_seq) is not int or after_seq < 0:
+        raise EventLogError("EVENT_CURSOR_INVALID")
+    if type(limit) is not int or not 1 <= limit <= MAX_EVENT_LIMIT:
+        raise EventLogError("EVENT_LIMIT_INVALID")
+    path = events_path(config)
+    with exclusive_lock(config.root / EVENTS_LOCK):
+        records = _read_locked_records(path)
+    if after_seq > len(records):
+        raise EventLogError("EVENT_CURSOR_INVALID")
+    if after_seq:
+        if records[after_seq - 1]["seq"] != after_seq:
+            raise EventLogError("EVENT_CURSOR_INVALID")
+    selected = records[after_seq : after_seq + limit]
+    last_seq = records[-1]["seq"] if records else 0
+    return tuple(selected), last_seq
+
+
+def event_at(config: Config, seq: int) -> dict[str, object] | None:
+    if type(seq) is not int or seq < 1:
+        return None
+    path = events_path(config)
+    with exclusive_lock(config.root / EVENTS_LOCK):
+        records = _read_locked_records(path)
+    if seq > len(records):
+        return None
+    return records[seq - 1]
+
+
+def append_event(
+    config: Config,
+    *,
+    kind: str,
+    actor: str,
+    subject: str,
+    family: str = "",
+    facts: Mapping[str, object] | None = None,
+    clock: Callable[[], datetime] | None = None,
+) -> dict[str, object]:
+    """Append one typed event.  Dry-run callers must not invoke this."""
+    if kind not in EVENT_KINDS:
+        raise EventLogError("EVENT_WRITE_INVALID")
+    actor = _safe_token(actor)
+    subject = _safe_token(subject)
+    family = _safe_token(family, allow_empty=True)
+    cleaned = _clean_facts(facts)
+    stamp = _utc(clock).strftime("%Y-%m-%dT%H:%M:%SZ")
+    path = events_path(config)
+    lock = config.root / EVENTS_LOCK
+    try:
+        with exclusive_lock(lock):
+            records = _read_locked_records(path)
+            seq = (records[-1]["seq"] + 1) if records else 1
+            record = {
+                "seq": seq,
+                "id": f"evt_{seq}",
+                "kind": kind,
+                "at": stamp,
+                "actor": actor,
+                "subject": subject,
+                "family": family,
+                "facts": cleaned,
+            }
+            append_text(
+                path,
+                json.dumps(record, ensure_ascii=False, sort_keys=True) + "\n",
+            )
+    except EventLogError:
+        raise
+    except OSError as exc:
+        raise EventLogError("EVENT_WRITE_FAILED") from exc
+    return record

--- a/src/dyro/families.py
+++ b/src/dyro/families.py
@@ -1,0 +1,92 @@
+"""One-level line families: ``F(P) = {P} ∪ children(P) ∪ {operator}``.
+
+P1 uses this only to project a graph.  Channel, ack, and artifact stores are
+P2 / P3 and are not created here.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable, Mapping
+
+
+OPERATOR_ID = "operator"
+
+
+def family_children(lines: Iterable[Mapping[str, object]], parent_id: str) -> tuple[str, ...]:
+    """Direct children of ``parent_id``.  Grandchildren are excluded."""
+    children: list[str] = []
+    for line in lines:
+        if str(line.get("parent") or "") == parent_id:
+            child_id = str(line.get("id") or "")
+            if child_id and child_id != parent_id:
+                children.append(child_id)
+    return tuple(children)
+
+
+def family_members(lines: Iterable[Mapping[str, object]], parent_id: str) -> tuple[str, ...]:
+    return (parent_id, *family_children(lines, parent_id), OPERATOR_ID)
+
+
+def family_ids(lines: Iterable[Mapping[str, object]]) -> tuple[str, ...]:
+    """Every line can be opened as a one-level family parent."""
+    return tuple(str(line.get("id") or "") for line in lines if line.get("id"))
+
+
+def family_graph(
+    lines: Iterable[Mapping[str, object]],
+    parent_id: str,
+    *,
+    badges: Mapping[str, Mapping[str, object]] | None = None,
+) -> dict[str, object]:
+    """Return the P1 graph for ``F(parent_id)``.
+
+    ``badges`` maps line id → ``dirty`` / ``missing_origin`` / ``in_progress`` /
+    ``unread``.  Unknown ids default to false / zero.  ``operator`` has no git
+    badges.
+    """
+    items = [dict(line) for line in lines]
+    ids = {str(line.get("id") or "") for line in items}
+    if parent_id not in ids:
+        return {}
+    children = family_children(items, parent_id)
+    marks = {key: dict(value) for key, value in dict(badges or {}).items()}
+    nodes = [
+        _node(parent_id, "parent", marks.get(parent_id, {})),
+        *(_node(child_id, "child", marks.get(child_id, {})) for child_id in children),
+        _node(OPERATOR_ID, "operator", marks.get(OPERATOR_ID, {}), git=False),
+    ]
+    edges = [{"from": parent_id, "to": child_id, "kind": "parent"} for child_id in children]
+    return {
+        "parent": parent_id,
+        "members": list(family_members(items, parent_id)),
+        "nodes": nodes,
+        "edges": edges,
+    }
+
+
+def _node(
+    node_id: str,
+    role: str,
+    badge: Mapping[str, object],
+    *,
+    git: bool = True,
+) -> dict[str, object]:
+    unread = badge.get("unread", 0)
+    unread_count = unread if type(unread) is int and unread >= 0 else 0
+    if not git:
+        return {
+            "id": node_id,
+            "role": role,
+            "dirty": False,
+            "missing_origin": False,
+            "in_progress": False,
+            "unread": unread_count,
+        }
+    return {
+        "id": node_id,
+        "role": role,
+        "dirty": bool(badge.get("dirty")),
+        "missing_origin": bool(badge.get("missing_origin")),
+        "in_progress": bool(badge.get("in_progress")),
+        "unread": unread_count,
+    }

--- a/src/dyro/observations.py
+++ b/src/dyro/observations.py
@@ -42,6 +42,7 @@ class WorkspaceLineObservation:
     branch: str
     base: str
     repository_count: int
+    parent: str = ""
 
 
 @dataclass(frozen=True)
@@ -233,6 +234,7 @@ def _revision_payload(
                 "branch": item.branch,
                 "base": item.base,
                 "repository_count": item.repository_count,
+                "parent": item.parent,
             }
             for item in lines
         ],
@@ -329,6 +331,7 @@ def capture_workspace_read_snapshot(
                 branch=line.branch,
                 base=line.base,
                 repository_count=len(line.repositories),
+                parent=line.parent,
             )
             for line in list_lines(config)
         )
@@ -344,6 +347,7 @@ def capture_workspace_read_snapshot(
                                 "branch": item.branch,
                                 "base": item.base,
                                 "repository_count": item.repository_count,
+                                "parent": item.parent,
                             }
                             for item in lines
                         ]
@@ -430,6 +434,7 @@ def inspect_workspace_read_snapshot(
                 branch=line.branch,
                 base=line.base,
                 repository_count=len(line.repositories),
+                parent=line.parent,
             )
             for line in list_lines(config)
         )
@@ -445,6 +450,7 @@ def inspect_workspace_read_snapshot(
                                 "branch": item.branch,
                                 "base": item.base,
                                 "repository_count": item.repository_count,
+                                "parent": item.parent,
                             }
                             for item in lines
                         ]

--- a/src/dyro/tasks.py
+++ b/src/dyro/tasks.py
@@ -877,6 +877,16 @@ def set_status(
             ledger(
                 config, task.id, "status", from_status=current, to_status=next_status
             )
+            from .events import append_event
+
+            append_event(
+                config,
+                kind="task_status",
+                actor=task.line,
+                subject=task.id,
+                family=task.line,
+                facts={"from_status": current, "to_status": next_status},
+            )
 
 
 def _set_quality_gate_status(
@@ -2035,15 +2045,55 @@ def _execute_task_agent(
         assert_write_executor_allowed(executor, risk=task.risk)
         assert_capability_allows_write(config, executor)
     if is_dispatch_write_ready(executor):
-        result = run_task_bound_dispatch(
-            task,
-            executor=executor,
-            workspace=workspace,
-            prompt=prompt,
-            timeout_seconds=float(task.timeout_minutes * 60),
-            dry_run=dry_run,
-            capabilities=getattr(config, "capabilities", None) or {},
-        )
+        if not dry_run:
+            from .events import append_event
+
+            append_event(
+                config,
+                kind="dispatch",
+                actor=task.line,
+                subject=task.id,
+                family=task.line,
+                facts={"executor": executor, "phase": "start"},
+            )
+        try:
+            result = run_task_bound_dispatch(
+                task,
+                executor=executor,
+                workspace=workspace,
+                prompt=prompt,
+                timeout_seconds=float(task.timeout_minutes * 60),
+                dry_run=dry_run,
+                capabilities=getattr(config, "capabilities", None) or {},
+            )
+        except Exception:
+            if not dry_run:
+                from .events import append_event
+
+                append_event(
+                    config,
+                    kind="dispatch",
+                    actor=task.line,
+                    subject=task.id,
+                    family=task.line,
+                    facts={"executor": executor, "phase": "end", "status": "failed"},
+                )
+            raise
+        if not dry_run:
+            from .events import append_event
+
+            append_event(
+                config,
+                kind="dispatch",
+                actor=task.line,
+                subject=task.id,
+                family=task.line,
+                facts={
+                    "executor": executor,
+                    "phase": "end",
+                    "status": "idle" if getattr(result, "code", 1) == 0 else "failed",
+                },
+            )
     elif executor in config.adapters:
         argv = _adapter_argv(
             config,

--- a/src/dyro/workspace.py
+++ b/src/dyro/workspace.py
@@ -698,7 +698,7 @@ def spawn_line(
         for repo_id in selected
         if parent.storage_for(repo_id) != "linked-worktree"
     }
-    return create_line(
+    line = create_line(
         config,
         line_id=child_id,
         branch=f"feat/{child_id}",
@@ -710,6 +710,18 @@ def spawn_line(
         parent=parent.id,
         dry_run=dry_run,
     )
+    if not dry_run:
+        from .events import append_event
+
+        append_event(
+            config,
+            kind="spawn",
+            actor=parent.id,
+            subject=line.id,
+            family=parent.id,
+            facts={"parent": parent.id, "child": line.id},
+        )
+    return line
 
 
 @dataclass(frozen=True)
@@ -1069,6 +1081,17 @@ def merge_line(
         dry_run=dry_run,
         extra_ledger={"parent": parent.id, "child": child.id},
     )
+    if not dry_run:
+        from .events import append_event
+
+        append_event(
+            config,
+            kind="merge",
+            actor=child.id,
+            subject=parent.id,
+            family=parent.id,
+            facts={"parent": parent.id, "child": child.id},
+        )
 
 
 def sync_line(
@@ -1098,6 +1121,17 @@ def sync_line(
         dry_run=dry_run,
         extra_ledger={"parent": parent.id, "child": child.id},
     )
+    if not dry_run:
+        from .events import append_event
+
+        append_event(
+            config,
+            kind="sync",
+            actor=parent.id,
+            subject=child.id,
+            family=parent.id,
+            facts={"parent": parent.id, "child": child.id},
+        )
 
 
 def _line_status_scope(line: Line) -> str:

--- a/tests/test_console_assets.py
+++ b/tests/test_console_assets.py
@@ -103,6 +103,19 @@ class ConsoleAssetTests(unittest.TestCase):
         self.assertIn("UPDATE_KIND_LABELS".encode(), script.body)
         self.assertIn("现在需要你".encode(), script.body)
         self.assertNotIn("没有工具".encode(), script.body)
+        self.assertIn("function renderFamilyTree".encode(), script.body)
+        self.assertIn("function startEventLive".encode(), script.body)
+        self.assertIn("function resetEventState".encode(), script.body)
+        self.assertIn("events/stream".encode(), script.body)
+        self.assertIn("--dry-run line spawn".encode(), script.body)
+        self.assertIn("--dry-run line merge".encode(), script.body)
+        self.assertIn("--dry-run line sync".encode(), script.body)
+        self.assertNotIn(b"--yes", script.body)
+        self.assertNotIn(b"--push", script.body)
+        self.assertIn("尚未开放".encode(), script.body)
+        self.assertIn("产物尚未开放".encode(), script.body)
+        self.assertIn("document.hidden".encode(), script.body)
+        self.assertIn("刚有合入或同步".encode(), script.body)
 
 
 if __name__ == "__main__":

--- a/tests/test_console_assets.py
+++ b/tests/test_console_assets.py
@@ -116,6 +116,9 @@ class ConsoleAssetTests(unittest.TestCase):
         self.assertIn("产物尚未开放".encode(), script.body)
         self.assertIn("document.hidden".encode(), script.body)
         self.assertIn("刚有合入或同步".encode(), script.body)
+        self.assertIn("未检查".encode(), script.body)
+        self.assertNotIn("干净".encode(), script.body)
+        self.assertNotIn("远端已绑定".encode(), script.body)
 
 
 if __name__ == "__main__":

--- a/tests/test_console_inspection.py
+++ b/tests/test_console_inspection.py
@@ -474,6 +474,39 @@ class IsolatedOverviewServiceTests(WorkspaceCase):
                 self.assertNotIn("git", str(error.exception))
                 self.assertNotIn("argv", str(error.exception))
 
+    def test_parent_rejects_digest_consistent_events_with_path_in_facts(self) -> None:
+        service = IsolatedOverviewService(
+            registry_state_home=self.home,
+            timeout_seconds=5,
+            cursor_secret=b"q" * 32,
+        )
+        valid = service.events("demo")
+        payload = deepcopy(valid)
+        payload["data"]["events"] = [
+            {
+                "seq": 1,
+                "id": "evt_1",
+                "kind": "spawn",
+                "at": "2026-08-20T12:00:00Z",
+                "actor": "core",
+                "subject": "core_pay",
+                "family": "core",
+                "facts": {"parent": "core", "path": "/tmp/secret"},
+            }
+        ]
+        payload["snapshot_sha256"] = hashlib.sha256(
+            canonical_json_bytes(
+                {
+                    "schema_version": 1,
+                    "freshness": payload["freshness"],
+                    "data": payload["data"],
+                }
+            )
+        ).hexdigest()
+        raw = json.dumps({"ok": True, "payload": payload}).encode("utf-8")
+        with self.assertRaisesRegex(ConsoleOverviewError, "OVERVIEW_UNAVAILABLE"):
+            service._parse_worker_output(raw, expected_operation="events")
+
     def test_isolated_command_allowlist_rejects_task_next(self) -> None:
         self.assertTrue(
             IsolatedOverviewService._safe_command(

--- a/tests/test_console_inspection.py
+++ b/tests/test_console_inspection.py
@@ -51,6 +51,9 @@ class IsolatedOverviewServiceTests(WorkspaceCase):
         self.assertEqual(overview["data"]["workspaces"][0]["proof_inspection"], "not_inspected")
         self.assertEqual(workspace["data"]["workspace"]["proof_inspection"], "not_inspected")
         self.assertEqual(set(workspace["data"]), {"workspace", "lines", "tasks", "objectives"})
+        self.assertTrue(
+            all("parent" in item for item in workspace["data"]["lines"])
+        )
         self.assertNotIn("proofs", workspace["data"])
         self.assertTrue(
             all(
@@ -62,12 +65,55 @@ class IsolatedOverviewServiceTests(WorkspaceCase):
         self.assertNotIn(str(self.root), repr(overview))
         self.assertNotIn(str(self.root), repr(workspace))
         self.assertNotIn(str(self.root), repr(inspect))
+        events = service.events("demo")
+        families = service.families("demo")
+        self.assertEqual(events["data"]["events"], [])
+        self.assertIn("next_cursor", events["data"])
+        self.assertIsInstance(families["data"]["families"], list)
+        self.assertNotIn(str(self.root), repr(events))
+        self.assertNotIn(str(self.root), repr(families))
         system = service.system()
         self.assertEqual(system["data"]["tool_inspection"], "not_inspected")
         self.assertEqual(system["data"]["tools"], [])
         self.assertIn(system["data"]["update"]["kind"], {"none", "patch", "minor", "major"})
         self.assertNotIn(str(self.root), repr(system))
         self.assertNotIn("/usr/", repr(system))
+
+    def test_events_after_cursor_and_one_level_family_survive_a_new_worker(self) -> None:
+        from dyro.config import load
+        from dyro.workspace import create_line, spawn_line
+
+        config = load(self.root)
+        create_line(config, line_id="core", branch="feat/core", base="main")
+        spawn_line(config, "core", "pay")
+        spawn_line(config, "core_pay", "fix")
+        service = IsolatedOverviewService(
+            registry_state_home=self.home,
+            timeout_seconds=5,
+            cursor_secret=b"q" * 32,
+        )
+
+        first = service.events("demo")
+        events = first["data"]["events"]
+        self.assertEqual([item["kind"] for item in events], ["spawn", "spawn"])
+        self.assertEqual(events[0]["facts"]["child"], "core_pay")
+        cursor = first["data"]["next_cursor"]
+        self.assertTrue(cursor)
+        resumed = service.events("demo", after=cursor)
+        self.assertEqual(resumed["data"]["events"], [])
+
+        workspace = service.workspace("demo")
+        parents = {item["id"]: item["parent"] for item in workspace["data"]["lines"]}
+        self.assertEqual(parents["core"], "")
+        self.assertEqual(parents["core_pay"], "core")
+        self.assertEqual(parents["core_pay_fix"], "core_pay")
+
+        core = service.family("demo", "core")
+        self.assertEqual(core["data"]["members"], ["core", "core_pay", "operator"])
+        self.assertFalse(any(node["id"] == "core_pay_fix" for node in core["data"]["nodes"]))
+        pay = service.family("demo", "core_pay")
+        self.assertIn("core_pay_fix", pay["data"]["members"])
+        self.assertNotIn("core", pay["data"]["members"])
 
     def test_default_workspace_budget_tolerates_process_startup_overhead(self) -> None:
         clock = [0.0]

--- a/tests/test_console_overview.py
+++ b/tests/test_console_overview.py
@@ -272,6 +272,7 @@ class ConsoleOverviewServiceTests(unittest.TestCase):
         self.assertEqual(payload["data"]["workspace"]["alias"], "alpha")
         self.assertEqual(payload["data"]["workspace"]["proof_inspection"], "not_inspected")
         self.assertEqual(payload["data"]["lines"][0]["id"], "alpha")
+        self.assertEqual(payload["data"]["lines"][0]["parent"], "")
         self.assertEqual(payload["data"]["tasks"][0]["id"], "TASK-A")
         self.assertEqual(payload["data"]["tasks"][0]["integration_state"], "not_inspected")
         self.assertEqual(payload["data"]["objectives"][0]["id"], "release")

--- a/tests/test_console_server.py
+++ b/tests/test_console_server.py
@@ -112,8 +112,8 @@ class ConsoleServerTests(unittest.TestCase):
         self.assertEqual(headers["Content-Type"], "application/json; charset=utf-8")
         payload = json.loads(body)
         self.assertEqual(payload["schema_version"], 1)
-        self.assertEqual(payload["data"]["surfaces"], ["overview", "proofs", "system"])
-        self.assertEqual(payload["data"]["capabilities"], ["overview", "proofs", "system"])
+        self.assertEqual(payload["data"]["surfaces"], ["overview", "proofs", "system", "events"])
+        self.assertEqual(payload["data"]["capabilities"], ["overview", "proofs", "system", "events"])
         self.assertEqual(payload["data"]["initial_workspace"], "")
         self.assertIn("session_expires_at", payload["data"])
 
@@ -268,6 +268,46 @@ class ConsoleOverviewServerTests(unittest.TestCase):
             "freshness": {"state": "fresh", "partial": False, "warnings": []},
             "data": {"proof_inspection": "inspected", "proofs": [], "objectives": []},
         }
+        self.overview.events.return_value = {
+            "schema_version": 1,
+            "captured_at": "2026-08-04T12:00:00+00:00",
+            "snapshot_sha256": "b" * 64,
+            "freshness": {"state": "fresh", "partial": False, "warnings": []},
+            "data": {
+                "events": [
+                    {
+                        "seq": 1,
+                        "id": "evt_1",
+                        "kind": "spawn",
+                        "at": "2026-08-20T12:00:00Z",
+                        "actor": "core",
+                        "subject": "core_pay",
+                        "family": "core",
+                        "facts": {"parent": "core", "child": "core_pay"},
+                    }
+                ],
+                "next_cursor": "after_evt_1",
+            },
+        }
+        self.overview.families.return_value = {
+            "schema_version": 1,
+            "captured_at": "2026-08-04T12:00:00+00:00",
+            "snapshot_sha256": "a" * 64,
+            "freshness": {"state": "fresh", "partial": False, "warnings": []},
+            "data": {"families": []},
+        }
+        self.overview.family.return_value = {
+            "schema_version": 1,
+            "captured_at": "2026-08-04T12:00:00+00:00",
+            "snapshot_sha256": "9" * 64,
+            "freshness": {"state": "fresh", "partial": False, "warnings": []},
+            "data": {
+                "parent": "core",
+                "members": ["core", "core_pay", "operator"],
+                "nodes": [],
+                "edges": [],
+            },
+        }
         self.server = create_console_http_server(
             port=0,
             bootstrap_secret="a" * 43,
@@ -389,6 +429,57 @@ class ConsoleOverviewServerTests(unittest.TestCase):
         self.assertEqual(json.loads(body)["data"]["tool_inspection"], "not_inspected")
         self.assertEqual(json.loads(body)["data"]["tools"], [])
         self.overview.system.assert_called_once_with()
+
+    def test_events_after_query_and_sse_resume_are_authenticated(self) -> None:
+        unauthorized, _, body = self._request("GET", "/api/v1/workspaces/alpha/events")
+        self.assertEqual(unauthorized, 401)
+        self.assertEqual(json.loads(body)["error"]["code"], "UNAUTHORIZED")
+
+        rejected, _, rejected_body = self._request("POST", "/api/v1/workspaces/alpha/events")
+        self.assertEqual(rejected, 405)
+        self.assertEqual(json.loads(rejected_body)["error"]["code"], "METHOD_NOT_ALLOWED")
+
+        bearer = self._bearer()
+        headers = {"Authorization": f"Bearer {bearer}", "Origin": self.origin}
+        status, _, body = self._request(
+            "GET", "/api/v1/workspaces/alpha/events?after=after_evt_1&limit=50", headers=headers
+        )
+        self.assertEqual(status, 200)
+        self.assertEqual(json.loads(body)["data"]["events"][0]["kind"], "spawn")
+        self.overview.events.assert_called_with("alpha", after="after_evt_1", limit=50)
+
+        stream, stream_headers, stream_body = self._request(
+            "GET", "/api/v1/workspaces/alpha/events/stream?after=after_evt_1", headers=headers
+        )
+        self.assertEqual(stream, 200)
+        self.assertEqual(stream_headers["Content-Type"], "text/event-stream; charset=utf-8")
+        self.assertIn(b"data: ", stream_body)
+        self.assertIn(b'"kind":"spawn"', stream_body)
+        self.assertIn(b"id: after_evt_1", stream_body)
+        self.assertIn(b": keepalive", stream_body)
+
+        localhost, _, _ = self._request(
+            "GET",
+            "/api/v1/workspaces/alpha/events",
+            headers={"Host": "localhost", "Authorization": f"Bearer {bearer}"},
+        )
+        self.assertEqual(localhost, 400)
+
+        channel, _, channel_body = self._request(
+            "POST", "/api/v1/workspaces/alpha/families/core/channel", headers=headers
+        )
+        self.assertEqual(channel, 405)
+        self.assertEqual(json.loads(channel_body)["error"]["code"], "METHOD_NOT_ALLOWED")
+
+    def test_family_graph_is_authenticated_get_only(self) -> None:
+        bearer = self._bearer()
+        headers = {"Authorization": f"Bearer {bearer}", "Origin": self.origin}
+        status, _, body = self._request(
+            "GET", "/api/v1/workspaces/alpha/families/core", headers=headers
+        )
+        self.assertEqual(status, 200)
+        self.assertEqual(json.loads(body)["data"]["parent"], "core")
+        self.overview.family.assert_called_once_with("alpha", "core")
 
 
 if __name__ == "__main__":

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -175,8 +175,10 @@ class WorkspaceEventLogTests(WorkspaceCase):
         self.assertEqual(len(digest), 64)
         resumed = event_page(self.config, secret=secret, after=cursor, limit=50)
         self.assertEqual(resumed["events"], [])
+        # Unpadded base64 can treat the final character as unused bits; flip
+        # a body character so the HMAC input actually changes.
         with self.assertRaisesRegex(ConsoleOverviewError, "EVENT_CURSOR_INVALID"):
-            event_page(self.config, secret=secret, after=cursor[:-1] + "x", limit=50)
+            event_page(self.config, secret=secret, after="x" + cursor[1:], limit=50)
         path = self.root / ".dyro" / "events.jsonl"
         path.write_text("", encoding="utf-8")
         with self.assertRaisesRegex(ConsoleOverviewError, "EVENT_CURSOR_INVALID"):

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -1,0 +1,179 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+import json
+import unittest
+
+from dyro.config import load
+from dyro.console.events import decode_event_cursor, event_page
+from dyro.console.overview import ConsoleOverviewError
+from dyro.events import EventLogError, append_event, read_events
+from dyro.tasks import set_status, task_template
+from dyro.workspace import create_line, spawn_line
+
+from .support import WorkspaceCase
+
+
+class WorkspaceEventLogTests(WorkspaceCase):
+    def setUp(self) -> None:
+        super().setUp()
+        self.config = load(self.root)
+        self.clock = lambda: datetime(2026, 8, 20, 12, 0, tzinfo=timezone.utc)
+
+    def test_append_and_read_are_ordered_and_typed(self) -> None:
+        first = append_event(
+            self.config,
+            kind="spawn",
+            actor="core",
+            subject="core_pay",
+            family="core",
+            facts={"parent": "core", "child": "core_pay"},
+            clock=self.clock,
+        )
+        second = append_event(
+            self.config,
+            kind="merge",
+            actor="core_pay",
+            subject="core",
+            family="core",
+            facts={"parent": "core", "child": "core_pay"},
+            clock=self.clock,
+        )
+
+        page, last = read_events(self.config, after_seq=0, limit=50)
+        self.assertEqual(last, 2)
+        self.assertEqual([item["id"] for item in page], ["evt_1", "evt_2"])
+        self.assertEqual(first["kind"], "spawn")
+        self.assertEqual(second["kind"], "merge")
+        self.assertEqual(page[0]["facts"]["child"], "core_pay")
+        after_first, _last = read_events(self.config, after_seq=1, limit=50)
+        self.assertEqual([item["id"] for item in after_first], ["evt_2"])
+
+    def test_truncated_log_fails_closed_on_read_and_write(self) -> None:
+        append_event(
+            self.config,
+            kind="sync",
+            actor="core",
+            subject="core_pay",
+            family="core",
+            facts={"parent": "core", "child": "core_pay"},
+            clock=self.clock,
+        )
+        path = self.root / ".dyro" / "events.jsonl"
+        path.write_text(path.read_text(encoding="utf-8").rstrip("\n"), encoding="utf-8")
+
+        with self.assertRaises(EventLogError) as raised:
+            read_events(self.config)
+        self.assertEqual(raised.exception.code, "EVENT_LOG_INVALID")
+        with self.assertRaises(EventLogError) as write_error:
+            append_event(
+                self.config,
+                kind="spawn",
+                actor="core",
+                subject="core_pay_fix",
+                family="core",
+                facts={"parent": "core", "child": "core_pay_fix"},
+                clock=self.clock,
+            )
+        self.assertEqual(write_error.exception.code, "EVENT_LOG_INVALID")
+
+    def test_write_refuses_a_non_file_log(self) -> None:
+        path = self.root / ".dyro" / "events.jsonl"
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.mkdir()
+        with self.assertRaises(EventLogError) as raised:
+            append_event(
+                self.config,
+                kind="host_seed",
+                actor="operator",
+                subject="overlay",
+                family="",
+                facts={"written": 1},
+                clock=self.clock,
+            )
+        self.assertEqual(raised.exception.code, "EVENT_LOG_INVALID")
+
+    def test_spawn_writes_an_event_and_dry_run_does_not(self) -> None:
+        create_line(self.config, line_id="core", branch="feat/core", base="main")
+        spawn_line(self.config, "core", "pay", dry_run=True)
+        self.assertFalse((self.root / ".dyro" / "events.jsonl").exists())
+
+        spawn_line(self.config, "core", "pay")
+        page, last = read_events(self.config)
+        self.assertEqual(last, 1)
+        self.assertEqual(page[0]["kind"], "spawn")
+        self.assertEqual(page[0]["facts"]["parent"], "core")
+        self.assertEqual(page[0]["facts"]["child"], "core_pay")
+
+    def test_task_status_writes_an_event(self) -> None:
+        create_line(self.config, line_id="core", branch="feat/core", base="main")
+        task = self.config.task_specs_dir / "TASK-A"
+        task.mkdir(parents=True)
+        task.joinpath("task.toml").write_text(
+            task_template("TASK-A", "Prepare release", "core", "api", "services/api"),
+            encoding="utf-8",
+        )
+        task.joinpath("handoff.md").write_text("# handoff\n", encoding="utf-8")
+        from dyro.tasks import load_task
+
+        item = load_task(self.config, "TASK-A")
+        set_status(self.config, item, "assigned")
+        page, _last = read_events(self.config)
+        self.assertEqual(page[0]["kind"], "task_status")
+        self.assertEqual(page[0]["facts"]["to_status"], "assigned")
+        self.assertNotIn("prompt", json.dumps(page[0]))
+
+    def test_write_refuses_path_or_unknown_kind(self) -> None:
+        with self.assertRaises(EventLogError) as path_error:
+            append_event(
+                self.config,
+                kind="spawn",
+                actor="core",
+                subject="core_pay",
+                family="core",
+                facts={"parent": "/tmp/core"},
+                clock=self.clock,
+            )
+        self.assertEqual(path_error.exception.code, "EVENT_WRITE_INVALID")
+        with self.assertRaises(EventLogError) as kind_error:
+            append_event(
+                self.config,
+                kind="merge_main",
+                actor="core",
+                subject="core_pay",
+                family="core",
+                facts={"parent": "core", "child": "core_pay"},
+                clock=self.clock,
+            )
+        self.assertEqual(kind_error.exception.code, "EVENT_WRITE_INVALID")
+        self.assertFalse((self.root / ".dyro" / "events.jsonl").exists())
+
+    def test_hmac_after_cursor_rejects_tampering(self) -> None:
+        append_event(
+            self.config,
+            kind="spawn",
+            actor="core",
+            subject="core_pay",
+            family="core",
+            facts={"parent": "core", "child": "core_pay"},
+            clock=self.clock,
+        )
+        secret = b"k" * 32
+        page = event_page(self.config, secret=secret, after=None, limit=50)
+        cursor = page["next_cursor"]
+        self.assertTrue(cursor)
+        after_seq, event_id = decode_event_cursor(secret, cursor)
+        self.assertEqual(after_seq, 1)
+        self.assertEqual(event_id, "evt_1")
+        resumed = event_page(self.config, secret=secret, after=cursor, limit=50)
+        self.assertEqual(resumed["events"], [])
+        with self.assertRaisesRegex(ConsoleOverviewError, "EVENT_CURSOR_INVALID"):
+            event_page(self.config, secret=secret, after=cursor[:-1] + "x", limit=50)
+        path = self.root / ".dyro" / "events.jsonl"
+        path.write_text("", encoding="utf-8")
+        with self.assertRaisesRegex(ConsoleOverviewError, "EVENT_CURSOR_INVALID"):
+            event_page(self.config, secret=secret, after=cursor, limit=50)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -1,12 +1,10 @@
 from __future__ import annotations
 
-from datetime import datetime, timezone
-import json
-import unittest
-
 from contextlib import redirect_stdout
 from datetime import datetime, timezone
 from io import StringIO
+import json
+import unittest
 from unittest.mock import patch
 
 from dyro.cli import build_parser, cmd_host_seed

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -4,14 +4,21 @@ from datetime import datetime, timezone
 import json
 import unittest
 
+from contextlib import redirect_stdout
+from datetime import datetime, timezone
+from io import StringIO
+from unittest.mock import patch
+
+from dyro.cli import build_parser, cmd_host_seed
 from dyro.config import load
-from dyro.console.events import decode_event_cursor, event_page
+from dyro.console.events import decode_event_cursor, event_page, project_event
 from dyro.console.overview import ConsoleOverviewError
 from dyro.events import EventLogError, append_event, read_events
-from dyro.tasks import set_status, task_template
-from dyro.workspace import create_line, spawn_line
+from dyro.process import Result
+from dyro.tasks import _execute_task_agent, load_task, set_status, task_template
+from dyro.workspace import create_line, line_repository_path, merge_line, spawn_line, sync_line
 
-from .support import WorkspaceCase
+from .support import WorkspaceCase, publish_origin_branch, shell
 
 
 class WorkspaceEventLogTests(WorkspaceCase):
@@ -162,9 +169,10 @@ class WorkspaceEventLogTests(WorkspaceCase):
         page = event_page(self.config, secret=secret, after=None, limit=50)
         cursor = page["next_cursor"]
         self.assertTrue(cursor)
-        after_seq, event_id = decode_event_cursor(secret, cursor)
+        after_seq, event_id, digest = decode_event_cursor(secret, cursor)
         self.assertEqual(after_seq, 1)
         self.assertEqual(event_id, "evt_1")
+        self.assertEqual(len(digest), 64)
         resumed = event_page(self.config, secret=secret, after=cursor, limit=50)
         self.assertEqual(resumed["events"], [])
         with self.assertRaisesRegex(ConsoleOverviewError, "EVENT_CURSOR_INVALID"):
@@ -173,6 +181,204 @@ class WorkspaceEventLogTests(WorkspaceCase):
         path.write_text("", encoding="utf-8")
         with self.assertRaisesRegex(ConsoleOverviewError, "EVENT_CURSOR_INVALID"):
             event_page(self.config, secret=secret, after=cursor, limit=50)
+
+    def test_hmac_after_cursor_rejects_replaced_same_seq_row(self) -> None:
+        append_event(
+            self.config,
+            kind="spawn",
+            actor="core",
+            subject="core_pay",
+            family="core",
+            facts={"parent": "core", "child": "core_pay"},
+            clock=self.clock,
+        )
+        secret = b"k" * 32
+        cursor = event_page(self.config, secret=secret, after=None, limit=50)["next_cursor"]
+        self.assertTrue(cursor)
+        replacement = {
+            "actor": "core",
+            "at": "2026-08-20T12:00:01Z",
+            "family": "core",
+            "facts": {"parent": "core", "child": "core_pay"},
+            "id": "evt_1",
+            "kind": "sync",
+            "seq": 1,
+            "subject": "core_pay",
+        }
+        path = self.root / ".dyro" / "events.jsonl"
+        path.write_text(
+            json.dumps(replacement, ensure_ascii=False, sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
+        with self.assertRaisesRegex(ConsoleOverviewError, "EVENT_CURSOR_INVALID"):
+            event_page(self.config, secret=secret, after=cursor, limit=50)
+
+    def test_project_event_drops_path_prompt_and_nested_facts(self) -> None:
+        projected = project_event(
+            {
+                "seq": 1,
+                "id": "evt_1",
+                "kind": "spawn",
+                "at": "2026-08-20T12:00:00Z",
+                "actor": "core",
+                "subject": "core_pay",
+                "family": "core",
+                "facts": {
+                    "parent": "core",
+                    "child": "core_pay",
+                    "path": "/tmp/secret",
+                    "prompt": "please prepare notes without any slash token",
+                    "nested": {"argv": ["dyro", "next"]},
+                },
+            }
+        )
+        self.assertEqual(projected["facts"], {"parent": "core", "child": "core_pay"})
+
+    def _event_kinds(self) -> list[str]:
+        path = self.root / ".dyro" / "events.jsonl"
+        if not path.is_file():
+            return []
+        return [
+            json.loads(line)["kind"]
+            for line in path.read_text(encoding="utf-8").splitlines()
+            if line
+        ]
+
+    def _parent_and_child(self):
+        publish_origin_branch(self.anchor, "feat/core")
+        parent = create_line(self.config, line_id="core", branch="feat/core", base="main")
+        child = spawn_line(self.config, "core", "pay")
+        return parent, child
+
+    def test_merge_and_sync_write_events_dry_run_and_failed_preflight_do_not(
+        self,
+    ) -> None:
+        from dyro.errors import DyroError
+
+        parent, child = self._parent_and_child()
+        self.assertEqual(self._event_kinds(), ["spawn"])
+        child_wt = line_repository_path(self.config, child, "api")
+        (child_wt / "child.txt").write_text("from child\n", encoding="utf-8")
+        shell("git", "add", "child.txt", cwd=child_wt)
+        shell("git", "commit", "-m", "feat: child work", cwd=child_wt)
+
+        merge_line(self.config, child.id, parent.id, dry_run=True)
+        self.assertEqual(self._event_kinds(), ["spawn"])
+
+        parent_wt = line_repository_path(self.config, parent, "api")
+        (parent_wt / "dirty.txt").write_text("pending\n", encoding="utf-8")
+        with self.assertRaisesRegex(DyroError, "不干净"):
+            merge_line(self.config, child.id, parent.id)
+        self.assertEqual(self._event_kinds(), ["spawn"])
+        (parent_wt / "dirty.txt").unlink()
+
+        merge_line(self.config, child.id, parent.id)
+        self.assertEqual(self._event_kinds(), ["spawn", "merge"])
+
+        sync_line(self.config, child.id, dry_run=True)
+        self.assertEqual(self._event_kinds(), ["spawn", "merge"])
+        sync_line(self.config, child.id)
+        self.assertEqual(self._event_kinds(), ["spawn", "merge", "sync"])
+
+    def test_dispatch_start_and_end_write_events_dry_run_does_not(self) -> None:
+        create_line(self.config, line_id="core", branch="feat/core", base="main")
+        task_dir = self.config.task_specs_dir / "TASK-A"
+        task_dir.mkdir(parents=True)
+        task_dir.joinpath("task.toml").write_text(
+            task_template("TASK-A", "Prepare release", "core", "api", "services/api"),
+            encoding="utf-8",
+        )
+        task_dir.joinpath("handoff.md").write_text("# handoff\n", encoding="utf-8")
+        task = load_task(self.config, "TASK-A")
+        result = Result(("dyro", "task-dispatch", "codex", "TASK-A"), 0, "")
+        with (
+            patch("dyro.task_dispatch.is_dispatch_write_ready", return_value=True),
+            patch(
+                "dyro.task_dispatch.run_task_bound_dispatch",
+                return_value=result,
+            ),
+        ):
+            _execute_task_agent(
+                self.config,
+                task,
+                workspace=self.root,
+                prompt="do-work",
+                log_name="executor.log",
+                dry_run=True,
+            )
+            self.assertEqual(self._event_kinds(), [])
+            _execute_task_agent(
+                self.config,
+                task,
+                workspace=self.root,
+                prompt="do-work",
+                log_name="executor.log",
+                dry_run=False,
+            )
+        page, _last = read_events(self.config)
+        self.assertEqual([item["kind"] for item in page], ["dispatch", "dispatch"])
+        self.assertEqual(page[0]["facts"]["phase"], "start")
+        self.assertEqual(page[1]["facts"]["phase"], "end")
+        self.assertEqual(page[1]["facts"]["status"], "idle")
+
+    def test_host_seed_writes_an_event_and_dry_run_does_not(self) -> None:
+        parser = build_parser()
+        dry = parser.parse_args(["--root", str(self.root), "host", "seed", "--dry-run"])
+        with redirect_stdout(StringIO()):
+            cmd_host_seed(dry)
+        self.assertEqual(self._event_kinds(), [])
+        seeded = parser.parse_args(["--root", str(self.root), "host", "seed"])
+        with redirect_stdout(StringIO()):
+            cmd_host_seed(seeded)
+        page, _last = read_events(self.config)
+        self.assertEqual(page[0]["kind"], "host_seed")
+        self.assertGreater(page[0]["facts"]["written"], 0)
+
+    def test_apply_supervised_wave_writes_an_event(self) -> None:
+        from dyro.continuation.store import create_objective
+        from dyro.continuation.supervision import apply_supervised_wave, build_supervised_wave
+        from dyro.host import compile_hosts
+
+        compile_hosts(self.config)
+        create_line(self.config, line_id="alpha", branch="feat/alpha", base="main")
+        task_dir = self.config.task_specs_dir / "TASK-A"
+        task_dir.mkdir(parents=True)
+        task_dir.joinpath("task.toml").write_text(
+            task_template("TASK-A", "Task A", "alpha", "api", "services/api").replace(
+                'agent = "codex"', 'agent = "noop"'
+            ),
+            encoding="utf-8",
+        )
+        task_dir.joinpath("handoff.md").write_text("# handoff\n", encoding="utf-8")
+        task_dir.joinpath("receipt.md").write_text("result: DONE\n", encoding="utf-8")
+        create_objective(
+            self.config,
+            '''schema_version = 1
+id = "release"
+title = "Release"
+line = "alpha"
+targets = ["TASK-A"]
+
+[continuation]
+requested_mode = "supervised"
+operations = ["execute", "review"]
+
+[budget]
+max_actions = 20
+max_attempts_per_task = 2
+max_failures = 3
+max_no_progress_cycles = 2
+max_parallel = 1
+''',
+        )
+        now = datetime(2026, 8, 20, 12, 0, tzinfo=timezone.utc)
+        wave = build_supervised_wave(self.config, "release", clock=lambda: now)
+        apply_supervised_wave(self.config, wave, clock=lambda: now)
+        kinds = self._event_kinds()
+        self.assertIn("objective_wave", kinds)
+        page, _last = read_events(self.config)
+        wave_events = [item for item in page if item["kind"] == "objective_wave"]
+        self.assertEqual(wave_events[0]["facts"]["mode"], "apply")
 
 
 if __name__ == "__main__":

--- a/tests/test_families.py
+++ b/tests/test_families.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+import unittest
+
+from dyro.config import load
+from dyro.console.families import family_cards, family_payload
+from dyro.console.read_model import workspace_envelope
+from dyro.families import family_graph, family_members
+from dyro.observations import capture_workspace_read_snapshot
+from dyro.workspace import create_line, spawn_line
+
+from .support import WorkspaceCase
+
+
+class OneLevelFamilyTests(WorkspaceCase):
+    def setUp(self) -> None:
+        super().setUp()
+        self.config = load(self.root)
+        create_line(self.config, line_id="core", branch="feat/core", base="main")
+        spawn_line(self.config, "core", "pay")
+        spawn_line(self.config, "core_pay", "fix")
+
+    def test_parent_is_projected_on_the_line_dto(self) -> None:
+        snapshot = capture_workspace_read_snapshot(self.config)
+        by_id = {item.id: item.parent for item in snapshot.lines}
+        self.assertEqual(by_id["core"], "")
+        self.assertEqual(by_id["core_pay"], "core")
+        self.assertEqual(by_id["core_pay_fix"], "core_pay")
+        envelope = workspace_envelope(snapshot)
+        projected = {item["id"]: item["parent"] for item in envelope["data"]["lines"]}
+        self.assertEqual(projected["core"], "")
+        self.assertEqual(projected["core_pay"], "core")
+        self.assertEqual(projected["core_pay_fix"], "core_pay")
+
+    def test_family_is_one_level_and_includes_operator(self) -> None:
+        lines = [
+            {"id": "core", "parent": ""},
+            {"id": "core_pay", "parent": "core"},
+            {"id": "core_pay_fix", "parent": "core_pay"},
+        ]
+        self.assertEqual(family_members(lines, "core"), ("core", "core_pay", "operator"))
+        self.assertEqual(
+            family_members(lines, "core_pay"),
+            ("core_pay", "core_pay_fix", "operator"),
+        )
+        core = family_graph(lines, "core")
+        self.assertEqual(core["members"], ["core", "core_pay", "operator"])
+        self.assertEqual(core["edges"], [{"from": "core", "to": "core_pay", "kind": "parent"}])
+        self.assertNotIn("core_pay_fix", core["members"])
+        pay = family_graph(lines, "core_pay")
+        self.assertIn("core_pay_fix", pay["members"])
+        self.assertNotIn("core", pay["members"])
+
+    def test_family_cards_and_payload_use_direct_children_only(self) -> None:
+        snapshot = capture_workspace_read_snapshot(self.config)
+        envelope = workspace_envelope(snapshot)
+        lines = envelope["data"]["lines"]
+        tasks = envelope["data"]["tasks"]
+        cards = {item["parent"]: item for item in family_cards(lines, tasks)}
+        self.assertEqual(cards["core"]["children"], ["core_pay"])
+        self.assertEqual(cards["core_pay"]["children"], ["core_pay_fix"])
+        payload = family_payload(lines, "core", tasks)
+        self.assertEqual(payload["parent"], "core")
+        self.assertEqual(payload["members"], ["core", "core_pay", "operator"])
+        self.assertFalse(any(node["id"] == "core_pay_fix" for node in payload["nodes"]))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Design plus P1 implementation for the local Web Console. Public version stays **0.7.7**. P2 channel POST and P3 artifacts are not implemented.

## What landed

- Design: `docs/designs/console-v2-live-family-signals.md` (extends, does not replace, `local-web-console.md` and ADR 0005).
- Append-only `.dyro/events.jsonl` written by in-process mutations that already have a natural moment: `line spawn` / `merge` / `sync`, task status, dispatch start/end, objective-wave apply, and `host seed`.
- Line DTO projects `parent` from overlay schema 3. Missing parent is root.
- One-level family graph: `F(P) = {P} ∪ direct children ∪ {operator}`. Grandchildren stay on the child’s family.
- Workspace detail adds family-tree and live event panes. Channel / artifact panes stay “尚未开放”.
- Live transport: authenticated SSE `GET .../events/stream?after=` with HMAC cursor. Hidden tabs pause. After SSE ends or fails, the page falls back to the existing 5s `GET .../events` poll. No WebSocket.
- Copy buttons emit dry-run CLI only (`--workspace` + `--dry-run`). No `--yes`, no `--push`, no browser POST.

## Review P1s on this revision

Four merge-blocking honesty / fail-closed holes from the adversarial review, smallest change:

1. **Badge lie.** Family badges no longer render 「干净」 or 「远端已绑定」. Uninspected git facts show 「未检查」. Real `in_progress` and unread `0` stay.
2. **Parent re-validates event facts.** Worker facts must be a safe id / enum / small int / bool. A digest-consistent payload with `facts.path` is `OVERVIEW_UNAVAILABLE`. `project_event` no longer fail-opens an 80-char prompt-like string.
3. **HMAC `after=` binds a row digest.** Replacing `evt_1` with a different valid `evt_1` is `EVENT_CURSOR_INVALID`. Truncate / missing newline / empty file / seq gap stay fail-closed. Tamper tests flip a body character; unpadded base64 last-char slack is not treated as a new token.
4. **Writer pins.** Tests require merge / sync / dispatch start+end / host_seed / `apply_supervised_wave` to append a row; dry-run and failed merge preflight write none. Existing spawn + task_status pins stay.

Loopback / Host / bearer / no CORS / no cookie are unchanged. Version stays 0.7.7.

## CI note

Required Python jobs are the source of truth. Vercel preview failures are out of scope for this PR.

Earlier revision: workspace paths had been split into suffix segments (`["proofs"]`), which dropped the `P7-route` marker. Routing uses `remainder.endswith("/proofs")`. The one-shot SSE body carries `Content-Length` like every other Console HTTP/1.1 response.

## How to try

1. `dyro console` (loopback only).
2. Open a workspace that has parented lines (`core` / `core_pay` / `core_pay_fix`).
3. The family pane shows one level at a time; switch parent to see `F(core_pay)`.
4. Run `dyro --workspace <alias> line spawn|merge|sync` (or the test equivalent). The event appears in the stream without a full page reload (SSE first paint, then 5s poll).

Examples use generic line ids only (`core`, `core_pay`, `core_pay_fix`).

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8580f80a-ed13-4db0-acc1-e2a4bf0ac216?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8580f80a-ed13-4db0-acc1-e2a4bf0ac216&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

