### PR TITLE
feat(集成): add OpenCode and Hermes Skill host seats

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## Unreleased
 
+- Attach first-party Skill avatars to OpenCode and Hermes when those host
+  homes already exist (`~/.config/opencode/skills/<skill>`,
+  `~/.hermes/skills/<skill>`). Detection stays fail-closed: absent homes
+  stay silent, and Dyro does not create OpenCode or Hermes directories.
+  `OPENCODE_CONFIG_DIR` and `HERMES_HOME` remain the existing overrides.
+  Pi (`PI_CODING_AGENT_DIR`, `~/.pi/agent`) is unchanged.
+
 ## 0.7.10 - 2026-08-21
 
 - `dyro next` no longer reports `ready` when doctor has FAIL findings,

--- a/docs/updates.md
+++ b/docs/updates.md
@@ -74,6 +74,11 @@ dyro integration sync skill --yes   # upgrade-only; skips absent installs
 
 (`codex` is an alias for `skill`.)
 
+Avatars attach only to already-present agent homes. OpenCode uses
+`~/.config/opencode/skills` (`OPENCODE_CONFIG_DIR` when set) and Hermes uses
+`~/.hermes/skills` (`HERMES_HOME` when set). Absent homes stay silent; Dyro
+does not create those directories.
+
 The outbound `dyro-dispatch`, executor, and board Skills keep independent
 ownership state from the read-only control-plane Skill. One `dyro setup` opt-in
 installs the first-batch seat bundle. An existing managed control-plane

--- a/src/dyro/integrations/manager.py
+++ b/src/dyro/integrations/manager.py
@@ -160,6 +160,8 @@ HOSTS: tuple[HostSpec, ...] = (
     HostSpec("grok", "GROK_HOME", ".grok"),
     HostSpec("pi", "PI_CODING_AGENT_DIR", ".pi/agent"),
     HostSpec("dsh", "DSH_HOME", ".dsh"),
+    HostSpec("opencode", "OPENCODE_CONFIG_DIR", ".config/opencode"),
+    HostSpec("hermes", "HERMES_HOME", ".hermes"),
 )
 
 

--- a/tests/test_integrations.py
+++ b/tests/test_integrations.py
@@ -1259,6 +1259,8 @@ class IntegrationManagerTests(unittest.TestCase):
         avatar = pi_home / "skills" / "dyro-control-plane"
         self.assertTrue(avatar.is_symlink() or avatar.is_dir())
         self.assertTrue((avatar / "SKILL.md").is_file())
+        pi_status = integration_status("skill", host_homes={"pi": pi_home})
+        self.assertIn("pi", {row.host for row in pi_status.avatars})
 
     def test_dsh_skill_host_uses_dsh_home(self) -> None:
         spec = next(host for host in manager.HOSTS if host.host_id == "dsh")
@@ -1270,6 +1272,138 @@ class IntegrationManagerTests(unittest.TestCase):
         avatar = dsh_home / "skills" / "dyro-control-plane"
         self.assertTrue(avatar.is_symlink() or avatar.is_dir())
         self.assertTrue((avatar / "SKILL.md").is_file())
+
+    def test_opencode_and_hermes_host_specs_use_existing_homes(self) -> None:
+        opencode = next(host for host in manager.HOSTS if host.host_id == "opencode")
+        hermes = next(host for host in manager.HOSTS if host.host_id == "hermes")
+        self.assertEqual(opencode.env_var, "OPENCODE_CONFIG_DIR")
+        self.assertEqual(opencode.default_dirname, ".config/opencode")
+        self.assertEqual(hermes.env_var, "HERMES_HOME")
+        self.assertEqual(hermes.default_dirname, ".hermes")
+
+        opencode_home = self.root / "opencode-home"
+        hermes_home = self.root / "hermes-home"
+        homes = {"opencode": opencode_home, "hermes": hermes_home}
+        preview = integration_status("skill", host_homes=homes)
+        self.assertEqual(
+            {row.host: row.state for row in preview.avatars if row.host in homes},
+            {"opencode": "missing", "hermes": "missing"},
+        )
+        self.assertEqual(
+            manager._avatar_path(opencode_home, manager.CONTROL_PLANE_SPEC),
+            opencode_home / "skills" / "dyro-control-plane",
+        )
+        self.assertEqual(
+            manager._avatar_path(hermes_home, manager.CONTROL_PLANE_SPEC),
+            hermes_home / "skills" / "dyro-control-plane",
+        )
+
+        installed = install_integration("skill", yes=True, host_homes=homes)
+        self.assertEqual(installed.status.state, IntegrationState.CURRENT)
+        opencode_avatar = opencode_home / "skills" / "dyro-control-plane"
+        hermes_avatar = hermes_home / "skills" / "dyro-control-plane"
+        self.assertTrue(opencode_avatar.is_symlink())
+        self.assertTrue(hermes_avatar.is_symlink())
+        self.assertEqual(opencode_avatar.resolve(), self.mirror.resolve())
+        self.assertEqual(hermes_avatar.resolve(), self.mirror.resolve())
+        self.assertTrue((opencode_avatar / "SKILL.md").is_file())
+        self.assertTrue((hermes_avatar / "SKILL.md").is_file())
+        self.assertEqual(
+            {row.host: row.state for row in installed.status.avatars if row.host in homes},
+            {"opencode": "current", "hermes": "current"},
+        )
+
+        synced = sync_managed_skill(yes=True, host_homes=homes)
+        self.assertIsNone(synced)
+        self.assertEqual(
+            integration_status("skill", host_homes=homes).state,
+            IntegrationState.CURRENT,
+        )
+
+        removed = uninstall_integration("skill", yes=True, host_homes=homes)
+        self.assertEqual(removed.status.state, IntegrationState.ABSENT)
+        self.assertFalse(opencode_avatar.exists() or opencode_avatar.is_symlink())
+        self.assertFalse(hermes_avatar.exists() or hermes_avatar.is_symlink())
+
+    def test_absent_opencode_and_hermes_homes_stay_silent(self) -> None:
+        config_root = self.fake_home / ".config"
+        default_opencode = config_root / "opencode"
+        default_hermes = self.fake_home / ".hermes"
+
+        config_root.mkdir()
+        status = integration_status("skill")
+        hosts = {row.host for row in status.avatars}
+        self.assertIn("codex", hosts)
+        self.assertNotIn("opencode", hosts)
+        self.assertNotIn("hermes", hosts)
+        self.assertIsNone(
+            manager._host_home(
+                next(host for host in manager.HOSTS if host.host_id == "opencode"),
+                None,
+            )
+        )
+        self.assertIsNone(
+            manager._host_home(
+                next(host for host in manager.HOSTS if host.host_id == "hermes"),
+                None,
+            )
+        )
+
+        install_integration("skill", yes=True)
+        self.assertFalse(default_opencode.exists())
+        self.assertFalse(default_hermes.exists())
+        self.assertEqual(
+            {row.host for row in integration_status("skill").avatars},
+            {"codex"},
+        )
+
+    def test_present_opencode_and_hermes_default_homes_receive_avatars(self) -> None:
+        opencode_home = self.fake_home / ".config" / "opencode"
+        hermes_home = self.fake_home / ".hermes"
+        opencode_home.mkdir(parents=True)
+        hermes_home.mkdir()
+
+        status = integration_status("skill")
+        hosts = {row.host: row for row in status.avatars}
+        self.assertIn("opencode", hosts)
+        self.assertIn("hermes", hosts)
+        self.assertIn("codex", hosts)
+        self.assertEqual(hosts["opencode"].state, "missing")
+        self.assertEqual(hosts["hermes"].state, "missing")
+        self.assertEqual(
+            hosts["opencode"].path,
+            opencode_home / "skills" / "dyro-control-plane",
+        )
+        self.assertEqual(
+            hosts["hermes"].path,
+            hermes_home / "skills" / "dyro-control-plane",
+        )
+
+        installed = install_integration("skill", yes=True)
+        self.assertEqual(installed.status.state, IntegrationState.CURRENT)
+        opencode_avatar = opencode_home / "skills" / "dyro-control-plane"
+        hermes_avatar = hermes_home / "skills" / "dyro-control-plane"
+        self.assertTrue(opencode_avatar.is_symlink())
+        self.assertTrue(hermes_avatar.is_symlink())
+        self.assertEqual(
+            {row.host: row.state for row in installed.status.avatars},
+            {"codex": "current", "opencode": "current", "hermes": "current"},
+        )
+
+        output = StringIO()
+        with redirect_stdout(output):
+            main(["integration", "status", "skill"])
+            main(["integration", "sync", "skill", "--yes"])
+        text = output.getvalue()
+        self.assertIn("avatar\topencode\tcurrent", text)
+        self.assertIn("avatar\thermes\tcurrent", text)
+        self.assertIn("无需同步", text)
+
+        uninstall_integration("skill", yes=True)
+        self.assertTrue(opencode_home.is_dir())
+        self.assertTrue(hermes_home.is_dir())
+        self.assertFalse(opencode_avatar.exists() or opencode_avatar.is_symlink())
+        self.assertFalse(hermes_avatar.exists() or hermes_avatar.is_symlink())
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why

`dyro integration` currently avatars first-party Skills only to Codex, Claude, Agents, Cursor, Grok, Pi, and DSH. Operators using OpenCode or Hermes have to hand-symlink into `~/.config/opencode/skills` and `~/.hermes/skills`.

## What

Add two first-party Skill host seats in `HOSTS`:

- `opencode` — `OPENCODE_CONFIG_DIR` (already used by the dispatch adapter) or `~/.config/opencode`
- `hermes` — `HERMES_HOME` (already used by the dispatch adapter) or `~/.hermes`

Avatar path stays `host_home / "skills" / skill_name` (existing `_avatar_path`). That yields:

- `~/.config/opencode/skills/<skill>`
- `~/.hermes/skills/<skill>`

OpenCode `host_home` is `.config/opencode`, not `.config`, so `_avatar_path`'s `target.parent.parent == host_home` check stays valid. Hermes stays flat under `~/.hermes/skills` (no `software-development/` nest).

## Inverted lock

Detection remains fail-closed:

- **Absent host** → no avatar row, no directory created
- **Present host** (real directory, not a symlink) → avatar under `skills/`

Install / sync / status / uninstall report `opencode` and `hermes` avatar rows when those homes exist, same as `pi` / `codex`. Pi (`PI_CODING_AGENT_DIR`, `.pi/agent`) is unchanged.

## Tests

Local verification:

- `uv run ruff check src tests experiments` — all checks passed
- Focused host-seat tests: 7/7 OK
- Full suite: **1031 tests OK** (`uv run python -m unittest discover -s tests -t . -v`)
- Isolated CLI demo of the inverted lock (absent → silent; present → `skills/` avatars; uninstall leaves homes)

GitHub required CI is green (Python 3.11–3.14, wheel/sdist smoke, Windows/macOS dispatch, TypeScript interop). Unrelated Vercel preview checks failed; this is a Python CLI package, not a Vercel app.

Evidence logs:

- `/opt/cursor/artifacts/integration_host_seat_unittests.log`
- `/opt/cursor/artifacts/inverted_lock_cli_demo.log`
- `/opt/cursor/artifacts/unittest_full_suite_summary.log`

## Docs / train

- CHANGELOG Unreleased bullet
- Short note in `docs/updates.md` skill-install section
- Public train stays `0.7.x`; no version / tag / Release / PyPI bump
- No new skill, no ADR 0005 / Console mutations

## Out of scope

- Creating OpenCode or Hermes homes
- Hermes `software-development/` layout
- New Skill assets or host-compiler changes

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e0302fa3-75d9-4ed4-b0be-f4624f92cb71?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e0302fa3-75d9-4ed4-b0be-f4624f92cb71&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

