### PR TITLE
chore(发布): 0.7.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## 0.7.10 - 2026-08-21
+
 - `dyro next` no longer reports `ready` when doctor has FAIL findings,
   including missing-origin-only. JSON `state` is `needs_repair`,
   `commands` includes scoped `doctor` (a read; `mutation_available`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "dyro"
-version = "0.7.9"
+version = "0.7.10"
 description = "DyroEngineeringFlow: local-first automation and delivery control for multi-repository teams"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/dyro/bridge/skill/SKILL.md
+++ b/src/dyro/bridge/skill/SKILL.md
@@ -50,7 +50,7 @@ release, publish, console, install, or any confirmation/approval field.
 ```json
 {
   "protocol": {"major": 1, "minor": 0},
-  "client": {"name": "dyro-agent-bridge-skill", "version": "0.7.9"},
+  "client": {"name": "dyro-agent-bridge-skill", "version": "0.7.10"},
   "operation": "bridge.capabilities.compact",
   "input": {}
 }

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2146,6 +2146,6 @@ class VersionTests(unittest.TestCase):
         from dyro import __version__
 
         metadata = tomllib.loads(Path("pyproject.toml").read_text(encoding="utf-8"))
-        self.assertEqual(metadata["project"]["version"], "0.7.9")
-        self.assertEqual(__version__, "0.7.9")
+        self.assertEqual(metadata["project"]["version"], "0.7.10")
+        self.assertEqual(__version__, "0.7.10")
         self.assertEqual(__version__, metadata["project"]["version"])

--- a/tests/test_console_artifacts.py
+++ b/tests/test_console_artifacts.py
@@ -225,12 +225,12 @@ class ConsoleArtifactPageTests(unittest.TestCase):
         self.assertNotEqual(refresh_at, -1)
         self.assertNotIn(b"/artifacts", script.body[refresh_at:next_fn])
 
-    def test_package_version_is_0_7_9(self) -> None:
+    def test_package_version_is_0_7_10(self) -> None:
         import tomllib
         from pathlib import Path
 
         metadata = tomllib.loads(Path("pyproject.toml").read_text(encoding="utf-8"))
-        self.assertEqual(metadata["project"]["version"], "0.7.9")
+        self.assertEqual(metadata["project"]["version"], "0.7.10")
 
 
 class ConsoleArtifactServiceTests(WorkspaceCase):

--- a/tests/test_release_gates.py
+++ b/tests/test_release_gates.py
@@ -32,7 +32,7 @@ class ReleaseGateTests(unittest.TestCase):
     def test_0_7_release_runs_gates_without_claiming_1_0(self) -> None:
         stdout = StringIO()
         with redirect_stdout(stdout):
-            code = main(["--root", str(ROOT), "--release-tag", "v0.7.9"])
+            code = main(["--root", str(ROOT), "--release-tag", "v0.7.10"])
         self.assertEqual(code, 0)
         self.assertIn("0.7 gates present", stdout.getvalue())
         self.assertNotIn("1.0 gates present", stdout.getvalue())

--- a/uv.lock
+++ b/uv.lock
@@ -286,7 +286,7 @@ wheels = [
 
 [[package]]
 name = "dyro"
-version = "0.7.9"
+version = "0.7.10"
 source = { editable = "." }
 dependencies = [
     { name = "cryptography" },


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
把已在 `main`（`1b39f40`，含 #54 Console 可用操作者表面与 #55 next FAIL 诚实）落地的内容收进补丁号 `0.7.10`。版本停在 `0.7.x`。本 PR 只准备号，不 merge、不打 tag、不发 PyPI、不改 GitHub Releases。

## 变更
- `pyproject.toml` / `uv.lock` / Agent Bridge Skill 客户端版本：`0.7.9` → `0.7.10`
- `CHANGELOG.md`：把 Unreleased 里的 #54 / #55 五条移到 `## 0.7.10 - 2026-08-21`；Unreleased 只留空标题；不改写 `0.7.9` 历史，也不把 P1–P4 记进 `0.7.10`
- 断言包装版本 `0.7.9` 的测试 / pin 跟着改到 `0.7.10`（`test_cli.py`、`test_release_gates.py`、`test_console_artifacts.py`）
- 不改 `docs/designs/console-v2-live-family-signals.md`：§P4 已在 0.7.9 标「已落地」，文中无版本 pin

## 非目标
- 不另开 `0.8` / `1.0`
- 不发明新功能，不纳入未上 main 的工作
- 不打 tag、不建 GitHub Release、不发 PyPI（本 PR 不做这些）
- 不移动、删除或改写 tag `v0.7.9`
- 不改 `.cursor/environment.json`，不关闭其它 PR

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-90bacdfd-c787-4490-a92c-c1fa83919463?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-90bacdfd-c787-4490-a92c-c1fa83919463&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

