### PR TITLE
chore(env): add Cloud Agent development environment for dyro

### DIFF
--- a/.cursor/environment.json
+++ b/.cursor/environment.json
@@ -1,0 +1,4 @@
+{
+  "name": "DyroEngineeringFlow (dyro)",
+  "install": "bash .cursor/install.sh"
+}

--- a/.cursor/install.sh
+++ b/.cursor/install.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# Idempotent Cloud Agent bootstrap for DyroEngineeringFlow (the `dyro` CLI).
+#
+# Mirrors the toolchain the CI workflow (.github/workflows/ci.yml) relies on:
+# uv-managed Python + a locked `uv sync`, plus the TypeScript interop runner deps.
+set -euo pipefail
+
+# uv is the project package/environment manager (see uv.lock + CI). Install once;
+# it lands in ~/.local/bin, which is already on the login-shell PATH.
+if ! command -v uv >/dev/null 2>&1; then
+  curl -LsSf https://astral.sh/uv/install.sh | sh
+fi
+export PATH="$HOME/.local/bin:$PATH"
+
+# Provision a uv-managed CPython so venv creation and `python -m build`
+# isolation do not depend on the base image shipping python3.x-venv.
+uv python install 3.12
+
+# Fail fast if uv.lock has drifted from pyproject.toml, then install the locked
+# project with all extras + dev tools (ruff / build / twine) into .venv.
+uv lock --check
+uv sync --locked --all-extras --dev --python-preference only-managed
+
+# Optional TypeScript protocol interop reference runner (CI job: typescript-interop).
+if command -v npm >/dev/null 2>&1; then
+  ( cd examples/typescript-runner && npm ci )
+fi
+
+echo "dyro environment ready: $(uv run dyro --version)"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a reproducible Cursor Cloud Agent development environment for **DyroEngineeringFlow** (`dyro`). Previously there was no `.cursor/environment.json`, so agents started with no `uv` toolchain.

This is a **repository-managed** environment: once merged to `main`, future Cloud Agents automatically pick up `.cursor/environment.json` (highest-precedence config source) — no dashboard Save required.

### What's included
- `.cursor/environment.json` — minimal repo-managed environment (`name` + `install`).
- `.cursor/install.sh` — an idempotent bootstrap that:
  1. installs the `uv` package/environment manager (once, into `~/.local/bin`, already on the login PATH),
  2. provisions a **uv-managed CPython 3.12** so venv creation and `python -m build` isolation don't depend on the base image shipping `python3.x-venv`,
  3. runs `uv lock --check` then `uv sync --locked --all-extras --dev` (installs the project plus `ruff`/`build`/`twine`),
  4. installs the `examples/typescript-runner` interop deps via `npm ci` when Node is present.

Mirrors the toolchain in `.github/workflows/ci.yml` (uv + locked sync). No dev servers, tests, or migrations run in `install`, so it terminates quickly and stays idempotent.

## Validation

### On the setup VM
| Check | Result |
| --- | --- |
| `uv lock --check` | Passed (37 packages, no drift) |
| `uv sync --locked --all-extras --dev` | Passed (managed CPython 3.12.14) |
| `uv run ruff check src tests experiments` | All checks passed |
| `uv run python -m unittest discover -s tests -t .` | **925 tests OK** |
| `uv run python -m compileall -q src tests experiments` | Passed |
| `uv run python -m build` + clean-venv wheel smoke | Wheel + sdist built; imports/assets/`dyro dispatch doctor`/bundle-stranger verify OK |
| `dyro --version` | `dyro 0.7.7` |
| TypeScript interop (`npm ci && npm test`) | 1/1 pass (canonical bytes + Ed25519 signature match Python) |
| `dyro console` local dashboard | Loads, secure local session established, workspace shown healthy, detail view opens (see demo video) |
| Install idempotence | Ran twice; sub-second second run; no lockfile changes |

### Prebuilt environment build + fresh Cloud Agent
A draft build was created from this branch on a READY VM snapshot and **SUCCEEDED**; a fresh Cloud Agent booted from that exact build id passed **12/12** read-only checks (`uv 0.12.5`, `dyro 0.7.7`, managed CPython 3.12.14, `uv sync --locked` made no changes, ruff/compile clean, `dyro dispatch --dry-run doctor` JSON, TS interop test pass).

## Demo
[dyro_console_dashboard_demo.mp4](https://cursor.com/agents/bc-97757d2f-186b-4396-8b7e-eb9042a2b5c7/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdyro_console_dashboard_demo.mp4)

## Activation
Merging this PR activates the environment for future Cloud Agents (repo-managed config takes precedence over dashboard settings).


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-97757d2f-186b-4396-8b7e-eb9042a2b5c7?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-97757d2f-186b-4396-8b7e-eb9042a2b5c7&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

