### PR TITLE
fix(控制台): next must not claim ready on doctor FAIL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## Unreleased
 
+- `dyro next` no longer reports `ready` when doctor has FAIL findings,
+  including missing-origin-only. JSON `state` is `needs_repair`,
+  `commands` includes scoped `doctor` (a read; `mutation_available`
+  stays false), and the human path prints the FAILs instead of
+  「工作区已就绪」。`dyro start` still treats missing-origin as
+  non-blocking. Isolated Console uses the same `next.commands` source
+  instead of an empty loader, so a FAIL workspace is not stuck with
+  empty commands while production is not.
 - Console operator surface: treat doctor FAIL findings as something the
   page must show even when `next` reports ready with empty commands.
   Overview heading and 现在需要你 surface those FAILs; the primary copy

--- a/src/dyro/cli.py
+++ b/src/dyro/cli.py
@@ -44,6 +44,7 @@ from .continuation.briefing import (
     render_human_attention,
     render_human_wave,
 )
+from .continuation.next_step import bootstrap_repair_applicable, repair_commands
 from .continuation.ready_briefing import briefing_command, build_ready_briefing
 from .continuation.engine import (
     build_scheduler_tick,
@@ -164,7 +165,6 @@ from .onboarding import (
     render_setup_plan,
     repository_input_from_path,
     sibling_workspace_for,
-    validate_bootstrap_destination,
 )
 from .read_limits import ObservationLimits, ReadBudget, ReadLimitCode, ReadLimitError
 from .profile import (
@@ -2525,14 +2525,6 @@ def cmd_start(args: argparse.Namespace) -> None:
     )
 
 
-def _bootstrap_destination_safe(config: Config, relative: str) -> bool:
-    try:
-        validate_bootstrap_destination(config, relative)
-    except (DyroError, OSError):
-        return False
-    return True
-
-
 def _next_push_fields(config: Config) -> dict[str, object]:
     return push_policy_fields(config.policy)
 
@@ -2581,34 +2573,10 @@ def cmd_next(args: argparse.Namespace) -> None:
     budget = _control_plane_budget(args) if args.format == "json" else None
     findings = doctor(config, read_budget=budget)
     failures = [finding for finding in findings if finding.startswith("FAIL")]
-    missing_origin_failures = [
-        finding for finding in failures if is_missing_origin_finding(finding)
-    ]
-    blocking_failures = [
-        finding for finding in failures if not is_missing_origin_finding(finding)
-    ]
-    if blocking_failures:
-        absent_bootstrap_ids = {
-            repo_id
-            for repo_id, repository in config.repositories.items()
-            if repository.remote
-            and not (config.root / repository.path).exists()
-            and not (config.root / repository.path).is_symlink()
-            and _bootstrap_destination_safe(config, repository.path)
-        }
-        expected_bootstrap_failures = {
-            f"FAIL repository {repo_id}: missing or not Git: "
-            f"{config.root / config.repositories[repo_id].path}"
-            for repo_id in absent_bootstrap_ids
-        }
-        bootstrap_applicable = (
-            bool(absent_bootstrap_ids) and set(failures) == expected_bootstrap_failures
-        )
-        repair_commands = (
-            [_briefing_command(args, config, "bootstrap", "--yes")]
-            if bootstrap_applicable
-            else []
-        )
+    if failures:
+        alias = getattr(args, "workspace_alias", None) or config.name
+        commands = repair_commands(config, str(alias), failures)
+        bootstrap_applicable = bootstrap_repair_applicable(config, failures)
         findings = [
             _doctor_finding_payload(item, include_paths=False) for item in failures
         ]
@@ -2617,7 +2585,7 @@ def cmd_next(args: argparse.Namespace) -> None:
                 "next_step",
                 state="needs_repair",
                 summary="工作区还不能开始任务。",
-                commands=repair_commands,
+                commands=commands,
                 diagnostic_commands=[_briefing_command(args, config, "doctor")],
                 mutation_available=bootstrap_applicable,
                 findings=findings,
@@ -2689,17 +2657,10 @@ def cmd_next(args: argparse.Namespace) -> None:
         if briefing is not None:
             payload["briefing"] = briefing
             payload["diagnostic_commands"] = diagnostic_commands
-        if missing_origin_failures:
-            payload["findings"] = [
-                _doctor_finding_payload(item, include_paths=False)
-                for item in missing_origin_failures
-            ]
         payload.update(_family_unacked_fields(config))
         payload.update(_next_push_fields(config))
         _print_control_plane_json("next_step", **payload)
         return
-    for finding in missing_origin_failures:
-        _print_doctor_finding(finding)
     if briefing is None:
         print("工作区已就绪。可用 dyro start 打开本机已安装的编码工具。")
         _print_family_unacked_attention(config)

--- a/src/dyro/console/_inspect_worker.py
+++ b/src/dyro/console/_inspect_worker.py
@@ -19,6 +19,7 @@ import time
 from typing import Any
 
 from ..config import load
+from ..continuation.next_step import next_commands
 from ..hub import WorkspaceRecord, WorkspaceRegistry
 from .overview import (
     ConsoleOverviewError,
@@ -61,7 +62,10 @@ def _capture_workspace_summary(
             default=record.name if is_default else "",
             workspaces=(record,),
         )
-        service = ConsoleOverviewService(registry_loader=lambda: registry)
+        service = ConsoleOverviewService(
+            registry_loader=lambda: registry,
+            commands_loader=next_commands,
+        )
         payload = service.workspace(record.name)
         summary = payload["data"]["workspace"]
         warnings = [item["code"] for item in payload["freshness"]["warnings"]]
@@ -282,6 +286,7 @@ def main(argv: list[str] | None = None) -> int:
         service_arguments: dict[str, object] = {
             "cursor_secret": _secret_from_environment(),
             "summary_loader": _isolated_summaries,
+            "commands_loader": next_commands,
         }
         if target_registry is not None:
             service_arguments["registry_loader"] = lambda: target_registry

--- a/src/dyro/console/overview.py
+++ b/src/dyro/console/overview.py
@@ -779,7 +779,7 @@ class ConsoleOverviewService:
             warning_codes.add("DOCTOR_UNAVAILABLE")
         commands: list[object] = []
         try:
-            loaded = self._commands_loader(config)
+            loaded = self._invoke_commands_loader(config, alias)
             if isinstance(loaded, list):
                 commands = loaded
         except (DyroError, ValidationError, OSError, UnicodeError, TypeError, AttributeError):
@@ -847,6 +847,14 @@ class ConsoleOverviewService:
             )
         )
         return {"counts": counts, "items": items}
+
+    def _invoke_commands_loader(self, config: Config, alias: str) -> object:
+        """Prefer ``(config, alias)`` so Isolated next.commands match the card."""
+        loader = self._commands_loader
+        try:
+            return loader(config, alias)
+        except TypeError:
+            return loader(config)
 
     def _recommendation(
         self,

--- a/src/dyro/continuation/next_step.py
+++ b/src/dyro/continuation/next_step.py
@@ -1,0 +1,89 @@
+"""Read-only ``next.commands`` projection. Isolated Console may import this."""
+
+from __future__ import annotations
+
+from ..config import Config
+from ..errors import DyroError, ValidationError
+from ..onboarding import validate_bootstrap_destination
+from ..read_limits import ReadBudget
+from ..workspace import doctor, list_lines
+from .ready_briefing import briefing_command
+
+
+def next_commands(
+    config: Config,
+    alias: str | None = None,
+    *,
+    read_budget: ReadBudget | None = None,
+) -> list[str]:
+    """Same list ``dyro next`` puts in JSON ``commands``.
+
+    Isolated workers may call this. It does not import launcher, provider,
+    or session credentials. Commands never embed ``--root`` paths.
+    """
+    token = alias if isinstance(alias, str) and alias else getattr(config, "name", "")
+    if not isinstance(token, str) or not token:
+        return []
+    try:
+        findings = doctor(config, read_budget=read_budget)
+    except (DyroError, ValidationError, OSError, TypeError, AttributeError):
+        return []
+    failures = [
+        item
+        for item in findings
+        if isinstance(item, str) and item.startswith("FAIL")
+    ]
+    if failures:
+        return repair_commands(config, token, failures)
+    try:
+        lines = list_lines(config, read_budget=read_budget)
+    except (DyroError, ValidationError, OSError, TypeError, AttributeError):
+        return []
+    if not lines:
+        return [briefing_command(token, "line", "create", "dev", "--yes")]
+    return []
+
+
+def repair_commands(config: Config, alias: str, failures: list[str]) -> list[str]:
+    """Scoped repair command for doctor FAILs. Doctor is a read, not ``--yes``."""
+    if not failures:
+        return []
+    if bootstrap_repair_applicable(config, failures):
+        return [briefing_command(alias, "bootstrap", "--yes")]
+    return [briefing_command(alias, "doctor")]
+
+
+def bootstrap_repair_applicable(config: Config, failures: list[str]) -> bool:
+    """True only when every FAIL is a missing repo that bootstrap can clone."""
+    repositories = getattr(config, "repositories", {})
+    if not isinstance(repositories, dict) or not failures:
+        return False
+    root = getattr(config, "root", None)
+    if root is None:
+        return False
+    absent: set[str] = set()
+    for repo_id, repository in repositories.items():
+        remote = getattr(repository, "remote", "")
+        path = getattr(repository, "path", "")
+        if not remote or not path:
+            continue
+        destination = root / path
+        try:
+            present = destination.exists() or destination.is_symlink()
+        except OSError:
+            continue
+        if present:
+            continue
+        try:
+            validate_bootstrap_destination(config, path)
+        except (DyroError, OSError):
+            continue
+        absent.add(str(repo_id))
+    if not absent:
+        return False
+    expected = {
+        f"FAIL repository {repo_id}: missing or not Git: "
+        f"{root / repositories[repo_id].path}"
+        for repo_id in absent
+    }
+    return set(failures) == expected

--- a/src/dyro/workspace.py
+++ b/src/dyro/workspace.py
@@ -1315,9 +1315,10 @@ _MISSING_ORIGIN_TOKEN = ": missing origin/"
 def is_missing_origin_finding(finding: str) -> bool:
     """True only for doctor FAILs that mean origin/<line.branch> is absent.
 
-    Join completion, setup post-doctor, start, next, and home-open skip these
-    so SHA-pinned / local-only lines can exist before the remote-tracking ref
-    is published. Wrong upstream, wrong branch, missing worktree, common-dir,
-    and symlink FAILs still fail.
+    Join completion, setup post-doctor, start, and home-open skip these so
+    SHA-pinned / local-only lines can exist before the remote-tracking ref
+    is published. ``dyro next`` and Isolated Console do not: a FAIL is not
+    ready. Wrong upstream, wrong branch, missing worktree, common-dir, and
+    symlink FAILs still fail.
     """
     return finding.startswith("FAIL ") and _MISSING_ORIGIN_TOKEN in finding

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1126,9 +1126,20 @@ class ObjectiveCliTests(WorkspaceCase):
                     )
 
         payload = json.loads(output.getvalue())
-        self.assertEqual(payload["state"], "ready")
-        self.assertEqual(payload["commands"], [])
+        self.assertEqual(payload["state"], "needs_repair")
+        self.assertNotEqual(payload["state"], "ready")
+        self.assertEqual(
+            payload["commands"],
+            ["dyro --workspace selected doctor"],
+        )
         self.assertFalse(payload["mutation_available"])
+        self.assertTrue(
+            any(
+                "missing origin/" in item.get("message", "")
+                for item in payload.get("findings", [])
+            ),
+            payload,
+        )
 
     def test_control_plane_json_runtime_errors_use_one_stable_envelope(self) -> None:
         with tempfile.TemporaryDirectory(prefix="dyro-registry-") as registry_home:
@@ -1259,7 +1270,10 @@ class ObjectiveCliTests(WorkspaceCase):
         self.anchor.rename(self.root / "api-missing")
         unavailable = self._read_json("next")
         self.assertFalse(unavailable["mutation_available"])
-        self.assertEqual(unavailable["commands"], [])
+        self.assertEqual(
+            unavailable["commands"],
+            ["dyro --workspace test-workspace doctor"],
+        )
         self.assertEqual(
             unavailable["diagnostic_commands"],
             ["dyro --workspace test-workspace doctor"],
@@ -1305,7 +1319,10 @@ class ObjectiveCliTests(WorkspaceCase):
         payload = self._read_json("next")
 
         self.assertFalse(payload["mutation_available"])
-        self.assertEqual(payload["commands"], [])
+        self.assertEqual(
+            payload["commands"],
+            ["dyro --workspace test-workspace doctor"],
+        )
         self.assertFalse((outside / "api").exists())
 
     def test_control_plane_rejects_symlinked_line_and_changeset_manifests(self) -> None:
@@ -1699,6 +1716,7 @@ class ObjectiveCliTests(WorkspaceCase):
         self.assertIn("下一步：", "\n".join(briefing["lines"]))
 
     def test_next_with_one_live_objective_points_to_follow_up(self) -> None:
+        publish_origin_branch(self.anchor, "feat/alpha")
         self._start_release_objective()
         explain = self._read_json("objective", "explain", "release")
         payload = self._read_json("next")
@@ -1744,6 +1762,7 @@ class ObjectiveCliTests(WorkspaceCase):
         self.assertNotIn("objective attention", text)
 
     def test_next_with_two_live_objectives_does_not_pick_one(self) -> None:
+        publish_origin_branch(self.anchor, "feat/alpha")
         self._start_release_objective()
         directory = self.config.task_specs_dir / "TASK-B"
         directory.mkdir(parents=True)

--- a/tests/test_console_inspection.py
+++ b/tests/test_console_inspection.py
@@ -794,6 +794,42 @@ class IsolatedOverviewServiceTests(WorkspaceCase):
         self.assertEqual(card["health"], "degraded")
         self.assertNotEqual(card["recommendation"]["reason"], "HOME_GUIDANCE")
         self.assertNotIn(str(self.root), repr(overview))
+        workspace = service.workspace("demo")
+        self.assertEqual(
+            workspace["data"]["workspace"]["recommendation"]["command"],
+            "dyro --workspace demo doctor",
+        )
+        self.assertNotEqual(
+            workspace["data"]["workspace"]["recommendation"]["command"],
+            "dyro --workspace demo",
+        )
+
+    def test_isolated_summary_worker_passes_next_commands_loader(self) -> None:
+        from dyro.config import load
+        from dyro.continuation.next_step import next_commands
+        from dyro.workspace import create_line
+
+        create_line(load(self.root), line_id="core", branch="feat/core", base="main")
+        seen: dict[str, object] = {}
+        real = _inspect_worker.ConsoleOverviewService
+
+        def spy(*args: object, **kwargs: object):
+            seen.update(kwargs)
+            return real(*args, **kwargs)
+
+        class _Queue:
+            def put(self, value: object) -> None:
+                self.value = value
+
+        with patch.object(_inspect_worker, "ConsoleOverviewService", side_effect=spy):
+            _inspect_worker._capture_workspace_summary(
+                _Queue(), WorkspaceRecord("demo", self.root), True
+            )
+
+        self.assertIs(seen.get("commands_loader"), next_commands)
+        commands = next_commands(load(self.root), alias="demo")
+        self.assertIn("dyro --workspace demo doctor", commands)
+        self.assertNotIn("dyro --workspace demo", commands)
 
     def test_worker_cannot_serve_or_write_artifacts_via_a_mutation_op(self) -> None:
         from dyro.config import load

--- a/tests/test_console_overview.py
+++ b/tests/test_console_overview.py
@@ -262,6 +262,39 @@ class ConsoleOverviewServiceTests(unittest.TestCase):
         self.assertEqual(recommendation["reason"], "MISSING_ORIGIN")
         self.assertNotEqual(recommendation["reason"], "HOME_GUIDANCE")
 
+    def test_commands_loader_receives_registry_alias_not_empty_default(self) -> None:
+        seen: list[str | None] = []
+
+        def loader(config: object, alias: str | None = None) -> list[str]:
+            seen.append(alias)
+            return [f"dyro --workspace {alias} doctor"]
+
+        self.registry = WorkspaceRegistry(
+            default="core",
+            workspaces=(WorkspaceRecord("core", self.alpha_root),),
+        )
+        self.snapshots["Alpha Project"] = _snapshot(
+            name="Alpha Project",
+            attention=(),
+        )
+        service = ConsoleOverviewService(
+            registry_loader=lambda: self.registry,
+            config_loader=self.service._config_loader,
+            snapshot_loader=lambda config: self.snapshots[config.name],
+            clock=self.service._clock,
+            cursor_secret=b"k" * 32,
+            doctor_loader=lambda config: [
+                "FAIL line:core/api: missing origin/feat/core",
+            ],
+            commands_loader=loader,
+        )
+
+        card = service.page()["data"]["workspaces"][0]
+
+        self.assertEqual(seen, ["core"])
+        self.assertEqual(card["recommendation"]["command"], "dyro --workspace core doctor")
+        self.assertNotEqual(card["recommendation"]["command"], "dyro --workspace core")
+
     def test_fail_findings_project_path_free_and_degrade_health(self) -> None:
         self.registry = WorkspaceRegistry(
             default="core",

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -117,16 +117,21 @@ class WorkspaceTests(WorkspaceCase):
         with redirect_stdout(output):
             main(["--root", str(self.root), "next"])
         rendered = output.getvalue()
-        # doctor still FAILs missing origin; next stays ready when that is
-        # the only FAIL and discloses it.
+        # doctor FAILs missing origin; next must not sell that as ready.
         self.assertIn("missing origin/feat/local-only", rendered)
-        self.assertNotIn("还不能开始任务", rendered)
-        self.assertIn("工作区已就绪", rendered)
+        self.assertIn("还不能开始任务", rendered)
+        self.assertNotIn("工作区已就绪", rendered)
+        self.assertIn("dyro --workspace test-workspace doctor", rendered)
         json_out = StringIO()
         with redirect_stdout(json_out):
             main(["--root", str(self.root), "next", "--format", "json"])
         payload = json.loads(json_out.getvalue())
-        self.assertEqual(payload["state"], "ready")
+        self.assertEqual(payload["state"], "needs_repair")
+        self.assertNotEqual(payload["state"], "ready")
+        self.assertIn(
+            "dyro --workspace test-workspace doctor", payload["commands"]
+        )
+        self.assertFalse(payload["mutation_available"])
         self.assertTrue(
             any(
                 "missing origin/feat/local-only" in item.get("message", "")


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why

After #54, `dyro next --format json` on a workspace whose `doctor` has only `missing origin/<branch>` FAILs still returned `state: "ready"`, `commands: []`, and `summary: "工作区已就绪。"`. Findings were extra payload. Isolated Console never saw real `next.commands` because `_inspect_worker` built `ConsoleOverviewService` with the default empty `commands_loader`.

This is CLI `next` + Isolated honesty only. ADR 0005 is unchanged: the page still cannot merge, push, `--yes`, or task-status. `dyro start` still treats missing-origin as non-blocking.

## Inverted locks

- **Ready-on-missing-origin:** `tests/test_workspace.py::test_local_only_line_creates_but_doctor_and_next_are_not_ready` and `tests/test_cli.py::test_control_plane_next_preserves_an_explicit_workspace_selector` no longer accept `state: "ready"` + empty `commands` while missing-origin FAILs are attached. They now require `needs_repair`, scoped `dyro --workspace ALIAS doctor`, `mutation_available: false`, and findings present. Human text must print the FAILs and point at doctor, not 「工作区已就绪。可用 dyro start…」.
- **Isolated empty commands:** Isolated `_inspect_worker` must construct `ConsoleOverviewService` with `commands_loader=next_commands`. `_capture` now passes the registry alias into that loader. A FAIL workspace must not recommend a bare `dyro --workspace ALIAS`, and Isolated is not stuck with empty commands while production `_capture` is not.

Non-bootstrap FAILs (missing repo without a safe clone, symlink parent, etc.) also put doctor in `commands` so Isolated and CLI share one repair list. Bootstrap `--yes` stays the mutation command when it is the only applicable FAIL.

Ready-path next tests that were accidentally sitting on unpublished origin (`test_next_with_one_live_objective_points_to_follow_up`, `test_next_with_two_live_objectives_does_not_pick_one`) now publish `origin/feat/alpha` so they still lock the honest ready/briefing contract.

## Hunch (verified)

The ready branch after `blocking_failures` (which excluded `is_missing_origin_finding`) was the entire `next` lie: missing-origin-only FAILs fell through to `_workspace_ready_briefing`, which hardcodes `state: "ready"` and `commands: []`. Isolated’s empty loader was the remaining console hole from the #54 review. Both are fixed; `start()` was left alone.

## Do not

- No version bump, tag, or Release. Public train stays 0.7.x (0.7.9).
- No browser merge/push/`--yes`.
- No customer or company names. Tests use `core`, `core_pay`, `release_a`, `test-workspace` only.

## Verify

```text
python3 -m pytest tests/test_workspace.py tests/test_cli.py \
  tests/test_console_overview.py tests/test_console_inspection.py \
  tests/test_console_twin.py tests/test_console_twin_live.py \
  tests/test_hub.py -q
```

232 passed, 16 subtests passed.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-76793be8-eeb8-4c55-9aa9-b766e89b37a3?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-76793be8-eeb8-4c55-9aa9-b766e89b37a3&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

