### PR TITLE
Hide user-facing dyro-board; keep /dyro-review-board

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## Unreleased
 
+- Hide the internal `dyro-board` protocol from slash / `$` skill pickers.
+  `/dyro-review-board` is the only human-facing 会审 command. The protocol
+  asset still installs as a non-invocable companion of `review-board` (and
+  with the board seat). `dyro integration install board` is a legacy id for
+  that same surface plus protocol; `dyro integration status board` still
+  inspects the protocol. The wrapper still refuses same-turn commit, push,
+  merge, or publish.
 - Add design `docs/designs/console-v2-live-family-signals.md` for live
   events, one-level line families, and overlay family signals. It extends
   the local Web Console and ADR 0005; it does not replace them.

--- a/README.md
+++ b/README.md
@@ -289,12 +289,13 @@ python3 -m pip install --user --upgrade dyro
 
 Interactive `dyro setup` can install the first-party Skill bundle during personal
 preferences. That one opt-in installs the first-batch seats: `dyro-control-plane`,
-`dyro-executor`, `dyro-board`, and `dyro-dispatch`. Existing managed control-plane
-installations automatically gain the new companions on the next interactive
-launch or package refresh, and managed Skills then stay synchronized with Dyro
-updates. Machines that have never opted into a Dyro Skill are not modified
-silently. Each seat auto-loads from context; loading a seat is not consent to
-mutate.
+`dyro-executor`, the 会审 protocol plus `/dyro-review-board`, and `dyro-dispatch`.
+`dyro-board` is the internal protocol id, not a second slash command. Existing
+managed control-plane installations automatically gain the new companions on the
+next interactive launch or package refresh, and managed Skills then stay
+synchronized with Dyro updates. Machines that have never opted into a Dyro Skill
+are not modified silently. Each seat auto-loads from context; loading a seat is
+not consent to mutate.
 
 Multi-harness delegation remains separate from the read-only control plane so its
 process/network effects are explicit. Manual installation is still available:
@@ -622,7 +623,7 @@ dyro --dry-run task run API-101
 | `objective list/status/explain/tick/attention/plan` | Inspect accepted Objectives and the switch-tool briefing. Mutations stay on `objective apply`. |
 | `proof list/show/verify/export/verify-bundle` | Rebind delivery Proof. `verify` rebinds the workspace; `verify-bundle` checks portable integrity only. `live` is not merge. |
 | `config get/set` / `agent list/add/test/discover` / `tool list/install/default/pin` / `open` | Safely manage policy, adapters, tool discovery and personal launch preferences, or open an agent in the correct line. |
-| `integration status/install/sync/uninstall` | Manage first-party Skill seats (`dyro-control-plane`, `dyro-executor`, `dyro-board`, `dyro-dispatch`). Loading a seat is not consent to mutate. |
+| `integration status/install/sync/uninstall` | Manage first-party Skill seats (`dyro-control-plane`, `dyro-executor`, `/dyro-review-board`, `dyro-dispatch`). `dyro-board` remains the internal 会审 protocol id. Loading a seat is not consent to mutate. |
 | `task create/open/list/board/status/next/graph/explain/attempts/binding` | Create or enter tasks, manage state, validate the task graph, explain scheduling, inspect provenance, and output review bindings. |
 | `task run/answer/gates/review/signoff` | Run tasks, resolve questions, execute gates, request independent review, and record external sign-off when a Profile requires it. |
 | `task claim --output` / `task evidence build/execution/review` | One-time claim with a create-only runner handoff file, portable execution-evidence build/import, and receipt-bound review import. |

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -286,7 +286,8 @@ python3 -m pip install --user --upgrade dyro
 ```
 
 交互式 `dyro setup` 可在个人偏好步骤一次启用第一方 Skill 套件，同时安装首批座位：
-`dyro-control-plane`、`dyro-executor`、`dyro-board` 与 `dyro-dispatch`。已经托管
+`dyro-control-plane`、`dyro-executor`、会审协议加 `/dyro-review-board` 与
+`dyro-dispatch`。`dyro-board` 是内部协议 id，不是第二条斜杠命令。已经托管
 控制面 Skill 的用户会在下次交互启动或包更新后自动补装新座位，此后都会随 Dyro
 自动同步；从未启用过 Dyro Skill 的机器不会被后台静默写入。座位按情景自动戴上，
 戴上不等于同意突变。
@@ -560,7 +561,7 @@ dyro --dry-run task run API-101
 | `objective list/status/explain/tick/attention/plan` | 查看已接受的 Objective 与换工具开场白。写操作在 `objective apply`。 |
 | `proof list/show/verify/export/verify-bundle` | 重绑交付 Proof。`verify` 重绑当前工作区；`verify-bundle` 只核便携完整性。`live` 不是 merge。 |
 | `config get/set` / `agent list/add/test/discover` / `tool list/install/default/pin` / `open` | 安全管理策略、adapter、工具发现与个人启动偏好，或在正确开发线启动 Agent。 |
-| `integration status/install/sync/uninstall` | 管理第一方座位 Skill（`dyro-control-plane`、`dyro-executor`、`dyro-board`、`dyro-dispatch`）。加载座位不是同意改世界。 |
+| `integration status/install/sync/uninstall` | 管理第一方座位 Skill（`dyro-control-plane`、`dyro-executor`、`/dyro-review-board`、`dyro-dispatch`）。`dyro-board` 仍是内部会审协议 id。加载座位不是同意改世界。 |
 | `task create/open/list/board/status/next/graph/explain/attempts/binding` | 创建或进入任务、管理状态，编译/校验任务图，解释调度，查看 provenance，输出精确复核绑定。 |
 | `task run/answer/gates/review/signoff` | 执行任务、回答追问、运行门禁、申请独立复核；需要时记录外部签收。 |
 | `task claim --output` / `task evidence build/execution/review` | 一次性领取任务并以“仅创建”文件交给隔离执行器，构建/导入可移植执行证据包，并导入与回执绑定的复核证据。 |

--- a/docs/agent-orchestration-discipline.md
+++ b/docs/agent-orchestration-discipline.md
@@ -58,7 +58,7 @@ Agent 输出永远是**建议**；进入交付链必须经过 Dyro 契约与独�
 
 ## 3. 对抗评审记录协议（摘要）
 
-第一方座位 `dyro-board` 在用户提出会审 / 对抗 / Go/No-Go 时自动戴上；记录仍不是 Proof。完整模板见 [可选本地 Agent 派发设计 §6](designs/optional-local-agent-dispatch.md#6-对抗评审记录协议)。
+第一方座位 `dyro-board` 在用户提出会审 / 对抗 / Go/No-Go 时自动戴上协议；人类命令是 `/dyro-review-board`。记录仍不是 Proof。完整模板见 [可选本地 Agent 派发设计 §6](designs/optional-local-agent-dispatch.md#6-对抗评审记录协议)。
 
 硬规则：
 

--- a/docs/updates.md
+++ b/docs/updates.md
@@ -62,7 +62,8 @@ the managed bundle through the fresh `dyro` entry point. Interactive `dyro`,
 `dyro home`, and `dyro start` launches also repair outdated managed Skills.
 The control-plane opt-in covers first-party companions, so an existing managed
 control plane automatically gains `dyro-dispatch`, `dyro-executor`, and
-`dyro-board`. A machine with no prior Dyro Skill ownership remains untouched.
+the 会审 protocol plus `/dyro-review-board`. `dyro-board` stays the internal
+protocol id. A machine with no prior Dyro Skill ownership remains untouched.
 Manual control-plane commands are:
 
 ```bash
@@ -86,8 +87,11 @@ dyro integration install dispatch --dry-run
 dyro integration install dispatch --yes
 dyro integration sync dispatch --yes
 dyro integration install executor --yes
-dyro integration install board --yes
+dyro integration install review-board --yes
 ```
+
+`dyro integration install board` is a legacy id for the same 会审 surface plus
+protocol. `dyro integration status board` still inspects the protocol seat.
 
 Editable source installations are deliberately rejected. Update those through
 their Git checkout so a convenience command cannot replace a development

--- a/src/dyro/cli.py
+++ b/src/dyro/cli.py
@@ -141,6 +141,7 @@ from .image_sidecar import (
 )
 from .integrations import (
     INTEGRATION_CHOICES,
+    USER_INTEGRATION_METAVAR,
     IntegrationState,
     install_integration,
     integration_status,
@@ -924,7 +925,7 @@ def _setup_skill_preference() -> bool:
         prompt,
         (
             ("1", option_one),
-            ("2", "稍后手动安装（dyro integration install skill / executor / board / dispatch）"),
+            ("2", "稍后手动安装（dyro integration install skill / executor / review-board / dispatch）"),
         ),
         default=default,
     )
@@ -991,7 +992,7 @@ def _render_setup_personal_preferences(
             print("  - Skills：无法安装：未检测到 Agent 宿主目录")
             print(
                 "      · 确认后会 soft-fail；请安装宿主后运行 "
-                "dyro integration install skill / executor / board / dispatch"
+                "dyro integration install skill / executor / review-board / dispatch"
             )
             return
         plans = []
@@ -4510,7 +4511,12 @@ def build_parser() -> argparse.ArgumentParser:
     integration_install_parser.add_argument(
         "id",
         choices=INTEGRATION_CHOICES,
-        help="skill 为控制面；executor 为执行座位；board 为评审板；dispatch 为派发；codex 为 skill 别名",
+        metavar=USER_INTEGRATION_METAVAR,
+        help=(
+            "review-board 安装会审斜杠 /dyro-review-board 及内部协议；"
+            "board 为遗留内部 id；skill=控制面；executor=执行；"
+            "dispatch=派发；task-merge/line-family=斜杠；codex=skill 别名"
+        ),
     )
     integration_install_parser.add_argument(
         "--yes", action="store_true", help="确认执行已预览的安装或升级"
@@ -4529,7 +4535,12 @@ def build_parser() -> argparse.ArgumentParser:
     integration_sync_parser.add_argument(
         "id",
         choices=INTEGRATION_CHOICES,
-        help="skill 为控制面；executor 为执行座位；board 为评审板；dispatch 为派发；codex 为 skill 别名",
+        metavar=USER_INTEGRATION_METAVAR,
+        help=(
+            "review-board 安装会审斜杠 /dyro-review-board 及内部协议；"
+            "board 为遗留内部 id；skill=控制面；executor=执行；"
+            "dispatch=派发；task-merge/line-family=斜杠；codex=skill 别名"
+        ),
     )
     integration_sync_parser.add_argument(
         "--yes", action="store_true", help="确认执行已预览的同步或升级"
@@ -4544,7 +4555,12 @@ def build_parser() -> argparse.ArgumentParser:
     integration_uninstall_parser = integration_sub.add_parser(
         "uninstall", help="仅卸载仍匹配 ownership manifest 的资产"
     )
-    integration_uninstall_parser.add_argument("id", choices=INTEGRATION_CHOICES)
+    integration_uninstall_parser.add_argument(
+        "id",
+        choices=INTEGRATION_CHOICES,
+        metavar=USER_INTEGRATION_METAVAR,
+        help="review-board 为会审斜杠；board 为遗留内部协议 id；其余与 install 相同",
+    )
     integration_uninstall_parser.add_argument(
         "--yes", action="store_true", help="确认卸载仍完整的自有资产"
     )

--- a/src/dyro/integrations/__init__.py
+++ b/src/dyro/integrations/__init__.py
@@ -3,6 +3,8 @@
 from .manager import (
     AvatarStatus,
     INTEGRATION_CHOICES,
+    USER_INTEGRATION_CHOICES,
+    USER_INTEGRATION_METAVAR,
     IntegrationPlan,
     IntegrationState,
     IntegrationStatus,
@@ -16,6 +18,8 @@ from .manager import (
 __all__ = [
     "AvatarStatus",
     "INTEGRATION_CHOICES",
+    "USER_INTEGRATION_CHOICES",
+    "USER_INTEGRATION_METAVAR",
     "IntegrationPlan",
     "IntegrationState",
     "IntegrationStatus",

--- a/src/dyro/integrations/assets/dyro-board/SKILL.md
+++ b/src/dyro/integrations/assets/dyro-board/SKILL.md
@@ -1,9 +1,12 @@
 ---
 name: dyro-board
-description: Run Dyro's first-party adversarial review-board protocol. Use when the user asks for multi-model review, 会审, 对抗, 能不能发, Go/No-Go, or P0/P1 arbitration. Auto-load this board seat. Findings are advisory records, not Proof and not a task review PASS.
+description: Internal Dyro 会审 protocol (not a user slash; humans run /dyro-review-board). Auto-load this board seat for multi-model review, 会审, 对抗, 能不能发, Go/No-Go, or P0/P1 arbitration. Findings are advisory records, not Proof and not a task review PASS.
+user-invocable: false
 ---
 
 # Dyro Review Board
+
+This file is the protocol, not a user slash. Humans run `/dyro-review-board`.
 
 Run the first-party adversarial record protocol. Auto-load this seat when the
 user asks for a board, 会审, 对抗, release Go/No-Go, or P0/P1 arbitration. Do

--- a/src/dyro/integrations/assets/dyro-board/agents/openai.yaml
+++ b/src/dyro/integrations/assets/dyro-board/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
-  display_name: "Dyro Review Board"
-  short_description: "Adversarial review record, not delivery proof"
-  default_prompt: "Use $dyro-board. Run the signed review-board protocol. Findings are advisory; they are not Proof or task review PASS."
+  display_name: "Dyro Review Board Protocol"
+  short_description: "Internal 会审 protocol, not a user slash"
+  default_prompt: "Load this installed protocol for 会审 / 对抗. This is not a user slash or $ command. Humans run /dyro-review-board. Findings are advisory; they are not Proof or task review PASS."

--- a/src/dyro/integrations/assets/dyro-control-plane/SKILL.md
+++ b/src/dyro/integrations/assets/dyro-control-plane/SKILL.md
@@ -7,7 +7,7 @@ description: Inspect Dyro control-plane state and prepare bounded read-only expl
 
 Treat Dyro as the delivery control plane. Run only the allowlisted observations below, prefer their JSON output, and leave every state-changing action to the user in Dyro.
 
-Auto-load this navigator seat at a workspace or line root, after switching tools, or when the user asks 下一步 / 堵住了 / status. Loading the seat is not consent to mutate. Writing in a task worktree is `dyro-executor`. 会审 / 对抗 is `dyro-board`. Parallel harnesses are `dyro-dispatch`.
+Auto-load this navigator seat at a workspace or line root, after switching tools, or when the user asks 下一步 / 堵住了 / status. Loading the seat is not consent to mutate. Writing in a task worktree is `dyro-executor`. 会审 / 对抗 auto-loads the `dyro-board` protocol; the human command is `/dyro-review-board`. Parallel harnesses are `dyro-dispatch`.
 
 ## Read-only routing
 
@@ -47,7 +47,7 @@ Keep the handoff short and separate evidence from judgment:
 
 Only hand off a workspace-scoped mutation when the returned command retains an explicit `--workspace <alias>` or absolute `--root <path>` selector. Never reconstruct, shorten, retarget, or strip that selector. When `next.commands` is empty or `mutation_available` is false, do not manufacture a mutation from `diagnostic_commands`, findings, or prose.
 
-If the user asks for 会审, 对抗, or Go/No-Go, follow `dyro-board` instead of inventing P0 here. A CLI summary alone is never final runtime or production acceptance.
+If the user asks for 会审, 对抗, or Go/No-Go, follow the `dyro-board` protocol (human command `/dyro-review-board`) instead of inventing P0 here. A CLI summary alone is never final runtime or production acceptance.
 
 ## Hard safety boundary
 

--- a/src/dyro/integrations/assets/dyro-executor/SKILL.md
+++ b/src/dyro/integrations/assets/dyro-executor/SKILL.md
@@ -18,7 +18,8 @@ Load immediately when any of these are true:
 - The user says to implement, fix, finish, 修这个, 做完, or 继续写.
 
 Do not load this seat at a workspace or line root. Use `dyro-control-plane`
-there. Do not load it for 会审 / 对抗; that is `dyro-board`.
+there. Do not load it for 会审 / 对抗; that auto-loads the `dyro-board`
+protocol. Humans run `/dyro-review-board`.
 
 ## Write boundary
 

--- a/src/dyro/integrations/manager.py
+++ b/src/dyro/integrations/manager.py
@@ -37,16 +37,16 @@ from .seats import (
 CANONICAL_INTEGRATION_ID = CONTROL_PLANE_ID
 LEGACY_INTEGRATION_ID = "codex"
 SKILL_NAME = CONTROL_PLANE_SKILL
-ASSET_VERSION = 4
+ASSET_VERSION = 5
 DISPATCH_INTEGRATION_ID = DISPATCH_ID
 DISPATCH_SKILL_NAME = DISPATCH_SKILL
 DISPATCH_ASSET_VERSION = 2
 EXECUTOR_INTEGRATION_ID = EXECUTOR_ID
 EXECUTOR_SKILL_NAME = EXECUTOR_SKILL
-EXECUTOR_ASSET_VERSION = 1
+EXECUTOR_ASSET_VERSION = 2
 BOARD_INTEGRATION_ID = BOARD_ID
 BOARD_SKILL_NAME = BOARD_SKILL
-BOARD_ASSET_VERSION = 1
+BOARD_ASSET_VERSION = 2
 REVIEW_BOARD_INTEGRATION_ID = "review-board"
 REVIEW_BOARD_SKILL_NAME = "dyro-review-board"
 REVIEW_BOARD_ASSET_VERSION = 1
@@ -68,6 +68,8 @@ class SkillIntegrationSpec:
     asset_version: int
     aliases: tuple[str, ...] = ()
     legacy_manifest_id: str | None = None
+    companions: tuple[str, ...] = ()
+    user_facing: bool = True
 
 
 CONTROL_PLANE_SPEC = SkillIntegrationSpec(
@@ -91,11 +93,14 @@ BOARD_SPEC = SkillIntegrationSpec(
     integration_id=BOARD_INTEGRATION_ID,
     skill_name=BOARD_SKILL_NAME,
     asset_version=BOARD_ASSET_VERSION,
+    companions=(REVIEW_BOARD_INTEGRATION_ID,),
+    user_facing=False,
 )
 REVIEW_BOARD_SPEC = SkillIntegrationSpec(
     integration_id=REVIEW_BOARD_INTEGRATION_ID,
     skill_name=REVIEW_BOARD_SKILL_NAME,
     asset_version=REVIEW_BOARD_ASSET_VERSION,
+    companions=(BOARD_INTEGRATION_ID,),
 )
 TASK_MERGE_SPEC = SkillIntegrationSpec(
     integration_id=TASK_MERGE_INTEGRATION_ID,
@@ -121,6 +126,13 @@ INTEGRATION_CHOICES: tuple[str, ...] = tuple(
     for spec in SKILL_INTEGRATIONS
     for choice in (spec.integration_id, *spec.aliases)
 )
+USER_INTEGRATION_CHOICES: tuple[str, ...] = tuple(
+    choice
+    for spec in SKILL_INTEGRATIONS
+    if spec.user_facing
+    for choice in (spec.integration_id, *spec.aliases)
+)
+USER_INTEGRATION_METAVAR = "{" + ",".join(USER_INTEGRATION_CHOICES) + "}"
 
 
 class IntegrationState(str, Enum):
@@ -1286,7 +1298,7 @@ def sync_managed_skill(
 ) -> IntegrationPlan | None:
     """Install or upgrade the Skill when the local state allows mutation.
 
-    - ``CURRENT``: no-op (``None``)
+    - ``CURRENT``: no-op (``None``), unless a companion still needs install
     - ``OUTDATED``: upgrade / repair the managed install
     - ``ABSENT``: first install only when ``allow_first_install`` is true
     - conflict / recovery states: raise ``DyroError`` (callers may soft-fail)
@@ -1298,7 +1310,20 @@ def sync_managed_skill(
         codex_home=codex_home,
     )
     if status.state is IntegrationState.CURRENT:
-        return None
+        spec = _integration_spec(integration)
+        if not spec.companions:
+            return None
+        plan = install_integration(
+            integration,
+            yes=yes,
+            dry_run=dry_run,
+            dyro_home=dyro_home,
+            host_homes=host_homes,
+            codex_home=codex_home,
+        )
+        if not any(change.startswith("同时安装") for change in plan.changes):
+            return None
+        return plan
     if status.state is IntegrationState.ABSENT and not allow_first_install:
         return None
     return install_integration(
@@ -1311,7 +1336,78 @@ def sync_managed_skill(
     )
 
 
+def _companion_install_label(companion_id: str) -> str:
+    if companion_id == BOARD_INTEGRATION_ID:
+        return "同时安装 board（`/dyro-review-board` 的内部协议，不是斜杠命令）"
+    if companion_id == REVIEW_BOARD_INTEGRATION_ID:
+        return "同时安装 review-board（人类斜杠 `/dyro-review-board`）"
+    return f"同时安装 {companion_id}"
+
+
+def _companion_plan_is_interesting(plan: IntegrationPlan) -> bool:
+    if not plan.changes:
+        return False
+    return plan.changes != ("无需写入；Integration 已是当前版本",)
+
+
+def _merge_companion_plans(
+    plan: IntegrationPlan, companion_plans: tuple[IntegrationPlan, ...]
+) -> IntegrationPlan:
+    extras: list[str] = []
+    for companion_plan in companion_plans:
+        if not _companion_plan_is_interesting(companion_plan):
+            continue
+        extras.append(_companion_install_label(companion_plan.status.integration))
+        extras.extend(companion_plan.changes)
+    if not extras:
+        return plan
+    return IntegrationPlan(plan.action, plan.status, plan.changes + tuple(extras))
+
+
 def install_integration(
+    integration: str,
+    *,
+    yes: bool,
+    dry_run: bool = False,
+    dyro_home: Path | None = None,
+    host_homes: Mapping[str, Path] | None = None,
+    codex_home: Path | None = None,
+    _seen: frozenset[str] | None = None,
+) -> IntegrationPlan:
+    spec = _integration_spec(integration)
+    seen = frozenset(_seen or ())
+    if spec.integration_id in seen:
+        status = integration_status(
+            integration,
+            dyro_home=dyro_home,
+            host_homes=host_homes,
+            codex_home=codex_home,
+        )
+        return IntegrationPlan("install", status, ())
+    plan = _install_one(
+        integration,
+        yes=yes,
+        dry_run=dry_run,
+        dyro_home=dyro_home,
+        host_homes=host_homes,
+        codex_home=codex_home,
+    )
+    companion_plans = tuple(
+        install_integration(
+            companion_id,
+            yes=yes,
+            dry_run=dry_run,
+            dyro_home=dyro_home,
+            host_homes=host_homes,
+            codex_home=codex_home,
+            _seen=seen | {spec.integration_id},
+        )
+        for companion_id in spec.companions
+    )
+    return _merge_companion_plans(plan, companion_plans)
+
+
+def _install_one(
     integration: str,
     *,
     yes: bool,

--- a/tests/test_integrations.py
+++ b/tests/test_integrations.py
@@ -14,6 +14,8 @@ from unittest.mock import patch
 from dyro.cli import main
 from dyro.errors import DyroError
 from dyro.integrations import (
+    INTEGRATION_CHOICES,
+    USER_INTEGRATION_CHOICES,
     IntegrationState,
     install_integration,
     integration_status,
@@ -263,6 +265,116 @@ class IntegrationManagerTests(unittest.TestCase):
         self.assertFalse(self.dispatch_mirror.exists())
         self.assertFalse(
             self.dispatch_avatar.exists() or self.dispatch_avatar.is_symlink()
+        )
+
+    def test_review_board_is_the_only_invocable_board_slash(self) -> None:
+        board = (manager._asset_root("board") / "SKILL.md").read_text(
+            encoding="utf-8"
+        )
+        review = (manager._asset_root("review-board") / "SKILL.md").read_text(
+            encoding="utf-8"
+        )
+        board_meta = (
+            manager._asset_root("board") / "agents" / "openai.yaml"
+        ).read_text(encoding="utf-8")
+        self.assertIn("user-invocable: false", board)
+        self.assertNotIn("user-invocable: true", board)
+        self.assertNotIn("/dyro-board", board)
+        self.assertNotIn("$dyro-board", board)
+        self.assertNotIn("$dyro-board", board_meta)
+        self.assertIn("/dyro-review-board", board)
+        self.assertIn("/dyro-review-board", board_meta)
+        self.assertIn("user-invocable: true", review)
+        self.assertIn("disable-model-invocation: true", review)
+        self.assertIn("dyro-board/SKILL.md", review)
+        self.assertIn("Refuse those delivery actions", review)
+        self.assertNotIn("--yes", review)
+        self.assertNotIn("board", USER_INTEGRATION_CHOICES)
+        self.assertIn("review-board", USER_INTEGRATION_CHOICES)
+        self.assertIn("board", INTEGRATION_CHOICES)
+
+    def test_review_board_install_also_installs_protocol(self) -> None:
+        installed = install_integration("review-board", yes=True)
+        self.assertEqual(installed.status.state, IntegrationState.CURRENT)
+        self.assertEqual(
+            integration_status("board").state, IntegrationState.CURRENT
+        )
+        review_avatar = self.codex_home / "skills" / "dyro-review-board"
+        protocol = review_avatar.parent / "dyro-board" / "SKILL.md"
+        self.assertTrue(review_avatar.is_symlink())
+        self.assertTrue(protocol.is_file())
+        self.assertIn("user-invocable: false", protocol.read_text(encoding="utf-8"))
+        self.assertTrue(
+            any("同时安装 board" in change for change in installed.changes),
+            msg=installed.changes,
+        )
+
+    def test_legacy_board_install_installs_review_board_surface(self) -> None:
+        installed = install_integration("board", yes=True)
+        self.assertEqual(installed.status.state, IntegrationState.CURRENT)
+        self.assertEqual(
+            integration_status("review-board").state, IntegrationState.CURRENT
+        )
+        self.assertTrue(
+            (self.codex_home / "skills" / "dyro-review-board" / "SKILL.md").is_file()
+        )
+        self.assertTrue(
+            any("同时安装 review-board" in change for change in installed.changes),
+            msg=installed.changes,
+        )
+
+    def test_sync_current_review_board_installs_missing_protocol(self) -> None:
+        install_integration("review-board", yes=True)
+        uninstall_integration("board", yes=True)
+        self.assertEqual(
+            integration_status("review-board").state, IntegrationState.CURRENT
+        )
+        self.assertEqual(integration_status("board").state, IntegrationState.ABSENT)
+
+        plan = sync_managed_skill("review-board", yes=True, allow_first_install=False)
+        self.assertIsNotNone(plan)
+        assert plan is not None
+        self.assertEqual(integration_status("board").state, IntegrationState.CURRENT)
+        self.assertTrue(
+            any("同时安装 board" in change for change in plan.changes),
+            msg=plan.changes,
+        )
+
+    def test_legacy_board_status_stays_on_protocol_id(self) -> None:
+        output = StringIO()
+        with redirect_stdout(output):
+            main(["integration", "status", "board", "--format", "json"])
+        payload = json.loads(output.getvalue())
+        self.assertEqual(payload["integration"], "board")
+        self.assertEqual(payload["state"], "absent")
+
+        install_integration("board", yes=True)
+        current = StringIO()
+        with redirect_stdout(current):
+            main(["integration", "status", "board", "--format", "json"])
+        installed = json.loads(current.getvalue())
+        self.assertEqual(installed["integration"], "board")
+        self.assertEqual(installed["state"], "current")
+
+    def test_integration_install_help_hides_board_slash_sibling(self) -> None:
+        stdout = StringIO()
+        stderr = StringIO()
+        with (
+            redirect_stdout(stdout),
+            patch("sys.stderr", stderr),
+            self.assertRaises(SystemExit) as raised,
+        ):
+            main(["integration", "install", "--help"])
+        self.assertEqual(raised.exception.code, 0)
+        text = stdout.getvalue() + stderr.getvalue()
+        collapsed = re.sub(r"\s+", "", text)
+        self.assertNotIn("/dyro-board", collapsed)
+        self.assertNotIn("$dyro-board", text)
+        self.assertIn("/dyro-review-board", collapsed)
+        self.assertIn("review-board", text)
+        self.assertNotIn(
+            "{skill,codex,dispatch,executor,board,review-board",
+            text,
         )
 
     def test_executor_and_board_skills_install_independently(self) -> None:

--- a/tests/test_seats.py
+++ b/tests/test_seats.py
@@ -91,12 +91,24 @@ class FirstBatchSeatTests(unittest.TestCase):
                 for line in frontmatter.splitlines()
                 if line.strip()
             }
-            self.assertEqual(keys, {"name", "description"}, msg=seat.skill_name)
+            expected_keys = {"name", "description"}
+            if seat.integration_id == BOARD_ID:
+                expected_keys = {"name", "description", "user-invocable"}
+                self.assertIn("user-invocable: false", frontmatter)
+                self.assertNotIn("user-invocable: true", frontmatter)
+                self.assertNotIn("/dyro-board", content)
+                self.assertIn("/dyro-review-board", content)
+            self.assertEqual(keys, expected_keys, msg=seat.skill_name)
             self.assertIn(f"name: {seat.skill_name}", frontmatter)
             lowered = content.lower()
             for term in seat.trigger_terms:
                 self.assertIn(term.lower(), lowered, msg=f"{seat.skill_name}: {term}")
-            self.assertIn(f"${seat.skill_name}", metadata.read_text(encoding="utf-8"))
+            metadata_text = metadata.read_text(encoding="utf-8")
+            if seat.integration_id == BOARD_ID:
+                self.assertNotIn("$dyro-board", metadata_text)
+                self.assertIn("/dyro-review-board", metadata_text)
+            else:
+                self.assertIn(f"${seat.skill_name}", metadata_text)
             description = frontmatter.split("description:", 1)[1].strip()
             self.assertLessEqual(len(description), 1024, msg=seat.skill_name)
             self.assertNotIn("~/", content)
@@ -136,6 +148,18 @@ class FirstBatchSeatTests(unittest.TestCase):
             self.assertIn("disable-model-invocation: true", content)
             self.assertIn("user-invocable: true", content)
             self.assertNotIn("TODO", content)
+        board = (
+            Path(__file__).resolve().parents[1]
+            / "src"
+            / "dyro"
+            / "integrations"
+            / "assets"
+            / "dyro-board"
+            / "SKILL.md"
+        ).read_text(encoding="utf-8")
+        self.assertIn("user-invocable: false", board)
+        self.assertNotIn("user-invocable: true", board)
+        self.assertNotIn("/dyro-board", board)
 
     def test_wheel_package_data_lists_every_first_batch_skill(self) -> None:
         metadata = Path(__file__).resolve().parents[1].joinpath("pyproject.toml")


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
`/dyro-review-board` is the only human-facing 会审 / 对抗审查 command. The `dyro-board` protocol stays installed, but it is no longer a sibling slash or `$` skill.

## What changed
- Mark `dyro-board` `user-invocable: false` and stop advertising `$dyro-board` in Codex metadata. Protocol steps are unchanged.
- Stop listing `board` in user-facing install/sync/uninstall choice help. `dyro integration install board` remains a legacy id that installs the same `/dyro-review-board` surface plus protocol.
- Installing `review-board` also installs the `dyro-board` protocol as a non-invocable companion, so the wrapper can still load `dyro-board/SKILL.md`.
- Chat/docs/help now tell humans the command is `/dyro-review-board`.
- The wrapper still refuses same-turn commit, push, merge, or publish and does not invent `--yes`.

## Leftover `dyro-board` strings (kept on purpose)
- Skill name / folder / `BOARD_SKILL` — protocol seat id
- `dyro integration status board` — internal integration id
- Wrapper lookup path `dyro-board/SKILL.md` and host sibling install
- Control-plane allowlist `integration status board`
- Historical 0.7.4 / 0.7.6 changelog text

Version stays **0.7.7**. Please leave this PR open for review; do not merge from this change set.

## Tests
- User-facing install/help no longer presents `dyro-board` as an invocable slash sibling
- Wrapper still finds the protocol; legacy `board` status/install still works
- Focused integration/seat tests passed. Full suite had only unrelated env failures (`uv`/`--user` pip and dispatch worker process tests).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-97e414c9-85ce-48a2-8772-429cd3f5695b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-97e414c9-85ce-48a2-8772-429cd3f5695b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

